### PR TITLE
Add code formatting rules

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,21 @@
+= Code formatting guidelines
+
+* The directory ./src/eclipse has two files for use with code formatting,
+`eclipse-code-formatter.xml` for the majority of the code formatting rules and `eclipse.importorder`
+to order the import statements.
+
+* In Eclipse you import these files by navigating `Windows -> Preferences` and then the menu items
+`Preferences > Java > Code Style > Formatter` and `Preferences > Java > Code Style >
+Organize Imports` respectively.
+
+* In IntelliJ IDEA, install the plugin `Eclipse Code Formatter`.  You can find it by searching in
+"Browse Repositories", under `Settings > Plugins` within IDEA (Once installed, you will need to
+reboot IDEA for it to take effect).
+Then navigate to `IntelliJ IDEA > Preferences` and select the Eclipse Code Formatter.
+Select the `eclipse-code-formatter.xml` file for the field `Eclipse Java Formatter config file`
+and the file `eclipse.importorder` for the field `Import order`.
+Enable the `Eclipse code formatter` by clicking `Use the Eclipse code formatter` radio button at the
+top of the page, then click the *OK* button.
+
+** NOTE: If you configure the `Eclipse Code Formatter` from `File > Other Settings > Default
+Settings`, it will set this policy across all of your IDEA projects.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -19,3 +19,7 @@ top of the page, then click the *OK* button.
 
 ** NOTE: If you configure the `Eclipse Code Formatter` from `File > Other Settings > Default
 Settings`, it will set this policy across all of your IDEA projects.
