### PR TITLE
Moves dependency versions to spring-cloud-dependencies

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -65,6 +65,32 @@
 				<version>1.2</version>
 			</dependency>
 
+			<!-- spring-cloud-gcp-starter-core -->
+			<dependency>
+				<groupId>com.google.auth</groupId>
+				<artifactId>google-auth-library-oauth2-http</artifactId>
+				<version>0.7.1</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.google.guava</groupId>
+						<artifactId>guava</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+
+			<!-- spring-cloud-gcp-starter-sql -->
+			<dependency>
+				<groupId>com.google.apis</groupId>
+				<artifactId>google-api-services-sqladmin</artifactId>
+				<version>v1beta4-rev45-1.22.0</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.cloud.sql</groupId>
+				<artifactId>mysql-socket-factory</artifactId>
+				<version>1.0.3</version>
+			</dependency>
+
 			<!--Starters-->
 
 			<dependency>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/pom.xml
@@ -26,13 +26,6 @@
 		<dependency>
 			<groupId>com.google.auth</groupId>
 			<artifactId>google-auth-library-oauth2-http</artifactId>
-			<version>0.7.1</version>
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- @ConfigurationProperties metadata -->

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/pom.xml
@@ -27,7 +27,6 @@
 		<dependency>
 			<groupId>com.google.apis</groupId>
 			<artifactId>google-api-services-sqladmin</artifactId>
-			<version>v1beta4-rev45-1.22.0</version>
 		</dependency>
 
 		<!-- Hibernate Validator -->
@@ -47,7 +46,6 @@
 		<dependency>
 			<groupId>com.google.cloud.sql</groupId>
 			<artifactId>mysql-socket-factory</artifactId>
-			<version>1.0.3</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
Enforces that the same version of a library is used across the entire
project and prevents dependency conflicts with different versions of the
same library.

Fixes #93