### PR TITLE
Documents undocumented parts of spring-cloud-gcp

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,8 +24,8 @@ start working on one, please take a look at our link:CONTRIBUTING.adoc[collabora
 == Spring Cloud GCP Bill of Materials (BOM)
 
 If you're a Maven user, it's probably a good idea to add our BOM to your maven.xml
-`<dependencyManagement>` section. This will allow you not to specify versions for any of the Maven
-dependencies and delegate versioning to the BOM.
+`<dependencyManagement>` section. This will allow you to not specify versions for any of the Maven
+dependencies and instead delegate versioning to the BOM.
 
 [source,xml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -14,3 +14,145 @@ We would love to hear from you.
 
 If you want to collaborate in the project, we would also love to get your Pull Requests. Before you
 start working on one, please take a look at our link:CONTRIBUTING.adoc[collaboration manual].
+
+== Spring Cloud GCP Pub/Sub
+
+Provides a simplified abstraction to interact with Google Cloud Pub/Sub. Using this abstraction
+allows user code to be independent from the underlying Google Cloud Pub/Sub API semantics. It's
+currently possible to publish messages to a Google Cloud Pub/Sub and to create new topics and
+subscriptions.
+
+You can refer to the `PubSubTemplate` and `PubSubAdmin` classes for more details on the
+functionality provided by this module.
+
+== Spring Cloud GCP Storage
+
+Enables the Spring Resource abstraction to run on Google Cloud Storage.
+
+You can use the `@Value` annotation
+
+[source,java]
+----
+@Value("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]")
+private Resource file;
+----
+
+or the Spring application context
+
+[source,java]
+----
+SpringApplication.run(...).getResource("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]");
+----
+
+== Spring Integration channel adapters
+
+Provides adapters for Spring Messaging channels to exchange messages via Google Cloud Pub/Sub.
+
+Refer to this https://spring.io/guides/gs/spring-cloud-gcp/[Spring getting started guide] to learn
+how to use the adapters.
+
+== Spring Boot GCP Core
+
+This starter creates and configures two important configuration sources: `CredentialsProvider` and
+`GcpProjectIdProvider`.
+
+It tries to read configuration from the application properties. For example, using a properties
+file:
+
+[source,yaml]
+----
+spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
+spring.cloud.gcp.credentials-location=file:[LOCAL_PRIVATE_KEY_FILE]
+----
+
+If `spring.cloud.gcp.project-id` is populated, the provided `GcpProjectIdProvider` returns that
+project ID. Otherwise, it uses google-cloud-java's
+http://googlecloudplatform.github.io/google-cloud-java/0.21.1/apidocs/com/google/cloud/ServiceOptions.html#getDefaultProjectId--[rules to discover the project ID].
+
+Similarly for `spring.cloud.gcp.credentials-location`, if a property is configured, the provided
+`CredentialsProvider` returns credentials for that private key. The value of
+`spring.cloud.gcp.credentials-location` is a Spring Resource, so you can specify
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html#resources-implementations[file system paths, HTTP URLs, etc.]
+If no property is configured, the provided `CredentialsProvider` returns the
+http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
+
+== Spring Boot Cloud SQL
+
+This starter provides a couple of configuration sources: `CloudSqlJdbcInfoProvider` and
+`DataSource`.
+
+`CloudSqlJdbcInfoProvider` returns the JDBC information to be used, such as the JDBC driver name
+and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on
+Google App Engine.
+
+Besides `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`,
+`CloudSqlJdbcInfoProvider` requires the following properties:
+
+[source,yaml]
+----
+spring.cloud.gcp.sql.instance-name=[YOUR_CLOUD_SQL_INSTANCE_NAME]
+spring.cloud.gcp.sql.database-name=[YOUR_CLOUD_SQL_DATABASE_NAME]
+----
+
+The following properties are optional:
+
+[source,yaml]
+----
+spring.cloud.gcp.sql.region=[YOUR_CLOUD_SQL_INSTANCE_REGION]
+spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
+spring.cloud.gcp.sql.user-name=[YOUR_CLOUD_SQL_USERNAME]
+spring.cloud.gcp.sql.password=[YOUR_CLOUD_SQL_PASSWORD]
+----
+
+If `spring.cloud.gcp.sql.region` isn't specified, the starter will use the
+https://cloud.google.com/sql/docs/mysql/admin-api/[Cloud SQL API] to auto-discover the instance
+region.
+
+If `spring.cloud.gcp.sql.instance-connection-name` is specified, it is used as the final instance
+connection name and `spring.cloud.gcp.sql.region` and `spring.cloud.gcp.sql.instance-name` are
+not used.
+
+If `spring.cloud.gcp.sql.user-name` isn't specified, `"root"` is used by default.
+
+If `spring.cloud.gcp.sql.password` isn't specified, an empty string is used by default.
+
+By using this starter in conjunction with
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC],
+it's possible to inject a fully configured `JdbcTemplate` object only from adding the required
+properties.
+
+Due to https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/41[an issue] in
+the Cloud SQL Socket Factory for JDBC drivers, the credentials used to connect to Cloud SQL are not
+the ones from the provided `CredentialsProvider`, but the
+http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials]
+instead. However, region auto-discovery uses the credentials provided by `CredentialsProvider`.
+
+The returned `DataSource` is an implementation of
+https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use another kind of
+`DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
+`DataSource` bean.
+
+== Spring Boot Cloud Pub/Sub
+
+This starter provides Pub/Sub key classes `PubSubTemplate` and `PubSubAdmin`.
+
+It requires the `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`
+properties.
+
+The following properties are optional:
+[source,yaml]
+----
+spring.cloud.gcp.pubsub.subscriber.executorThreads=[SUBSCRIBER_EXECUTOR_THREADS]
+spring.cloud.gcp.pubsub.publisher.executorThreads=[PUBLISHER_EXECUTOR_THREADS]
+----
+
+`spring.cloud.gcp.pubsub.subscriber.executorThreads` is the number of threads used by the subscriber
+executor. Likewise, `spring.cloud.gcp.pubsub.publisher.executorThreads` is the number of threads
+used by the publisher executor. The default value for both of these properties is 4.
+
+== Spring Boot Cloud Storage
+
+This starter provides the underpinnings of the Spring Cloud GCP Storage. It doesn't provide any
+bean to be used by an end-user.
+
+It requires the `spring.cloud.gcp.credentials-location` property.

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,7 @@
 = Spring Framework on Google Cloud Platform
 
-This project aims at making it as seamless as possible for Spring users to run their applications on
-Google Cloud Platform. The project website is http://cloud.spring.io/spring-cloud-gcp/ (under
-development).
+This project makes it easy for Spring users to run their applications on Google Cloud Platform. The
+project website is http://cloud.spring.io/spring-cloud-gcp/ (under development).
 
 Currently, this repository provides support for:
 
@@ -49,8 +48,8 @@ Spring Boot greatly simplifies the Spring Cloud GCP experience. Our starters han
 instantiation and configuration logic so you don't have to.
 
 Every starter depends on the core starter to provide critical bits of configuration, like the
-GCP project ID or OAuth2 credentials location. You can configure these as properties in e.g., a
-properties file:
+GCP project ID or OAuth2 credentials location. You can configure these as properties in, for
+example, a properties file:
 
 [source, yaml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -42,3 +42,22 @@ dependencies and instead delegate versioning to the BOM.
     </dependencies>
 </dependencyManagement>
 ----
+
+== Spring Boot Starters
+
+Spring Boot greatly simplifies the Spring Cloud GCP experience. Our starters handle the object
+instantiation and configuration logic so you don't have to.
+
+Every starter depends on the core starter to provide critical bits of configuration, like the
+GCP project ID or OAuth2 credentials location. You can configure these as properties in e.g., a
+properties file:
+
+[source, yaml]
+----
+spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
+spring.cloud.gcp.credentials-location=file:[LOCAL_PRIVATE_KEY_FILE]
+----
+
+These properties are optional and, if not specified, Spring Boot will attempt to automatically find
+them for you. For details on how Spring Boot finds these properties, refer to the desired starter
+README.

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,28 @@ We would love to hear from you.
 If you want to collaborate in the project, we would also love to get your Pull Requests. Before you
 start working on one, please take a look at our link:CONTRIBUTING.adoc[collaboration manual].
 
-== Spring Cloud GCP Pub/Sub
+== Spring Cloud GCP Bill of Materials (BOM)
+
+If you're a Maven user, it's probably a good idea to add our BOM to your maven.xml
+`<dependencyManagement>` section. This will allow you not to specify versions for any of the Maven
+dependencies and delegate versioning to the BOM.
+
+[source,xml]
+----
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-dependencies</artifactId>
+            <version>1.0.0.BUILD-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+----
+
+== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-pubsub[Spring Cloud GCP Pub/Sub]
 
 Provides a simplified abstraction to interact with Google Cloud Pub/Sub. Using this abstraction
 allows user code to be independent from the underlying Google Cloud Pub/Sub API semantics. It's
@@ -31,7 +52,7 @@ subscriptions.
 You can refer to the `PubSubTemplate` and `PubSubAdmin` classes for more details on the
 functionality provided by this module.
 
-== Spring Resource Abstraction for Google Cloud Storage
+== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-storage[Spring Resource Abstraction for Google Cloud Storage]
 
 Enables the Spring Resource abstraction to run on Google Cloud Storage.
 
@@ -59,7 +80,7 @@ try (OutputStream os = ((WritableResource) gcsResource).getOutputStream()) {
 }
 ----
 
-== Spring Integration Channel Adapters for Google Cloud Pub/Sub
+== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-integration-gcp[Spring Integration Channel Adapters for Google Cloud Pub/Sub]
 
 Provides adapters for Spring Messaging channels to exchange messages via Google Cloud Pub/Sub. Makes
 extensive usage of the constructs provided by the Spring Cloud GCP Pub/Sub module, like
@@ -68,7 +89,7 @@ extensive usage of the constructs provided by the Spring Cloud GCP Pub/Sub modul
 Refer to this https://spring.io/guides/gs/spring-cloud-gcp/[Spring getting started guide] to learn
 how to use the adapters.
 
-== Google Cloud Core Spring Boot Starter
+== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core[Google Cloud Core Spring Boot Starter]
 
 This starter creates and configures two important configuration sources: `CredentialsProvider` and
 `GcpProjectIdProvider`.
@@ -93,7 +114,7 @@ https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resou
 If no property is configured, the provided `CredentialsProvider` returns the
 http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
 
-== Google Cloud SQL Spring Boot Starter
+== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql[Google Cloud SQL Spring Boot Starter]
 
 This starter provides a couple of configuration sources: `CloudSqlJdbcInfoProvider` and
 `DataSource`.
@@ -149,7 +170,7 @@ https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use anothe
 `DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
 `DataSource` bean.
 
