### PR TITLE
Adds features and fixes Spring project name, so Javascript widgets work

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ name: Spring Cloud GCP
 
 # ID of the project in the metadata API at spring.io (if this is not a
 # valid project ID the javascript widgets in the home page will not work)
-project: spring-Cloud GCP
+project: spring-cloud-gcp
 
 # Project github URL
 github_repo_url: http://github.com/spring-cloud/spring-cloud-gcp

--- a/index.html
+++ b/index.html
@@ -55,17 +55,17 @@ The Spring Cloud GCP project brings the familiar Spring programming model to Goo
 
 * spring-cloud-gcp-core - Common utilities
 
-* spring-cloud-gcp-pubsub - Core Pubsub functionality
+* spring-cloud-gcp-pubsub - Core Pub/Sub functionality
 
 * spring-cloud-gcp-starters - Spring Boot starters
 
 * spring-cloud-gcp-storage - Core storage functionality
 
-* spring-integration-gpc - Spring Integration Extensions for GCP
+* spring-integration-gcp - Spring Integration Extensions for GCP
 
 ## Features
 
-* Spring Integration Pubsub channel adapters;
+* Spring Integration Pub/Sub channel adapters;
 
 * `PubsubTemplate`, Spring's message sending abstraction for Google Cloud Pub/Sub;
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 # The name of your project
-title: Spring Clound GCP
+title: Spring Cloud GCP
 
 badges:
 
@@ -51,32 +51,33 @@ The Spring Cloud GCP project brings the familiar Spring programming model to Goo
 
 {% capture main_content %}
 
-**INTRODUCTORY PARAGRAPHS**
-TBD
-
 ## Components
 
-* spring-cloud-gcp-core - common utilities
+* spring-cloud-gcp-core - Common utilities
 
-* spring-cloud-gcp-pubsub - core pubsub functionality
+* spring-cloud-gcp-pubsub - Core Pubsub functionality
 
-* spring-cloud-gcp-starters - boot starters
+* spring-cloud-gcp-starters - Spring Boot starters
 
-* spring-cloud-gcp-storage - core storage functionality
+* spring-cloud-gcp-storage - Core storage functionality
 
 * spring-integration-gpc - Spring Integration Extensions for GCP
 
 ## Features
 
-* TBD
+* Spring Integration Pubsub channel adapters;
+
+* `PubsubTemplate`, Spring's message sending abstraction for Google Cloud Pub/Sub;
+
+* Spring Resources on Google Cloud Storage;
+
+* Spring Boot starters for Google Cloud Pub/Sub and Google Cloud Storage.
 
 <span id="quick-start"></span>
 
 ## Quick Start
 
 {% include download_widget.md %}
-
-TBD
 
 {% endcapture %}
 


### PR DESCRIPTION
After this, the right hand "Sample Projects", "Getting Started Guides"
and "Tutorials" will still need attention. We might also want to add
to Quick Start.

Helps with #11