+
+** IDEA'S "Optimize imports on the fly" option turned on interferes with the Eclipse code formatter
+import optimization. Consider disabling the option if optimization does not yield the expected
+results.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -11,9 +11,9 @@ Organize Imports` respectively.
 * In IntelliJ IDEA, install the plugin `Eclipse Code Formatter`.  You can find it by searching in
 "Browse Repositories", under `Settings > Plugins` within IDEA (Once installed, you will need to
 reboot IDEA for it to take effect).
-Then navigate to `IntelliJ IDEA > Preferences` and select the Eclipse Code Formatter.
-Select the `eclipse-code-formatter.xml` file for the field `Eclipse Java Formatter config file`
-and the file `eclipse.importorder` for the field `Import order`.
+Then navigate to `Settings > Other Settings` (this might be under `Preferences` on Mac) and select
+the Eclipse Code Formatter. Select the `eclipse-code-formatter.xml` file for the field `Eclipse Java
+Formatter config file` and the file `eclipse.importorder` for the field `Import order`.
 Enable the `Eclipse code formatter` by clicking `Use the Eclipse code formatter` radio button at the
 top of the page, then click the *OK* button.
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,16 @@
+= Spring Framework on Google Cloud Platform
+
+This project aims at making it as seamless as possible for Spring users to run their applications on
+Google Cloud Platform. The project website is http://cloud.spring.io/spring-cloud-gcp/ (under
+development).
+
+Currently, this repository contains Spring Integration inbound and outbound channel adapters which
+use Google Cloud Pub/Sub, as well as a Google Cloud Pub/Sub Spring abstraction, i.e.,
+`PubSubTemplate`.
+
+If you have any other ideas, suggestions or bug reports, please use our
+link:https://github.com/spring-cloud/spring-cloud-gcp/issues[GitHub issue tracker] and let us know!
+We would love to hear from you.
+
+If you want to collaborate in the project, we would also love to get your PRs. Before you start
+working on one, please take a look at our link:CONTRIBUTING.adoc[collaboration manual].

--- a/README.adoc
+++ b/README.adoc
@@ -12,5 +12,5 @@ If you have any other ideas, suggestions or bug reports, please use our
 link:https://github.com/spring-cloud/spring-cloud-gcp/issues[GitHub issue tracker] and let us know!
 We would love to hear from you.
 
-If you want to collaborate in the project, we would also love to get your PRs. Before you start
-working on one, please take a look at our link:CONTRIBUTING.adoc[collaboration manual].
+If you want to collaborate in the project, we would also love to get your Pull Requests. Before you
+start working on one, please take a look at our link:CONTRIBUTING.adoc[collaboration manual].

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# spring-cloud-gcp
-Integration for Google Cloud Platform APIs with Spring

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,30 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+				<executions>
+					<execution>
+						<id>checkstyle-validation</id>
+						<phase>validate</phase>
+						<configuration>
+							<encoding>UTF-8</encoding>
+							<failOnViolation>true</failOnViolation>
+							<violationSeverity>warning</violationSeverity>
+							<includeTestSourceDirectory>true</includeTestSourceDirectory>
+							<configLocation>src/checkstyle/checkstyle.xml</configLocation>
+						</configuration>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+		</plugins>
 	</build>
 
 	<reporting>

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/AbstractPubSubSender.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/AbstractPubSubSender.java
@@ -35,7 +35,7 @@ public abstract class AbstractPubSubSender implements ReactivePubSubSender, Life
 
 	private PubSubHeaderMapper headerMapper;
 
-	private volatile boolean running = false;
+	private volatile boolean running;
 
 	public AbstractPubSubSender(String project, Credentials credentials) {
 		this.project = project;
@@ -44,7 +44,7 @@ public abstract class AbstractPubSubSender implements ReactivePubSubSender, Life
 	}
 
 	public PubSubHeaderMapper getHeaderMapper() {
-		return headerMapper;
+		return this.headerMapper;
 	}
 
 	public void setHeaderMapper(PubSubHeaderMapper headerMapper) {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/DefaultPubSubSender.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/DefaultPubSubSender.java
@@ -19,12 +19,11 @@ package org.springframework.cloud.gcp.pubsub;
 import java.util.Collection;
 import java.util.Map;
 
-import org.springframework.messaging.Message;
-
 import com.google.auth.Credentials;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import org.springframework.messaging.Message;
 
 /**
  * @author Vinicius Carvalho

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/ReactivePubSubSender.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/ReactivePubSubSender.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.gcp.pubsub;
 
-import org.springframework.messaging.Message;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import org.springframework.messaging.Message;
 
 /**
  * @author Vinicius Carvalho

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/converters/PubSubHeaderMapper.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/converters/PubSubHeaderMapper.java
@@ -42,7 +42,7 @@ public class PubSubHeaderMapper
 	private String datePattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
 	public String getDatePattern() {
-		return datePattern;
+		return this.datePattern;
 	}
 
 	public void setDatePattern(String datePattern) {
@@ -51,12 +51,12 @@ public class PubSubHeaderMapper
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		converterMap.put(Boolean.class, new BooleanConverter());
-		converterMap.put(Integer.class, new IntegerConverter());
-		converterMap.put(Long.class, new LongConverter());
-		converterMap.put(Float.class, new FloatConverter());
-		converterMap.put(Double.class, new DoubleConverter());
-		converterMap.put(Date.class, new DateConverter(datePattern));
+		this.converterMap.put(Boolean.class, new BooleanConverter());
+		this.converterMap.put(Integer.class, new IntegerConverter());
+		this.converterMap.put(Long.class, new LongConverter());
+		this.converterMap.put(Float.class, new FloatConverter());
+		this.converterMap.put(Double.class, new DoubleConverter());
+		this.converterMap.put(Date.class, new DateConverter(this.datePattern));
 	}
 
 	@Override
@@ -80,14 +80,14 @@ public class PubSubHeaderMapper
 		if (value instanceof String) {
 			return (String) value;
 		}
-		HeaderConverter converter = converterMap.get(value.getClass());
+		HeaderConverter converter = this.converterMap.get(value.getClass());
 		return (converter != null) ? converter.encode(value) : value.toString();
 	}
 
 	@SuppressWarnings("rawtypes")
 	private Object decode(String value) {
 		Object result = null;
-		for (HeaderConverter converter : converterMap.values()) {
+		for (HeaderConverter converter : this.converterMap.values()) {
 			result = converter.decode(value);
 			if (result != null) {
 				break;

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/converters/PubSubMessagingConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/converters/PubSubMessagingConverter.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.gcp.pubsub.converters;
 
-import org.springframework.messaging.Message;
-
 import com.google.pubsub.v1.PubsubMessage;
+
+import org.springframework.messaging.Message;
 
 /**
  * @author Vinicius Carvalho

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/converters/SimpleMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/converters/SimpleMessageConverter.java
@@ -12,7 +12,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package org.springframework.cloud.gcp.pubsub.converters;

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/converters/support/DateConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/converters/support/DateConverter.java
@@ -52,7 +52,7 @@ public class DateConverter implements HeaderConverter<Date> {
 	public Date decode(String value) {
 		Date result = null;
 		try {
-			result = dateFormat.parse(value);
+			result = this.dateFormat.parse(value);
 		}
 		catch (ParseException e) {
 		}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubException.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubException.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2017 original author or authors.
+ *  Copyright 2017 original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package org.springframework.cloud.gcp.pubsub.core;

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
@@ -12,7 +12,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package org.springframework.cloud.gcp.pubsub.core;

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -12,21 +12,12 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package org.springframework.cloud.gcp.pubsub.core;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.cloud.gcp.pubsub.converters.SimpleMessageConverter;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.converter.MessageConversionException;
-import org.springframework.messaging.converter.MessageConverter;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
@@ -38,6 +29,14 @@ import com.google.cloud.pubsub.spi.v1.Publisher;
 import com.google.cloud.pubsub.spi.v1.TopicAdminSettings;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.TopicName;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cloud.gcp.pubsub.converters.SimpleMessageConverter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Vinicius Carvalho

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/GcpHeaders.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/GcpHeaders.java
@@ -4,15 +4,14 @@
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *  
  */
 
 package org.springframework.cloud.gcp.pubsub.support;

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/converters/PubSubHeaderMapperTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/converters/PubSubHeaderMapperTests.java
@@ -46,7 +46,7 @@ public class PubSubHeaderMapperTests {
 		source.put("double", Double.MAX_VALUE + "");
 		source.put("long", Long.MAX_VALUE + "");
 		source.put("string", "foo");
-		source.put("date", dateFormat.format(new Date()));
+		source.put("date", this.dateFormat.format(new Date()));
 		source.put("objectToString", "http://www.spring.io");
 		MessageHeaders result = mapper.toHeaders(source);
 		Assert.assertEquals(Boolean.class, result.get("bool").getClass());
@@ -78,7 +78,7 @@ public class PubSubHeaderMapperTests {
 		Assert.assertEquals("1", source.get("int"));
 		Assert.assertEquals("3.0", source.get("float"));
 		Assert.assertEquals("2.010012", source.get("double"));
-		Assert.assertEquals(dateFormat.format(date), source.get("date"));
+		Assert.assertEquals(this.dateFormat.format(date), source.get("date"));
 		Assert.assertEquals(o.toString(), source.get("object"));
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/converters/SimpleMessageConverterTest.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/converters/SimpleMessageConverterTest.java
@@ -1,11 +1,25 @@
+/*
+ *  Copyright 2017 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.springframework.cloud.gcp.pubsub.integration.converters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import com.google.pubsub.v1.PubsubMessage;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.pubsub.v1.PubsubMessage;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -15,6 +29,9 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.support.GenericMessage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class SimpleMessageConverterTest {

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
@@ -12,7 +12,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package org.springframework.cloud.gcp.core;

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
@@ -1,4 +1,22 @@
+/*
+ *  Copyright 2017 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.springframework.cloud.gcp.core.autoconfig;
+
+import com.google.auth.oauth2.GoogleCredentials;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -7,8 +25,6 @@ import org.springframework.cloud.gcp.core.GcpProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
-
-import com.google.auth.oauth2.GoogleCredentials;
 
 /**
  *

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.gcp.storage.autoconfig;
 
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.gcp.storage.GoogleStorageProtocolResolver;
@@ -23,10 +27,6 @@ import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
-
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
 
 /**
  * @author Vinicius Carvalho

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageProtocolResolver.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageProtocolResolver.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.gcp.storage;
 
-import java.util.logging.Logger;
-
 import com.google.cloud.storage.Storage;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -36,7 +36,7 @@ public class GoogleStorageProtocolResolver implements ProtocolResolver, Initiali
 
 	private final Storage storage;
 
-	private final Logger logger = Logger.getLogger(GoogleStorageProtocolResolver.class.getName());
+	private final Log logger = LogFactory.getLog(this.getClass());
 
 	public GoogleStorageProtocolResolver(ResourceLoader delegate, Storage storage) {
 		Assert.notNull(delegate, "Parent resource loader can not be null");
@@ -51,7 +51,7 @@ public class GoogleStorageProtocolResolver implements ProtocolResolver, Initiali
 			((DefaultResourceLoader) this.delegate).addProtocolResolver(this);
 		}
 		else {
-			this.logger.warning("The provided delegate resource loader is not an implementation " +
+			this.logger.warn("The provided delegate resource loader is not an implementation " +
 					"of DefaultResourceLoader. Custom Protocol using gs:// prefix will not be " +
 					"enabled.");
 		}

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageProtocolResolver.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageProtocolResolver.java
@@ -16,8 +16,9 @@
 
 package org.springframework.cloud.gcp.storage;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+
+import com.google.cloud.storage.Storage;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -25,8 +26,6 @@ import org.springframework.core.io.ProtocolResolver;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
-
-import com.google.cloud.storage.Storage;
 
 /**
  * @author Vinicius Carvalho
@@ -37,8 +36,7 @@ public class GoogleStorageProtocolResolver implements ProtocolResolver, Initiali
 
 	private final Storage storage;
 
-	private final Logger logger = LoggerFactory
-			.getLogger(GoogleStorageProtocolResolver.class);
+	private final Logger logger = Logger.getLogger(GoogleStorageProtocolResolver.class.getName());
 
 	public GoogleStorageProtocolResolver(ResourceLoader delegate, Storage storage) {
 		Assert.notNull(delegate, "Parent resource loader can not be null");
@@ -53,9 +51,9 @@ public class GoogleStorageProtocolResolver implements ProtocolResolver, Initiali
 			((DefaultResourceLoader) this.delegate).addProtocolResolver(this);
 		}
 		else {
-			logger.warn(
-					"The provided delegate resource loader is not an implementation of DefaultResourceLoader. "
-							+ "Custom Protocol using gs:// prefix will not be enabled.");
+			this.logger.warning("The provided delegate resource loader is not an implementation " +
+					"of DefaultResourceLoader. Custom Protocol using gs:// prefix will not be " +
+					"enabled.");
 		}
 	}
 

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -24,12 +24,12 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.Channels;
 
-import org.springframework.core.io.Resource;
-import org.springframework.util.Assert;
-
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
+
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
 
 /**
  * @author Vinicius Carvalho
@@ -99,7 +99,7 @@ public class GoogleStorageResource implements Resource {
 				}
 				catch (Exception e) {
 					throw new IOException(
-							"Failed to open remote connection to " + location, e);
+							"Failed to open remote connection to " + this.location, e);
 				}
 			}
 		}

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -12,7 +12,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package org.springframework.cloud.gcp.storage;
@@ -21,6 +20,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
+import com.google.cloud.ReadChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,15 +42,10 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.google.cloud.ReadChannel;
-import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.BlobId;
-import com.google.cloud.storage.Storage;
-
 /**
  * @author Vinicius Carvalho
  */
-@SpringBootTest()
+@SpringBootTest
 @RunWith(SpringRunner.class)
 public class GoogleStorageTests {
 
@@ -56,11 +54,11 @@ public class GoogleStorageTests {
 
 	@Test
 	public void testValidObject() throws Exception {
-		Assert.assertTrue(remoteResource.exists());
-		Assert.assertEquals(4096L, remoteResource.contentLength());
+		Assert.assertTrue(this.remoteResource.exists());
+		Assert.assertEquals(4096L, this.remoteResource.contentLength());
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		InputStream is = remoteResource.getInputStream();
-		byte[] data = new byte[(int) remoteResource.contentLength()];
+		InputStream is = this.remoteResource.getInputStream();
+		byte[] data = new byte[(int) this.remoteResource.contentLength()];
 		int read = 0;
 		while ((read = is.read(data, 0, data.length)) != -1) {
 			baos.write(data, 0, read);
@@ -76,7 +74,7 @@ public class GoogleStorageTests {
 		}
 
 		@Configuration
-		static class GoogleStorageTestsConfiguration implements ResourceLoaderAware{
+		static class GoogleStorageTestsConfiguration implements ResourceLoaderAware {
 
 			private ResourceLoader defaultResourceLoader;
 

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
@@ -12,7 +12,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package org.springframework.integration.gcp.inbound;
@@ -45,7 +44,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 	private Subscriber subscriber;
 
 	public PubSubInboundChannelAdapter(String projectId, String subscriptionName,
-									   GoogleCredentials credentials) {
+			GoogleCredentials credentials) {
 		this.projectId = projectId;
 		this.subscriptionName = subscriptionName;
 		this.credentials = credentials;
@@ -56,15 +55,15 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		super.doStart();
 
 		// TODO(joaomartins): Allow user to pass in receiveMessage.
-		subscriber = Subscriber
-				.defaultBuilder(SubscriptionName.create(projectId, this.subscriptionName),
+		this.subscriber = Subscriber
+				.defaultBuilder(SubscriptionName.create(this.projectId, this.subscriptionName),
 						this::receiveMessage)
 				.setChannelProvider(
 						SubscriptionAdminSettings.defaultChannelProviderBuilder()
-								.setCredentialsProvider(() -> credentials)
+								.setCredentialsProvider(() -> this.credentials)
 								.build())
 				.build();
-		subscriber.startAsync();
+		this.subscriber.startAsync();
 	}
 
 	private void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
@@ -80,8 +79,8 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 
 	@Override
 	protected void doStop() {
-		if (subscriber != null) {
-			subscriber.stopAsync();
+		if (this.subscriber != null) {
+			this.subscriber.stopAsync();
 		}
 
 		super.doStop();

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/outbound/PubSubMessageHandler.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/outbound/PubSubMessageHandler.java
@@ -12,7 +12,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package org.springframework.integration.gcp.outbound;

--- a/src/checkstyle/checkstyle-header.txt
+++ b/src/checkstyle/checkstyle-header.txt
@@ -1,0 +1,15 @@
+^\Q/*\E$
+^\Q *  Copyright \E(20\d\d\-)?20\d\d\Q original author or authors.\E$
+^\Q *\E$
+^\Q *  Licensed under the Apache License, Version 2.0 (the "License");\E$
+^\Q *  you may not use this file except in compliance with the License.\E$
+^\Q *  You may obtain a copy of the License at\E$
+^\Q *\E$
+^\Q *       http://www.apache.org/licenses/LICENSE-2.0\E$
+^\Q *\E$
+^\Q *  Unless required by applicable law or agreed to in writing, software\E$
+^\Q *  distributed under the License is distributed on an "AS IS" BASIS,\E$
+^\Q *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\E$
+^\Q *  See the License for the specific language governing permissions and\E$
+^\Q *  limitations under the License.\E$
+^\Q */\E$

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <!-- Root Checks -->
+    <module name="RegexpHeader">
+        <property name="headerFile" value="src/checkstyle/checkstyle-header.txt"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
+    <module name="TreeWalker">
+        <property name="tabWidth" value="4"/>
+        <module name="LineLength">
+            <property name="max" value="120"/>
+        </module>
+
+        <!-- Annotations -->
+        <module name="AnnotationUseStyle">
+            <property name="elementStyle" value="compact"/>
+        </module>
+        <module name="MissingOverride"/>
+        <module name="PackageAnnotation"/>
+        <module name="AnnotationLocation">
+            <property name="allowSamelineSingleParameterlessAnnotation"
+                      value="false"/>
+        </module>
+
+        <!-- Block Checks -->
+        <module name="EmptyBlock">
+            <property name="option" value="text"/>
+        </module>
+        <module name="LeftCurly"/>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="AvoidNestedBlocks"/>
+
+        <!-- tabs instead of spaces -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t* "/>
+            <property name="message" value="Indent must use tab characters"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
+        <!-- Class Design -->
+        <module name="FinalClass"/>
+        <module name="InterfaceIsType"/>
+        <module name="MutableException"/>
+        <module name="InnerTypeLast"/>
+        <module name="OneTopLevelClass"/>
+
+        <!-- Coding -->
+        <module name="CovariantEquals"/>
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="InnerAssignment"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="StringLiteralEquality"/>
+        <module name="NestedForDepth">
+            <property name="max" value="3"/>
+        </module>
+        <module name="NestedIfDepth">
+            <property name="max" value="3"/>
+        </module>
+        <module name="NestedTryDepth">
+            <property name="max" value="3"/>
+        </module>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="RequireThis">
+            <property name="checkMethods" value="false"/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="ExplicitInitialization"/>
+
+        <module name="ParameterAssignment"/>
+
+        <!-- Imports -->
+        <module name="AvoidStarImport"/>
+        <module name="AvoidStaticImport">
+            <property name="excludes"
+                      value="org.junit.Assert.*,org.mockito.Mockito.*,org.mockito.Matchers.*,org.hamcrest.Matchers.*,org.assertj.core.api.Assertions.*"/>
+        </module>
+        <module name="FallThrough"/>
+        <module name="ImportOrder">
+            <property name="groups" value="java,/^javax?\./,*,org.springframework"/>
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="option" value="bottom"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+        </module>
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="org.slf4j"/>
+        </module>
+        <module name="RedundantImport"/>
+        <module name="ReturnCount">
+            <property name="max" value="0"/>
+            <property name="tokens" value="CTOR_DEF"/>
+        </module>
+        <module name="ReturnCount">
+            <property name="max" value="1"/>
+            <property name="tokens" value="LAMBDA"/>
+        </module>
+        <module name="ReturnCount">
+            <property name="max" value="3"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
+        <module name="UnusedImports"/>
+
+        <!-- Miscellaneous -->
+        <module name="CommentsIndentation"/>
+        <module name="UpperEll"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="OuterTypeFilename"/>
+
+        <!-- Modifiers -->
+        <module name="RedundantModifier"/>
+
+        <!-- Regexp -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t* +\t*\S"/>
+            <property name="message"
+                      value="Line has leading space characters; indentation should be performed with tabs only."/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+        <module name="Regexp">
+            <property name="format" value="[ \t]+$"/>
+            <property name="illegalPattern" value="true"/>
+            <property name="message" value="Trailing whitespace"/>
+        </module>
+
+        <!-- Whitespace -->
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens"
+                      value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS, UNARY_PLUS, ARRAY_DECLARATOR"/>
+        </module>
+        <module name="NoWhitespaceBefore"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+    </module>
+</module>

--- a/src/eclipse/eclipse-code-formatter.xml
+++ b/src/eclipse/eclipse-code-formatter.xml
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+	<profile kind="CodeFormatterProfile" name="Spring Boot Java Conventions" version="12">
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="do not insert"/>
+		<setting
+				id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration"
+				value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+		<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+		<setting
+				id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference"
+				value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+		<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="90"/>
+		<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments"
+				 value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header"
+				 value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+		<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+		<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+		<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration"
+				 value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+		<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+		<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header"
+				 value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+		<setting
+				id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference"
+				value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference"
+				 value="do not insert"/>
+		<setting
+				id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference"
+				value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression"
+				 value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+		<setting
+				id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration"
+				value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header"
+				 value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration"
+				 value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+		<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation"
+				 value="do not insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+	</profile>
+</profiles>

--- a/src/eclipse/eclipse.importorder
+++ b/src/eclipse/eclipse.importorder
@@ -1,0 +1,7 @@
+#Organize Import Order
+#Wed Apr 26 12:53:22 EDT 2017
+4=\#
+3=org.springframework
+2=
+1=javax
+0=java


### PR DESCRIPTION
This is a copy of #38 with a number of fixes

The original description:
- new etc/ folder with eclipse code formatter and checkstyle rules
- refactoring of classes where import order / copyright were not
  following spec
- adding section on readme on how to enable eclipse code formatter

I uncommented all the checkstyle rules, improved the README, created CONTRIBUTING and modified a few more classes.
I also deleted the checkstyle rule recommending usage of AssertJ in detriment of Junit.

Fixes #15