-== Google Cloud Pub/Sub Spring Boot Starter
+== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub[Google Cloud Pub/Sub Spring Boot Starter]
 
 This starter provides Pub/Sub key classes `PubSubTemplate` and `PubSubAdmin`.
 
@@ -167,7 +188,7 @@ spring.cloud.gcp.pubsub.publisher.executorThreads=[PUBLISHER_EXECUTOR_THREADS]
 executor. Likewise, `spring.cloud.gcp.pubsub.publisher.executorThreads` is the number of threads
 used by the publisher executor. The default value for both of these properties is 4.
 
-== Google Cloud Storage Spring Boot Starter
+== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage[Google Cloud Storage Spring Boot Starter]
 
 This starter provides the underpinnings of the Spring Cloud GCP Storage. It doesn't provide any
 bean to be used by an end-user.

--- a/README.adoc
+++ b/README.adoc
@@ -4,9 +4,14 @@ This project aims at making it as seamless as possible for Spring users to run t
 Google Cloud Platform. The project website is http://cloud.spring.io/spring-cloud-gcp/ (under
 development).
 
-Currently, this repository contains Spring Integration inbound and outbound channel adapters which
-use Google Cloud Pub/Sub, as well as a Google Cloud Pub/Sub Spring abstraction, i.e.,
-`PubSubTemplate`.
+Currently, this repository provides support for:
+* Spring Cloud GCP Pub/Sub
+* Spring Resource Abstraction for Google Cloud Storage
+* Spring Integration Channel Adapters for Google Cloud Pub/Sub
+* Spring Boot starters
+** Google Cloud Pub/Sub
+** Google Cloud SQL
+** Google Cloud Storage
 
 If you have any other ideas, suggestions or bug reports, please use our
 link:https://github.com/spring-cloud/spring-cloud-gcp/issues[GitHub issue tracker] and let us know!
