### PR TITLE
Adds the SQL starter to the spring-cloud-gcp BOM

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -82,6 +82,11 @@
 				<artifactId>spring-cloud-gcp-starter-storage</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-gcp-starter-sql</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
The SQL starter is currently missing from the BOM.