### PR TITLE
Removes dependencies from high level spring-cloud-gcp-starters

### DIFF
--- a/spring-cloud-gcp-starters/pom.xml
+++ b/spring-cloud-gcp-starters/pom.xml
@@ -25,23 +25,4 @@
 		<module>spring-cloud-gcp-starter-storage</module>
 		<module>spring-cloud-gcp-starter-sql</module>
 	</modules>
-
-	<dependencies>
-		<dependency>
-			<groupId>com.google.cloud</groupId>
-			<artifactId>google-cloud-pubsub</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.google.cloud</groupId>
-			<artifactId>google-cloud-storage</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-		</dependency>
-	</dependencies>
 </project>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/pom.xml
@@ -41,5 +41,17 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+
+		<!-- AnnotationConfigApplicationContext requires this in tests -->
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/pom.xml
@@ -50,5 +50,12 @@
 			<version>1.0.3</version>
 		</dependency>
 
+		<!-- AnnotationConfigApplicationContext requires this in tests -->
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>


### PR DESCRIPTION
These dependencies would go on to be added to every sub-module, even
those that didn't need them. The dependencies should be added on a
per-module basis, instead.

Fixes #91