@@ -19,13 +24,13 @@ start working on one, please take a look at our link:CONTRIBUTING.adoc[collabora
 
 Provides a simplified abstraction to interact with Google Cloud Pub/Sub. Using this abstraction
 allows user code to be independent from the underlying Google Cloud Pub/Sub API semantics. It's
-currently possible to publish messages to a Google Cloud Pub/Sub and to create new topics and
+currently possible to publish messages to a Google Cloud Pub/Sub topic and to create new topics and
 subscriptions.
 
 You can refer to the `PubSubTemplate` and `PubSubAdmin` classes for more details on the
 functionality provided by this module.
 
-== Spring Cloud GCP Storage
+== Spring Resource Abstraction for Google Cloud Storage
 
 Enables the Spring Resource abstraction to run on Google Cloud Storage.
 
@@ -34,7 +39,7 @@ You can use the `@Value` annotation
 [source,java]
 ----
 @Value("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]")
-private Resource file;
+private Resource gcsResource;
 ----
 
 or the Spring application context
@@ -44,14 +49,25 @@ or the Spring application context
 SpringApplication.run(...).getResource("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]");
 ----
 
-== Spring Integration channel adapters
+You can also use this resource to write to a Google Cloud Storage object:
 
-Provides adapters for Spring Messaging channels to exchange messages via Google Cloud Pub/Sub.
+[source,java]
+----
+try (OutputStream os = ((WritableResource) gcsResource).getOutputStream()) {
+  os.write("foo".getBytes());
+}
+----
+
+== Spring Integration Channel Adapters for Google Cloud Pub/Sub
+
+Provides adapters for Spring Messaging channels to exchange messages via Google Cloud Pub/Sub. Makes
+extensive usage of the constructs provided by the Spring Cloud GCP Pub/Sub module, like
+`PubSubTemplate`.
 
 Refer to this https://spring.io/guides/gs/spring-cloud-gcp/[Spring getting started guide] to learn
 how to use the adapters.
 
-== Spring Boot GCP Core
+== Google Cloud Core Spring Boot Starter
 
 This starter creates and configures two important configuration sources: `CredentialsProvider` and
 `GcpProjectIdProvider`.
@@ -76,7 +92,7 @@ https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resou
 If no property is configured, the provided `CredentialsProvider` returns the
 http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
 
-== Spring Boot Cloud SQL
+== Google Cloud SQL Spring Boot Starter
 
 This starter provides a couple of configuration sources: `CloudSqlJdbcInfoProvider` and
 `DataSource`.
@@ -132,7 +148,7 @@ https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use anothe
 `DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
 `DataSource` bean.
 
-== Spring Boot Cloud Pub/Sub
+== Google Cloud Pub/Sub Spring Boot Starter
 
 This starter provides Pub/Sub key classes `PubSubTemplate` and `PubSubAdmin`.
 
@@ -150,7 +166,7 @@ spring.cloud.gcp.pubsub.publisher.executorThreads=[PUBLISHER_EXECUTOR_THREADS]
 executor. Likewise, `spring.cloud.gcp.pubsub.publisher.executorThreads` is the number of threads
 used by the publisher executor. The default value for both of these properties is 4.
 
-== Spring Boot Cloud Storage
+== Google Cloud Storage Spring Boot Starter
 
 This starter provides the underpinnings of the Spring Cloud GCP Storage. It doesn't provide any
 bean to be used by an end-user.

--- a/README.adoc
+++ b/README.adoc
@@ -6,13 +6,14 @@ development).
 
 Currently, this repository provides support for:
 
-* Spring Cloud GCP Pub/Sub
-* Spring Resource Abstraction for Google Cloud Storage
-* Spring Integration Channel Adapters for Google Cloud Pub/Sub
+* https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-pubsub[Spring Cloud GCP Pub/Sub]
+* https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-storage[Spring Resource Abstraction for Google Cloud Storage]
+* https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-integration-gcp[Spring Integration Channel Adapters for Google Cloud Pub/Sub]
 * Spring Boot starters
-** Google Cloud Pub/Sub
-** Google Cloud SQL
-** Google Cloud Storage
+** https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core[Core]
+** https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub[Google Cloud Pub/Sub]
+** https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql[Google Cloud SQL]
+** https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage[Google Cloud Storage]
 
 If you have any other ideas, suggestions or bug reports, please use our
 link:https://github.com/spring-cloud/spring-cloud-gcp/issues[GitHub issue tracker] and let us know!
@@ -41,156 +42,3 @@ dependencies and instead delegate versioning to the BOM.
     </dependencies>
 </dependencyManagement>
 ----
-
-== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-pubsub[Spring Cloud GCP Pub/Sub]
-
-Provides a simplified abstraction to interact with Google Cloud Pub/Sub. Using this abstraction
-allows user code to be independent from the underlying Google Cloud Pub/Sub API semantics. It's
-currently possible to publish messages to a Google Cloud Pub/Sub topic and to create new topics and
-subscriptions.
-
-You can refer to the `PubSubTemplate` and `PubSubAdmin` classes for more details on the
-functionality provided by this module.
-
-== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-storage[Spring Resource Abstraction for Google Cloud Storage]
-
-Enables the Spring Resource abstraction to run on Google Cloud Storage.
-
-You can use the `@Value` annotation
-
-[source,java]
-----
-@Value("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]")
-private Resource gcsResource;
-----
-
-or the Spring application context
-
-[source,java]
-----
-SpringApplication.run(...).getResource("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]");
-----
-
-You can also use this resource to write to a Google Cloud Storage object:
-
-[source,java]
-----
-try (OutputStream os = ((WritableResource) gcsResource).getOutputStream()) {
-  os.write("foo".getBytes());
-}
-----
-
-== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-integration-gcp[Spring Integration Channel Adapters for Google Cloud Pub/Sub]
-
-Provides adapters for Spring Messaging channels to exchange messages via Google Cloud Pub/Sub. Makes
-extensive usage of the constructs provided by the Spring Cloud GCP Pub/Sub module, like
-`PubSubTemplate`.
-
-Refer to this https://spring.io/guides/gs/spring-cloud-gcp/[Spring getting started guide] to learn
-how to use the adapters.
-
-== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core[Google Cloud Core Spring Boot Starter]
-
-This starter creates and configures two important configuration sources: `CredentialsProvider` and
-`GcpProjectIdProvider`.
-
-It tries to read configuration from the application properties. For example, using a properties
-file:
-
-[source,yaml]
-----
-spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
-spring.cloud.gcp.credentials-location=file:[LOCAL_PRIVATE_KEY_FILE]
-----
-
-If `spring.cloud.gcp.project-id` is populated, the provided `GcpProjectIdProvider` returns that
-project ID. Otherwise, it uses google-cloud-java's
-http://googlecloudplatform.github.io/google-cloud-java/0.21.1/apidocs/com/google/cloud/ServiceOptions.html#getDefaultProjectId--[rules to discover the project ID].
-
-Similarly for `spring.cloud.gcp.credentials-location`, if a property is configured, the provided
-`CredentialsProvider` returns credentials for that private key. The value of
-`spring.cloud.gcp.credentials-location` is a Spring Resource, so you can specify
-https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html#resources-implementations[file system paths, HTTP URLs, etc.]
-If no property is configured, the provided `CredentialsProvider` returns the
-http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
-
-== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql[Google Cloud SQL Spring Boot Starter]
-
-This starter provides a couple of configuration sources: `CloudSqlJdbcInfoProvider` and
-`DataSource`.
-
-`CloudSqlJdbcInfoProvider` returns the JDBC information to be used, such as the JDBC driver name
-and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on
-Google App Engine.
-
-Besides `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`,
-`CloudSqlJdbcInfoProvider` requires the following properties:
-
-[source,yaml]
-----
-spring.cloud.gcp.sql.instance-name=[YOUR_CLOUD_SQL_INSTANCE_NAME]
-spring.cloud.gcp.sql.database-name=[YOUR_CLOUD_SQL_DATABASE_NAME]
-----
-
-The following properties are optional:
-
-[source,yaml]
-----
-spring.cloud.gcp.sql.region=[YOUR_CLOUD_SQL_INSTANCE_REGION]
-spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
-spring.cloud.gcp.sql.user-name=[YOUR_CLOUD_SQL_USERNAME]
-spring.cloud.gcp.sql.password=[YOUR_CLOUD_SQL_PASSWORD]
-----
-
-If `spring.cloud.gcp.sql.region` isn't specified, the starter will use the
-https://cloud.google.com/sql/docs/mysql/admin-api/[Cloud SQL API] to auto-discover the instance
-region.
-
-If `spring.cloud.gcp.sql.instance-connection-name` is specified, it is used as the final instance
-connection name and `spring.cloud.gcp.sql.region` and `spring.cloud.gcp.sql.instance-name` are
-not used.
-
-If `spring.cloud.gcp.sql.user-name` isn't specified, `"root"` is used by default.
-
-If `spring.cloud.gcp.sql.password` isn't specified, an empty string is used by default.
-
-By using this starter in conjunction with
-https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC],
-it's possible to inject a fully configured `JdbcTemplate` object only from adding the required
-properties.
-
-Due to https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/41[an issue] in
-the Cloud SQL Socket Factory for JDBC drivers, the credentials used to connect to Cloud SQL are not
-the ones from the provided `CredentialsProvider`, but the
-http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials]
-instead. However, region auto-discovery uses the credentials provided by `CredentialsProvider`.
-
-The returned `DataSource` is an implementation of
-https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use another kind of
-`DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
-`DataSource` bean.
-
-== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub[Google Cloud Pub/Sub Spring Boot Starter]
-
-This starter provides Pub/Sub key classes `PubSubTemplate` and `PubSubAdmin`.
-
-It requires the `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`
-properties.
-
-The following properties are optional:
-[source,yaml]
-----
-spring.cloud.gcp.pubsub.subscriber.executorThreads=[SUBSCRIBER_EXECUTOR_THREADS]
-spring.cloud.gcp.pubsub.publisher.executorThreads=[PUBLISHER_EXECUTOR_THREADS]
-----
-
-`spring.cloud.gcp.pubsub.subscriber.executorThreads` is the number of threads used by the subscriber
-executor. Likewise, `spring.cloud.gcp.pubsub.publisher.executorThreads` is the number of threads
-used by the publisher executor. The default value for both of these properties is 4.
-
-== https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage[Google Cloud Storage Spring Boot Starter]
-
-This starter provides the underpinnings of the Spring Cloud GCP Storage. It doesn't provide any
-bean to be used by an end-user.
-
-It requires the `spring.cloud.gcp.credentials-location` property.

--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,7 @@ Google Cloud Platform. The project website is http://cloud.spring.io/spring-clou
 development).
 
 Currently, this repository provides support for:
