### PR TITLE
Makes instanceName not mandatory

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
@@ -30,7 +30,6 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class GcpCloudSqlProperties {
 
-	@NotEmpty
 	private String instanceName;
 
 	@NotEmpty

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/DefaultCloudSqlJdbcInfoProvider.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/DefaultCloudSqlJdbcInfoProvider.java
@@ -46,7 +46,7 @@ public class DefaultCloudSqlJdbcInfoProvider implements CloudSqlJdbcInfoProvider
 		Assert.hasText(projectId,
 				"A project ID must be provided.");
 
-	if (StringUtils.isEmpty(properties.getInstanceConnectionName())) {
+		if (StringUtils.isEmpty(properties.getInstanceConnectionName())) {
 			Assert.hasText(this.properties.getInstanceName(),
 					"Instance Name is required, or specify Instance Connection Name explicitly");
 			if (StringUtils.isEmpty(properties.getRegion())) {

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfigurationMockTests.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfigurationMockTests.java
@@ -40,7 +40,6 @@ import static org.junit.Assert.assertEquals;
 @SpringBootTest(classes = { GcpCloudSqlAutoConfiguration.class, GcpContextAutoConfiguration.class,
 		GcpCloudSqlTestConfiguration.class
 }, properties = { "spring.cloud.gcp.projectId=proj",
-		"spring.cloud.gcp.sql.instanceName=test-instance",
 		"spring.cloud.gcp.sql.databaseName=test-database",
 		"spring.cloud.gcp.sql.initFailFast=false"
 })
@@ -54,6 +53,9 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 
 	public abstract void test();
 
+	@TestPropertySource(properties = {
+			"spring.cloud.gcp.sql.instanceName=test-instance"
+	})
 	public static class CloudSqlJdbcInfoProviderTest extends GcpCloudSqlAutoConfigurationMockTests {
 		@Test
 		@Override
@@ -64,6 +66,9 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		}
 	}
 
+	@TestPropertySource(properties = {
+			"spring.cloud.gcp.sql.instanceName=test-instance"
+	})
 	public static class CloudSqlDataSourceTest extends GcpCloudSqlAutoConfigurationMockTests {
 		@Test
 		@Override
@@ -78,7 +83,9 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		}
 	}
 
-	@TestPropertySource(properties = { "spring.cloud.gcp.sql.region=australia" })
+	@TestPropertySource(properties = {
+			"spring.cloud.gcp.sql.region=australia",
+			"spring.cloud.gcp.sql.instanceName=test-instance"})
 	public static class CloudSqlAppEngineDataSourceTest extends GcpCloudSqlAutoConfigurationMockTests {
 		@BeforeClass
 		public static void setUp() {
@@ -102,7 +109,9 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		}
 	}
 
-	@TestPropertySource(properties = { "spring.cloud.gcp.sql.region=siberia" })
+	@TestPropertySource(properties = {
+			"spring.cloud.gcp.sql.region=siberia",
+			"spring.cloud.gcp.sql.instanceName=test-instance"})
 	public static class GcpCloudSqlAutoConfigurationWithRegionTest
 			extends GcpCloudSqlAutoConfigurationMockTests {
 		@Test
@@ -120,7 +129,8 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 
 	@TestPropertySource(properties = {
 			"spring.cloud.gcp.sql.userName=watchmaker",
-			"spring.cloud.gcp.sql.password=pass"
+			"spring.cloud.gcp.sql.password=pass",
+			"spring.cloud.gcp.sql.instanceName=test-instance"
 	})
 	public static class GcpCloudSqlAutoConfigurationWithUserAndPassTest
 			extends GcpCloudSqlAutoConfigurationMockTests {
@@ -133,6 +143,20 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 					this.urlProvider.getJdbcUrl());
 			assertEquals("watchmaker", dataSource.getUsername());
 			assertEquals("pass", dataSource.getPassword());
+		}
+	}
+
+	@TestPropertySource(properties = {
+			"spring.cloud.gcp.sql.instanceConnectionName=world:asia:japan"
+	})
+	public static class GcpCloudSqlAutoConfigurationWithInstanceConnectionNameTest
+			extends GcpCloudSqlAutoConfigurationMockTests {
+		@Test
+		@Override
+		public void test() {
+			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=world:asia:japan"
+							+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory",
+					this.urlProvider.getJdbcUrl());
 		}
 	}
 }


### PR DESCRIPTION
Users might provide instanceConnectionName instead. If none is provided,
IllegalArgumentException arises.

Fixes #109