### PR TITLE
Adds CredentialProviders to Subscribers and Publishers directly

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -20,9 +20,11 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.grpc.ChannelProvider;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.pubsub.v1.TopicName;
 
@@ -53,11 +55,17 @@ public class DefaultPublisherFactory implements PublisherFactory {
 
 	private final ChannelProvider channelProvider;
 
+	private final CredentialsProvider credentialsProvider;
+
 	public DefaultPublisherFactory(String projectId, ExecutorProvider executorProvider,
-			ChannelProvider channelProvider) {
+			CredentialsProvider credentialsProvider) {
 		this.projectId = projectId;
 		this.executorProvider = executorProvider;
-		this.channelProvider = channelProvider;
+		this.channelProvider = TopicAdminSettings.defaultChannelProviderBuilder()
+				.setClientLibHeader("spring",
+						this.getClass().getPackage().getImplementationVersion())
+				.build();
+		this.credentialsProvider = credentialsProvider;
 	}
 
 	@Override
@@ -67,6 +75,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 				return Publisher.defaultBuilder(TopicName.create(this.projectId, key))
 						.setExecutorProvider(this.executorProvider)
 						.setChannelProvider(this.channelProvider)
+						.setCredentialsProvider(this.credentialsProvider)
 						.build();
 			}
 			catch (IOException ioe) {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -24,7 +24,6 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.grpc.ChannelProvider;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.cloud.pubsub.v1.Publisher;
-import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.pubsub.v1.TopicName;
 
@@ -58,13 +57,10 @@ public class DefaultPublisherFactory implements PublisherFactory {
 	private final CredentialsProvider credentialsProvider;
 
 	public DefaultPublisherFactory(String projectId, ExecutorProvider executorProvider,
-			CredentialsProvider credentialsProvider) {
+			ChannelProvider channelProvider, CredentialsProvider credentialsProvider) {
 		this.projectId = projectId;
 		this.executorProvider = executorProvider;
-		this.channelProvider = TopicAdminSettings.defaultChannelProviderBuilder()
-				.setClientLibHeader("spring",
-						this.getClass().getPackage().getImplementationVersion())
-				.build();
+		this.channelProvider = channelProvider;
 		this.credentialsProvider = credentialsProvider;
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactory.java
@@ -21,7 +21,6 @@ import com.google.api.gax.grpc.ChannelProvider;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.pubsub.v1.SubscriptionName;
 
 /**
@@ -41,13 +40,10 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 	private final CredentialsProvider credentialsProvider;
 
 	public DefaultSubscriberFactory(String projectId, ExecutorProvider executorProvider,
-			CredentialsProvider credentialsProvider) {
+			ChannelProvider channelProvider, CredentialsProvider credentialsProvider) {
 		this.projectId = projectId;
 		this.executorProvider = executorProvider;
-		this.channelProvider = SubscriptionAdminSettings.defaultChannelProviderBuilder()
-				.setClientLibHeader("spring",
-						this.getClass().getPackage().getImplementationVersion())
-				.build();
+		this.channelProvider = channelProvider;
 		this.credentialsProvider = credentialsProvider;
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactory.java
@@ -16,10 +16,12 @@
 
 package org.springframework.cloud.gcp.pubsub.support;
 
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.grpc.ChannelProvider;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.pubsub.v1.SubscriptionName;
 
 /**
@@ -32,15 +34,21 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 
 	private String projectId;
 
-	private ExecutorProvider executorProvider;
+	private final ExecutorProvider executorProvider;
 
-	private ChannelProvider channelProvider;
+	private final ChannelProvider channelProvider;
+
+	private final CredentialsProvider credentialsProvider;
 
 	public DefaultSubscriberFactory(String projectId, ExecutorProvider executorProvider,
-			ChannelProvider channelProvider) {
+			CredentialsProvider credentialsProvider) {
 		this.projectId = projectId;
 		this.executorProvider = executorProvider;
-		this.channelProvider = channelProvider;
+		this.channelProvider = SubscriptionAdminSettings.defaultChannelProviderBuilder()
+				.setClientLibHeader("spring",
+						this.getClass().getPackage().getImplementationVersion())
+				.build();
+		this.credentialsProvider = credentialsProvider;
 	}
 
 	@Override
@@ -49,6 +57,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 				SubscriptionName.create(this.projectId, subscriptionName), receiver)
 				.setChannelProvider(this.channelProvider)
 				.setExecutorProvider(this.executorProvider)
+				.setCredentialsProvider(this.credentialsProvider)
 				.build();
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactoryTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gcp.pubsub.support;
 
 import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.grpc.ChannelProvider;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import org.junit.Before;
@@ -38,12 +39,15 @@ public class DefaultPublisherFactoryTests {
 	@Mock
 	private ExecutorProvider executorProvider;
 	@Mock
+	private ChannelProvider channelProvider;
+	@Mock
 	private CredentialsProvider credentialsProvider;
 
 	@Before
 	public void setUp() {
 		this.factory = new DefaultPublisherFactory(
-				"projectId", this.executorProvider, this.credentialsProvider);
+				"projectId", this.executorProvider, this.channelProvider,
+				this.credentialsProvider);
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactoryTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.gcp.pubsub.support;
 
-import com.google.api.gax.grpc.ChannelProvider;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import org.junit.Before;
@@ -38,12 +38,12 @@ public class DefaultPublisherFactoryTests {
 	@Mock
 	private ExecutorProvider executorProvider;
 	@Mock
-	private ChannelProvider channelProvider;
+	private CredentialsProvider credentialsProvider;
 
 	@Before
 	public void setUp() {
 		this.factory = new DefaultPublisherFactory(
-				"projectId", this.executorProvider, this.channelProvider);
+				"projectId", this.executorProvider, this.credentialsProvider);
 	}
 
 	@Test

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubsubAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubsubAutoConfiguration.java
@@ -18,10 +18,10 @@ package org.springframework.cloud.gcp.pubsub.autoconfig;
 
 import java.util.concurrent.Executors;
 
-import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.grpc.ChannelProvider;
 import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.api.gax.grpc.FixedExecutorProvider;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
 
@@ -96,20 +96,20 @@ public class GcpPubsubAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public SubscriberFactory defaultSubscriberFactory(GcpProperties gcpProperties,
+			GoogleCredentials credentials,
 			@Qualifier("publisherExecutorProvider") ExecutorProvider executorProvider,
-			@Qualifier("publisherChannelProvider") ChannelProvider channelProvider,
-			CredentialsProvider credentialsProvider) {
+			@Qualifier("publisherChannelProvider") ChannelProvider channelProvider) {
 		return new DefaultSubscriberFactory(gcpProperties.getProjectId(),
-				executorProvider, channelProvider, credentialsProvider);
+				executorProvider, channelProvider, () -> credentials);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
 	public PublisherFactory defaultPublisherFactory(GcpProperties gcpProperties,
+			GoogleCredentials credentials,
 			@Qualifier("subscriberExecutorProvider") ExecutorProvider subscriberProvider,
-			@Qualifier("subscriberChannelProvider") ChannelProvider channelProvider,
-			CredentialsProvider credentialsProvider) {
+			@Qualifier("subscriberChannelProvider") ChannelProvider channelProvider) {
 		return new DefaultPublisherFactory(gcpProperties.getProjectId(),
-				subscriberProvider, channelProvider, credentialsProvider);
+				subscriberProvider, channelProvider, () -> credentials);
 	}
 }


### PR DESCRIPTION
Setting CredentialsProviders in the ChannelProvider is deprecated since
google-cloud-pubsub version 0.20.1-alpha. That allows us to not require
a ChannelProvider from users, which better allows us to enforce that
clientLibName and clientLibVersion are filled with our data.

Fixes #64