### PR TITLE
Updates to google-cloud-pubsub version 0.20.1-alpha

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<description>Spring Cloud GCP Dependencies</description>
 
 	<properties>
-		<google-cloud-java.version>0.17.2-alpha</google-cloud-java.version>
+		<google-cloud-java.version>0.20.1-alpha</google-cloud-java.version>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -25,8 +25,8 @@ import com.google.api.core.ApiFutures;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.api.gax.grpc.InstantiatingExecutorProvider;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.pubsub.spi.v1.Publisher;
-import com.google.cloud.pubsub.spi.v1.TopicAdminSettings;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.TopicName;
 

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/inbound/PubSubInboundChannelAdapter.java
@@ -20,9 +20,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.pubsub.spi.v1.AckReplyConsumer;
-import com.google.cloud.pubsub.spi.v1.Subscriber;
-import com.google.cloud.pubsub.spi.v1.SubscriptionAdminSettings;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.SubscriptionName;
 


### PR DESCRIPTION
Last update contains a breaking change, "spi" is removed from the
package name.