+
 * Spring Cloud GCP Pub/Sub
 * Spring Resource Abstraction for Google Cloud Storage
 * Spring Integration Channel Adapters for Google Cloud Pub/Sub

--- a/spring-cloud-gcp-pubsub/README.adoc
+++ b/spring-cloud-gcp-pubsub/README.adoc
@@ -1,0 +1,17 @@
+= Spring Cloud GCP Pub/Sub
+
+Maven coordinates, using Spring Cloud GCP BOM:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-pubsub</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub', version: '1.0.0.BUILD-SNAPSHOT'
+}

--- a/spring-cloud-gcp-pubsub/README.adoc
+++ b/spring-cloud-gcp-pubsub/README.adoc
@@ -12,6 +12,9 @@ Maven coordinates, using Spring Cloud GCP BOM:
 
 Gradle coordinates:
 
+[source]
+----
 dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub', version: '1.0.0.BUILD-SNAPSHOT'
 }
+----

--- a/spring-cloud-gcp-pubsub/README.adoc
+++ b/spring-cloud-gcp-pubsub/README.adoc
@@ -18,3 +18,12 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub', version: '1.0.0.BUILD-SNAPSHOT'
 }
 ----
+
+
+Provides a simplified abstraction to interact with Google Cloud Pub/Sub. Using this abstraction
+allows user code to be independent from the underlying Google Cloud Pub/Sub API semantics. It's
+currently possible to publish messages to a Google Cloud Pub/Sub topic and to create new topics and
+subscriptions.
+
+You can refer to the `PubSubTemplate` and `PubSubAdmin` classes for more details on the
+functionality provided by this module.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -12,6 +12,10 @@ Maven coordinates, using Spring Cloud GCP BOM:
 
 Gradle coordinates:
 
