### PR TITLE
Passes user credentials to Cloud SQL

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -88,7 +88,7 @@
 			<dependency>
 				<groupId>com.google.cloud.sql</groupId>
 				<artifactId>mysql-socket-factory</artifactId>
-				<version>1.0.3</version>
+				<version>1.0.4</version>
 			</dependency>
 
 			<!--Starters-->

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
@@ -66,8 +66,8 @@ public class GcpContextAutoConfiguration {
 	private static final String STORAGE_WRITE_SCOPE =
 			"https://www.googleapis.com/auth/devstorage.read_write";
 
-	private static final List<String> SCOPES_LIST = ImmutableList.of(PUBSUB_SCOPE, SQLADMIN_SCOPE,
-			STORAGE_READ_SCOPE, STORAGE_WRITE_SCOPE);
+	public static final List<String> CREDENTIALS_SCOPES_LIST =
+			ImmutableList.of(PUBSUB_SCOPE, SQLADMIN_SCOPE, STORAGE_READ_SCOPE, STORAGE_WRITE_SCOPE);
 
 	private static final Log LOGGER = LogFactory.getLog(GcpContextAutoConfiguration.class);
 
@@ -83,11 +83,11 @@ public class GcpContextAutoConfiguration {
 			credentialsProvider = FixedCredentialsProvider
 					.create(GoogleCredentials.fromStream(
 							this.gcpProperties.getCredentialsLocation().getInputStream())
-					.createScoped(SCOPES_LIST));
+					.createScoped(CREDENTIALS_SCOPES_LIST));
 		}
 		else {
 			credentialsProvider = GoogleCredentialsProvider.newBuilder()
-					.setScopesToApply(SCOPES_LIST)
+					.setScopesToApply(CREDENTIALS_SCOPES_LIST)
 					.build();
 		}
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.sql;
 
+import java.nio.file.Path;
+
 import org.hibernate.validator.constraints.NotEmpty;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -45,6 +47,8 @@ public class GcpCloudSqlProperties {
 	private String password = "";
 
 	private boolean initFailFast;
+
+	private Path credentialsLocation;
 
 	public String getInstanceName() {
 		return this.instanceName;
@@ -94,11 +98,19 @@ public class GcpCloudSqlProperties {
 		this.password = password;
 	}
 
-	public boolean getInitFailFast() {
+	public boolean isInitFailFast() {
 		return this.initFailFast;
 	}
 
 	public void setInitFailFast(boolean initFailFast) {
 		this.initFailFast = initFailFast;
+	}
+
+	public Path getCredentialsLocation() {
+		return this.credentialsLocation;
+	}
+
+	public void setCredentialsLocation(Path credentialsLocation) {
+		this.credentialsLocation = credentialsLocation;
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2017 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.sql;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.cloud.sql.CredentialFactory;
+
+import org.springframework.cloud.gcp.core.autoconfig.GcpContextAutoConfiguration;
+
+/**
+ * Returns the credentials that are written to a system property by the Cloud SQL starter.
+ *
+ * <p>
+ * Since the sockets factory creates an instance of this class by reflection and without any
+ * arguments, the credential location must be in a place that this class knows without any context.
+ *
+ * @author João André Martins
+ */
+public class SqlCredentialFactory implements CredentialFactory {
+
+	public static final String CREDENTIAL_LOCATION_PROPERTY_NAME =
+			"GOOGLE_CLOUD_SQL_CREDS_LOCATION";
+
+	@Override
+	public Credential create() {
+		// TODO(joaomartins): Consider supporting Spring Resources as credential locations. There
+		// would need to be a way to create or inject a Spring context here statically, to load
+		// the resource from there.
+		String credentialResourceLocation = System.getProperty(CREDENTIAL_LOCATION_PROPERTY_NAME);
+		if (credentialResourceLocation == null) {
+			return null;
+		}
+
+		try {
+			return GoogleCredential.fromStream(new FileInputStream(credentialResourceLocation))
+					.createScoped(GcpContextAutoConfiguration.CREDENTIALS_SCOPES_LIST);
+		}
+		catch (IOException e) {
+			return null;
+		}
+	}
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/DefaultCloudSqlJdbcInfoProvider.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/DefaultCloudSqlJdbcInfoProvider.java
@@ -78,9 +78,6 @@ public class DefaultCloudSqlJdbcInfoProvider implements CloudSqlJdbcInfoProvider
 
 	@Override
 	public String getJdbcUrl() {
-		// TODO(joaomartins): Set the credential factory to be used by SocketFactory when
-		// https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/41 is
-		// resolved. For now, it uses application default creds.
 		return String.format("jdbc:mysql://google/%s?cloudSqlInstance=%s&"
 				+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory",
 				this.properties.getDatabaseName(),


### PR DESCRIPTION
Currently, Cloud SQL uses application default credentials. They just
implemented a fix on their end to allow external credentials to be
provided.

Fixes #104