### PR TITLE
Allows the JDBC URL and driver to be specified in the SQL properties

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -41,6 +41,8 @@ The following properties are optional:
 ----
 spring.cloud.gcp.sql.region=[YOUR_CLOUD_SQL_INSTANCE_REGION]
 spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
+spring.cloud.gcp.sql.jdbc-url=[YOUR_JDBC_URL]
+spring.cloud.gcp.sql.jdbc-driver=[YOUR_JDBC_DRIVER]
 spring.cloud.gcp.sql.user-name=[YOUR_CLOUD_SQL_USERNAME]
 spring.cloud.gcp.sql.password=[YOUR_CLOUD_SQL_PASSWORD]
 ----
@@ -50,10 +52,17 @@ https://cloud.google.com/sql/docs/mysql/admin-api/[Cloud SQL API] to auto-discov
 region.
 
 If `spring.cloud.gcp.sql.instance-connection-name` is specified, it is used as the final instance
-connection name and `spring.cloud.gcp.sql.region` and `spring.cloud.gcp.sql.instance-name` are
-not used.
+connection name and has precedence over `spring.cloud.gcp.sql.region` and
+`spring.cloud.gcp.sql.instance-name`.
 
-If `spring.cloud.gcp.sql.user-name` isn't specified, `"root"` is used by default.
+If `spring.cloud.gcp.sql.jdbc-url` is specified, it is used as the final JDBC URL and has precedence
+over `spring.cloud.gcp.sql.instance-connection-name`, `spring.cloud.gcp.sql.region` and
+`spring.cloud.gcp.sql.instance-name`.
+
+If `spring.cloud.gcp.sql.jdbc-driver` isn't specified, `com.mysql.jdbc.Driver` is used by default,
+or `com.mysql.jdbc.GoogleDriver` if running on Google App Engine.
+
+If `spring.cloud.gcp.sql.user-name` isn't specified, `root` is used by default.
 
 If `spring.cloud.gcp.sql.password` isn't specified, an empty string is used by default.
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
@@ -39,6 +39,10 @@ public class GcpCloudSqlProperties {
 
 	private String instanceConnectionName;
 
+	private String jdbcUrl;
+
+	private String jdbcDriver = "com.mysql.jdbc.Driver";
+
 	private String userName = "root";
 
 	private String password = "";
@@ -75,6 +79,22 @@ public class GcpCloudSqlProperties {
 
 	public void setInstanceConnectionName(String instanceConnectionName) {
 		this.instanceConnectionName = instanceConnectionName;
+	}
+
+	public String getJdbcUrl() {
+		return this.jdbcUrl;
+	}
+
+	public void setJdbcUrl(String jdbcUrl) {
+		this.jdbcUrl = jdbcUrl;
+	}
+
+	public String getJdbcDriver() {
+		return this.jdbcDriver;
+	}
+
+	public void setJdbcDriver(String jdbcDriver) {
+		this.jdbcDriver = jdbcDriver;
 	}
 
 	public String getUserName() {

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/AppEngineCloudSqlJdbcInfoProvider.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/AppEngineCloudSqlJdbcInfoProvider.java
@@ -28,12 +28,10 @@ import org.springframework.util.StringUtils;
  * @author Ray Tsang
  */
 public class AppEngineCloudSqlJdbcInfoProvider implements CloudSqlJdbcInfoProvider {
-	private final String projectId;
 
 	private final GcpCloudSqlProperties properties;
 
 	public AppEngineCloudSqlJdbcInfoProvider(String projectId, GcpCloudSqlProperties properties) {
-		this.projectId = projectId;
 		this.properties = properties;
 		Assert.hasText(projectId,
 				"A project ID must be provided.");

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfigurationMockTests.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfigurationMockTests.java
@@ -63,6 +63,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=proj:reg:test-instance"
 					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory",
 					this.urlProvider.getJdbcUrl());
+			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
 		}
 	}
 
@@ -80,6 +81,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 					this.urlProvider.getJdbcUrl());
 			assertEquals("root", dataSource.getUsername());
 			assertEquals("", dataSource.getPassword());
+			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
 		}
 	}
 
@@ -101,6 +103,8 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		@Override
 		public void test() {
 			HikariDataSource dataSource = (HikariDataSource) this.dataSource;
+			assertEquals("com.mysql.jdbc.GoogleDriver",
+					this.urlProvider.getJdbcDriverClass());
 			assertEquals("com.mysql.jdbc.GoogleDriver", dataSource.getDriverClassName());
 			assertEquals("jdbc:google:mysql://proj:australia:test-instance/test-database",
 					this.urlProvider.getJdbcUrl());
@@ -124,6 +128,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 					this.urlProvider.getJdbcUrl());
 			assertEquals("root", dataSource.getUsername());
 			assertEquals("", dataSource.getPassword());
+			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
 		}
 	}
 
@@ -143,6 +148,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 					this.urlProvider.getJdbcUrl());
 			assertEquals("watchmaker", dataSource.getUsername());
 			assertEquals("pass", dataSource.getPassword());
+			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
 		}
 	}
 
@@ -157,6 +163,22 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=world:asia:japan"
 							+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory",
 					this.urlProvider.getJdbcUrl());
+			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
+		}
+	}
+
+	@TestPropertySource(properties = {
+			"spring.cloud.gcp.sql.jdbcUrl=turnItOut",
+			"spring.cloud.gcp.sql.jdbcDriver=romanticRights"
+	})
+	public static class GcpCloudSqlAutoConfigurationWithUrlAndDriver
+			extends GcpCloudSqlAutoConfigurationMockTests {
+
+		@Test
+		@Override
+		public void test() {
+			assertEquals("turnItOut", this.urlProvider.getJdbcUrl());
+			assertEquals("romanticRights", this.urlProvider.getJdbcDriverClass());
 		}
 	}
 }


### PR DESCRIPTION
Allows more flexibility to users in cases not contemplated by the
defaults.

Fixes #112