+
+[source]
+----
 dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-core', version: '1.0.0.BUILD-SNAPSHOT'
 }
+----

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -1,0 +1,17 @@
+= Google Cloud Core Spring Boot Starter
+
+Maven coordinates, using Spring Cloud GCP BOM:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-core</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-core', version: '1.0.0.BUILD-SNAPSHOT'
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -19,3 +19,28 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-core', version: '1.0.0.BUILD-SNAPSHOT'
 }
 ----
+
+
+This starter creates and configures two important configuration sources: `CredentialsProvider` and
+`GcpProjectIdProvider`.
+
+It tries to read configuration from the application properties. For example, using a properties
+file:
+
+[source,yaml]
+----
+spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
+spring.cloud.gcp.credentials-location=file:[LOCAL_PRIVATE_KEY_FILE]
+----
+
+If `spring.cloud.gcp.project-id` is populated, the provided `GcpProjectIdProvider` returns that
+project ID. Otherwise, it uses google-cloud-java's
+http://googlecloudplatform.github.io/google-cloud-java/0.21.1/apidocs/com/google/cloud/ServiceOptions.html#getDefaultProjectId--[rules to discover the project ID].
+
+Similarly for `spring.cloud.gcp.credentials-location`, if a property is configured, the provided
+`CredentialsProvider` returns credentials for that private key. The value of
+`spring.cloud.gcp.credentials-location` is a Spring Resource, so you can specify
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html#resources-implementations[file system paths, HTTP URLs, etc.]
+If no property is configured, the provided `CredentialsProvider` returns the
+http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
+

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -43,4 +43,3 @@ Similarly for `spring.cloud.gcp.credentials-location`, if a property is configur
 https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html#resources-implementations[file system paths, HTTP URLs, etc.]
 If no property is configured, the provided `CredentialsProvider` returns the
 http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
