### PR TITLE
Adds storage scopes

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
@@ -53,7 +53,14 @@ public class GcpContextAutoConfiguration {
 	private static final String SQLADMIN_SCOPE =
 			"https://www.googleapis.com/auth/sqlservice.admin";
 
-	private static final List<String> SCOPES_LIST = ImmutableList.of(PUBSUB_SCOPE, SQLADMIN_SCOPE);
+	private static final String STORAGE_READ_SCOPE =
+			"https://www.googleapis.com/auth/devstorage.read_only";
+
+	private static final String STORAGE_WRITE_SCOPE =
+			"https://www.googleapis.com/auth/devstorage.read_write";
+
+	private static final List<String> SCOPES_LIST = ImmutableList.of(PUBSUB_SCOPE, SQLADMIN_SCOPE,
+			STORAGE_READ_SCOPE, STORAGE_WRITE_SCOPE);
 
 	@Autowired
 	private GcpProperties gcpProperties;


### PR DESCRIPTION
Using service account credentials, calls to GCS will fail due to the
lack of scopes. Curiously enough, using the CredentialsProvider from
GoogleCredentialsProvider doesn't fail due to lack of the scope..