### PR TITLE
Adds PubSubException

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubException.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.pubsub.core;
+
+import org.springframework.core.NestedRuntimeException;
+
+/**
+ * The Spring Google Cloud Pub/Sub specific {@link NestedRuntimeException}.
+ *
+ * @author João André Martins
+ */
+public class PubSubException extends NestedRuntimeException {
+
+	public PubSubException(String msg) {
+		super(msg);
+	}
+
+	public PubSubException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+}


### PR DESCRIPTION
PubSubException will be the wrapper exception for any errors arising
from Google Cloud Pub/Sub. It shouldn't be used for message conversion,
there's already MessageConversionException for that.

Fixes #7 

I thought of adding unit tests here, but that would likely involve adding Publisher factories which might be over the scope of this PR and preferable in another PR?
Also, because #38 isn't merged yet, this copyright header is probably not well formatted, so we should wait until #38 is submitted to run checkstyle.