-

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
@@ -21,56 +21,18 @@ dependencies {
 ----
 
 
-This starter provides a couple of configuration sources: `CloudSqlJdbcInfoProvider` and
-`DataSource`.
+This starter provides Pub/Sub key classes `PubSubTemplate` and `PubSubAdmin`.
 
-`CloudSqlJdbcInfoProvider` returns the JDBC information to be used, such as the JDBC driver name
-and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on
-Google App Engine.
-
-Besides `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`,
-`CloudSqlJdbcInfoProvider` requires the following properties:
-
-[source,yaml]
-----
-spring.cloud.gcp.sql.instance-name=[YOUR_CLOUD_SQL_INSTANCE_NAME]
-spring.cloud.gcp.sql.database-name=[YOUR_CLOUD_SQL_DATABASE_NAME]
-----
-
-The following properties are optional:
-
-[source,yaml]
-----
-spring.cloud.gcp.sql.region=[YOUR_CLOUD_SQL_INSTANCE_REGION]
-spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
-spring.cloud.gcp.sql.user-name=[YOUR_CLOUD_SQL_USERNAME]
-spring.cloud.gcp.sql.password=[YOUR_CLOUD_SQL_PASSWORD]
-----
-
-If `spring.cloud.gcp.sql.region` isn't specified, the starter will use the
-https://cloud.google.com/sql/docs/mysql/admin-api/[Cloud SQL API] to auto-discover the instance
-region.
-
-If `spring.cloud.gcp.sql.instance-connection-name` is specified, it is used as the final instance
-connection name and `spring.cloud.gcp.sql.region` and `spring.cloud.gcp.sql.instance-name` are
-not used.
-
-If `spring.cloud.gcp.sql.user-name` isn't specified, `"root"` is used by default.
-
-If `spring.cloud.gcp.sql.password` isn't specified, an empty string is used by default.
-
-By using this starter in conjunction with
-https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC],
-it's possible to inject a fully configured `JdbcTemplate` object only from adding the required
+It requires the `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`
 properties.
 
-Due to https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/41[an issue] in
-the Cloud SQL Socket Factory for JDBC drivers, the credentials used to connect to Cloud SQL are not
-the ones from the provided `CredentialsProvider`, but the
-http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials]
-instead. However, region auto-discovery uses the credentials provided by `CredentialsProvider`.
+The following properties are optional:
+[source,yaml]
+----
+spring.cloud.gcp.pubsub.subscriber.executorThreads=[SUBSCRIBER_EXECUTOR_THREADS]
+spring.cloud.gcp.pubsub.publisher.executorThreads=[PUBLISHER_EXECUTOR_THREADS]
+----
 
-The returned `DataSource` is an implementation of
-https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use another kind of
-`DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
-`DataSource` bean.
+`spring.cloud.gcp.pubsub.subscriber.executorThreads` is the number of threads used by the subscriber
+executor. Likewise, `spring.cloud.gcp.pubsub.publisher.executorThreads` is the number of threads
+used by the publisher executor. The default value for both of these properties is 4.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
@@ -12,6 +12,10 @@ Maven coordinates, using Spring Cloud GCP BOM:
 
 Gradle coordinates:
 
+
+[source]
+----
 dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub', version: '1.0.0.BUILD-SNAPSHOT'
 }
+----

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
@@ -19,3 +19,58 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub', version: '1.0.0.BUILD-SNAPSHOT'
 }
 ----
+
+
+This starter provides a couple of configuration sources: `CloudSqlJdbcInfoProvider` and
+`DataSource`.
+
+`CloudSqlJdbcInfoProvider` returns the JDBC information to be used, such as the JDBC driver name
+and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on
+Google App Engine.
+
+Besides `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`,
+`CloudSqlJdbcInfoProvider` requires the following properties:
+
+[source,yaml]
+----
+spring.cloud.gcp.sql.instance-name=[YOUR_CLOUD_SQL_INSTANCE_NAME]
+spring.cloud.gcp.sql.database-name=[YOUR_CLOUD_SQL_DATABASE_NAME]
+----
+
+The following properties are optional:
+
+[source,yaml]
+----
+spring.cloud.gcp.sql.region=[YOUR_CLOUD_SQL_INSTANCE_REGION]
+spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
+spring.cloud.gcp.sql.user-name=[YOUR_CLOUD_SQL_USERNAME]
+spring.cloud.gcp.sql.password=[YOUR_CLOUD_SQL_PASSWORD]
+----
+
+If `spring.cloud.gcp.sql.region` isn't specified, the starter will use the
+https://cloud.google.com/sql/docs/mysql/admin-api/[Cloud SQL API] to auto-discover the instance
+region.
+
+If `spring.cloud.gcp.sql.instance-connection-name` is specified, it is used as the final instance
+connection name and `spring.cloud.gcp.sql.region` and `spring.cloud.gcp.sql.instance-name` are
+not used.
+
+If `spring.cloud.gcp.sql.user-name` isn't specified, `"root"` is used by default.
+
+If `spring.cloud.gcp.sql.password` isn't specified, an empty string is used by default.
+
+By using this starter in conjunction with
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC],
+it's possible to inject a fully configured `JdbcTemplate` object only from adding the required
+properties.
+
+Due to https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/41[an issue] in
+the Cloud SQL Socket Factory for JDBC drivers, the credentials used to connect to Cloud SQL are not
+the ones from the provided `CredentialsProvider`, but the
+http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials]
+instead. However, region auto-discovery uses the credentials provided by `CredentialsProvider`.
+
+The returned `DataSource` is an implementation of
+https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use another kind of
+`DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
+`DataSource` bean.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
@@ -1,0 +1,17 @@
+= Google Cloud Pub/Sub Spring Boot Starter
+
+Maven coordinates, using Spring Cloud GCP BOM:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub', version: '1.0.0.BUILD-SNAPSHOT'
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -1,0 +1,17 @@
+= Google Cloud SQL Spring Boot Starter
+
+Maven coordinates, using Spring Cloud GCP BOM:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-sql</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-sql', version: '1.0.0.BUILD-SNAPSHOT'
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -12,6 +12,9 @@ Maven coordinates, using Spring Cloud GCP BOM:
 
 Gradle coordinates:
 
