### PR TITLE
Adds manual Pub/Sub message acking mode

### DIFF
--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/AckMode.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/AckMode.java
@@ -18,6 +18,8 @@ package org.springframework.integration.gcp;
 
 /**
  * Determines acknowledgement policy for incoming messages from Google Cloud Pub/Sub.
+ *
+ * @author João André Martins
  */
 public enum AckMode {
 

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/AckMode.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/AckMode.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2017 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.integration.gcp;
+
+/**
+ * Determines acknowledgement policy for incoming messages from Google Cloud Pub/Sub.
+ */
+public enum AckMode {
+
+	/**
+	 * The framework does not ack/nack and the
+	 * {@link com.google.cloud.pubsub.spi.v1.AckReplyConsumer} is sent back to the user.
+	 */
+	MANUAL,
+
+	/**
+	 * The framework acks {@link com.google.pubsub.v1.PubsubMessage} after they are sent to the
+	 * channel.
+	 */
+	AUTO
+}

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
@@ -83,8 +83,15 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		}
 
 
-		sendMessage(getMessagingTemplate().getMessageConverter()
-				.toMessage(message.getData(), new MessageHeaders(messageHeaders)));
+		try {
+			sendMessage(getMessagingTemplate().getMessageConverter()
+					.toMessage(message.getData(), new MessageHeaders(messageHeaders)));
+		} catch (RuntimeException re) {
+			if (this.ackMode == AckMode.AUTO) {
+				consumer.nack();
+			}
+			throw re;
+		}
 
 		if (this.ackMode == AckMode.AUTO) {
 			consumer.ack();

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.gcp.pubsub.support.GcpHeaders;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.gcp.AckMode;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.util.Assert;
 
 /**
  * Converts from GCP Pub/Sub message to Spring message and sends the Spring message to the
@@ -104,6 +105,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 	}
 
 	public void setAckMode(AckMode ackMode) {
+		Assert.notNull(ackMode, "The acknowledgement mode can't be null.");
 		this.ackMode = ackMode;
 	}
 }

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
@@ -82,11 +82,11 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 			messageHeaders.put(GcpHeaders.ACKNOWLEDGEMENT, consumer);
 		}
 
-
 		try {
 			sendMessage(getMessagingTemplate().getMessageConverter()
 					.toMessage(message.getData(), new MessageHeaders(messageHeaders)));
-		} catch (RuntimeException re) {
+		}
+		catch (RuntimeException re) {
 			if (this.ackMode == AckMode.AUTO) {
 				consumer.nack();
 			}

--- a/spring-integration-gcp/src/test/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapterTest.java
+++ b/spring-integration-gcp/src/test/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapterTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2017 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.integration.gcp.inbound;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * {@link PubSubInboundChannelAdapter} unit tests.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PubSubInboundChannelAdapterTest {
+
+	@Mock
+	private GoogleCredentials mockCredentials;
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testNonNullAckMode() {
+		PubSubInboundChannelAdapter adapter = new PubSubInboundChannelAdapter(
+				"projectId", "testSubscription", this.mockCredentials);
+		adapter.setAckMode(null);
+	}
+}

--- a/spring-integration-gcp/src/test/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapterTest.java
+++ b/spring-integration-gcp/src/test/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapterTest.java
@@ -24,6 +24,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  * {@link PubSubInboundChannelAdapter} unit tests.
+ *
+ * @author João André Martins
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PubSubInboundChannelAdapterTest {


### PR DESCRIPTION
Users can now choose between getting the AckReplyConsumer and acking
the messages themselves, or having the channel adapters acking for
them.

Fixes #8.