+[source]
+----
 dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-sql', version: '1.0.0.BUILD-SNAPSHOT'
 }
+----

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -18,3 +18,20 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-sql', version: '1.0.0.BUILD-SNAPSHOT'
 }
 ----
+
+
+This starter provides Pub/Sub key classes `PubSubTemplate` and `PubSubAdmin`.
+
+It requires the `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`
+properties.
+
+The following properties are optional:
+[source,yaml]
+----
+spring.cloud.gcp.pubsub.subscriber.executorThreads=[SUBSCRIBER_EXECUTOR_THREADS]
+spring.cloud.gcp.pubsub.publisher.executorThreads=[PUBLISHER_EXECUTOR_THREADS]
+----
+
+`spring.cloud.gcp.pubsub.subscriber.executorThreads` is the number of threads used by the subscriber
+executor. Likewise, `spring.cloud.gcp.pubsub.publisher.executorThreads` is the number of threads
+used by the publisher executor. The default value for both of these properties is 4.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -20,8 +20,7 @@ dependencies {
 ----
 
 
-This starter provides a couple of configuration sources: `CloudSqlJdbcInfoProvider` and
-`DataSource`.
+This starter provides the configuration sources: `CloudSqlJdbcInfoProvider` and `DataSource`.
 
 `CloudSqlJdbcInfoProvider` returns the JDBC information to be used, such as the JDBC driver name
 and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -20,18 +20,56 @@ dependencies {
 ----
 
 
-This starter provides Pub/Sub key classes `PubSubTemplate` and `PubSubAdmin`.
+This starter provides a couple of configuration sources: `CloudSqlJdbcInfoProvider` and
+`DataSource`.
 
-It requires the `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`
-properties.
+`CloudSqlJdbcInfoProvider` returns the JDBC information to be used, such as the JDBC driver name
+and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on
+Google App Engine.
 
-The following properties are optional:
+Besides `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`,
+`CloudSqlJdbcInfoProvider` requires the following properties:
+
 [source,yaml]
 ----
-spring.cloud.gcp.pubsub.subscriber.executorThreads=[SUBSCRIBER_EXECUTOR_THREADS]
-spring.cloud.gcp.pubsub.publisher.executorThreads=[PUBLISHER_EXECUTOR_THREADS]
+spring.cloud.gcp.sql.instance-name=[YOUR_CLOUD_SQL_INSTANCE_NAME]
+spring.cloud.gcp.sql.database-name=[YOUR_CLOUD_SQL_DATABASE_NAME]
 ----
 
-`spring.cloud.gcp.pubsub.subscriber.executorThreads` is the number of threads used by the subscriber
-executor. Likewise, `spring.cloud.gcp.pubsub.publisher.executorThreads` is the number of threads
-used by the publisher executor. The default value for both of these properties is 4.
+The following properties are optional:
+
+[source,yaml]
+----
+spring.cloud.gcp.sql.region=[YOUR_CLOUD_SQL_INSTANCE_REGION]
+spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
+spring.cloud.gcp.sql.user-name=[YOUR_CLOUD_SQL_USERNAME]
+spring.cloud.gcp.sql.password=[YOUR_CLOUD_SQL_PASSWORD]
+----
+
+If `spring.cloud.gcp.sql.region` isn't specified, the starter will use the
+https://cloud.google.com/sql/docs/mysql/admin-api/[Cloud SQL API] to auto-discover the instance
+region.
+
+If `spring.cloud.gcp.sql.instance-connection-name` is specified, it is used as the final instance
+connection name and `spring.cloud.gcp.sql.region` and `spring.cloud.gcp.sql.instance-name` are
+not used.
+
+If `spring.cloud.gcp.sql.user-name` isn't specified, `"root"` is used by default.
+
+If `spring.cloud.gcp.sql.password` isn't specified, an empty string is used by default.
+
+By using this starter in conjunction with
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC],
+it's possible to inject a fully configured `JdbcTemplate` object only from adding the required
+properties.
+
+Due to https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/41[an issue] in
+the Cloud SQL Socket Factory for JDBC drivers, the credentials used to connect to Cloud SQL are not
+the ones from the provided `CredentialsProvider`, but the
+http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials]
+instead. However, region auto-discovery uses the credentials provided by `CredentialsProvider`.
+
+The returned `DataSource` is an implementation of
+https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use another kind of
+`DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
+`DataSource` bean.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
@@ -12,6 +12,9 @@ Maven coordinates, using Spring Cloud GCP BOM:
 
 Gradle coordinates:
 
+[source]
+----
 dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage', version: '1.0.0.BUILD-SNAPSHOT'
 }
+----

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
@@ -1,0 +1,17 @@
+= Google Cloud Storage Spring Boot Starter
+
+Maven coordinates, using Spring Cloud GCP BOM:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-storage</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage', version: '1.0.0.BUILD-SNAPSHOT'
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
@@ -18,3 +18,9 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage', version: '1.0.0.BUILD-SNAPSHOT'
 }
 ----
+
+
+This starter provides the underpinnings of the Spring Cloud GCP Storage. It doesn't provide any
+bean to be used by an end-user.
+
+It requires the `spring.cloud.gcp.credentials-location` property.

--- a/spring-cloud-gcp-storage/README.adoc
+++ b/spring-cloud-gcp-storage/README.adoc
@@ -1,0 +1,17 @@
+= Spring Resource Abstraction for Google Cloud Storage
+
+Maven coordinates, using Spring Cloud GCP BOM:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-storage</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage', version: '1.0.0.BUILD-SNAPSHOT'
+}

--- a/spring-cloud-gcp-storage/README.adoc
+++ b/spring-cloud-gcp-storage/README.adoc
@@ -12,6 +12,9 @@ Maven coordinates, using Spring Cloud GCP BOM:
 
 Gradle coordinates:
 
+[source]
+----
 dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage', version: '1.0.0.BUILD-SNAPSHOT'
 }
+----

--- a/spring-cloud-gcp-storage/README.adoc
+++ b/spring-cloud-gcp-storage/README.adoc
@@ -18,3 +18,30 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage', version: '1.0.0.BUILD-SNAPSHOT'
 }
 ----
+
+
+Enables the Spring Resource abstraction to run on Google Cloud Storage.
+
+You can use the `@Value` annotation
+
+[source,java]
+----
+@Value("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]")
+private Resource gcsResource;
+----
+
+or the Spring application context
+
+[source,java]
+----
+SpringApplication.run(...).getResource("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]");
+----
+
+You can also use this resource to write to a Google Cloud Storage object:
+
+[source,java]
+----
+try (OutputStream os = ((WritableResource) gcsResource).getOutputStream()) {
+  os.write("foo".getBytes());
+}
+----

--- a/spring-integration-gcp/README.adoc
+++ b/spring-integration-gcp/README.adoc
@@ -21,8 +21,8 @@ dependencies {
 
 
 Provides adapters for Spring Messaging channels to exchange messages via Google Cloud Pub/Sub. Makes
-extensive usage of the constructs provided by the Spring Cloud GCP Pub/Sub module, like
+extensive use of the constructs provided by the Spring Cloud GCP Pub/Sub module, like
 `PubSubTemplate`.
 
-Refer to this https://spring.io/guides/gs/spring-cloud-gcp/[Spring getting started guide] to learn
+Refer to the https://spring.io/guides/gs/spring-cloud-gcp/[Spring getting started guide] to learn
 how to use the adapters.

--- a/spring-integration-gcp/README.adoc
+++ b/spring-integration-gcp/README.adoc
@@ -12,6 +12,9 @@ Maven coordinates, using Spring Cloud GCP BOM:
 
 Gradle coordinates:
 
+[source]
+----
 dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-integration-gcp', version: '1.0.0.BUILD-SNAPSHOT'
 }
+----

--- a/spring-integration-gcp/README.adoc
+++ b/spring-integration-gcp/README.adoc
@@ -1,0 +1,17 @@
+= Spring Integration Channel Adapters for Google Cloud Pub/Sub
+
+Maven coordinates, using Spring Cloud GCP BOM:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-integration-gcp</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-integration-gcp', version: '1.0.0.BUILD-SNAPSHOT'
+}

--- a/spring-integration-gcp/README.adoc
+++ b/spring-integration-gcp/README.adoc
@@ -18,3 +18,11 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-integration-gcp', version: '1.0.0.BUILD-SNAPSHOT'
 }
 ----
+
+
+Provides adapters for Spring Messaging channels to exchange messages via Google Cloud Pub/Sub. Makes
+extensive usage of the constructs provided by the Spring Cloud GCP Pub/Sub module, like
+`PubSubTemplate`.
+
+Refer to this https://spring.io/guides/gs/spring-cloud-gcp/[Spring getting started guide] to learn
+how to use the adapters.


### PR DESCRIPTION
Things like property names aren't configured anywhere yet. This is one
step while we don't have a reference document with more comprehensive
documentation.

Fixes #100