### PR TITLE
Scopes SQL credentials to Cloud SQL only

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
@@ -55,15 +55,15 @@ import org.springframework.util.StringUtils;
 @EnableConfigurationProperties(GcpProperties.class)
 public class GcpContextAutoConfiguration {
 
-	private static final String PUBSUB_SCOPE = "https://www.googleapis.com/auth/pubsub";
+	public static final String PUBSUB_SCOPE = "https://www.googleapis.com/auth/pubsub";
 
-	private static final String SQLADMIN_SCOPE =
+	public static final String SQLADMIN_SCOPE =
 			"https://www.googleapis.com/auth/sqlservice.admin";
 
-	private static final String STORAGE_READ_SCOPE =
+	public static final String STORAGE_READ_SCOPE =
 			"https://www.googleapis.com/auth/devstorage.read_only";
 
-	private static final String STORAGE_WRITE_SCOPE =
+	public static final String STORAGE_WRITE_SCOPE =
 			"https://www.googleapis.com/auth/devstorage.read_write";
 
 	public static final List<String> CREDENTIALS_SCOPES_LIST =

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -81,3 +81,24 @@ The returned `DataSource` is an implementation of
 https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use another kind of
 `DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
 `DataSource` bean.
+
+== Frequently Asked Questions
+
+=== I'm seeing a lot of log lines similar to "c.g.cloud.sql.core.SslSocketFactory : Re-throwing cached exception due to attempt to refresh instance information too soon after error." in a loop and I can't connect to my database
+
+This is usually a symptom that something isn't right with the permissions of your credentials. For
+example, your service account doesn't have the
+https://cloud.google.com/sql/docs/mysql/project-access-control#roles[necessary IAM roles].
+
+To find out what's causing the issue, you can enable DEBUG logging level at HikariCP by adding the
+following logback.xml file to your application's resources, or only add the relevant set log level
+line if you already have one logback.xml file:
+
+[source, xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="com.zaxxer.hikari.pool" level="DEBUG"/>
+</configuration>
+----

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.sql;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collections;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
@@ -59,7 +60,8 @@ public class SqlCredentialFactory implements CredentialFactory {
 
 		try {
 			return GoogleCredential.fromStream(new FileInputStream(credentialResourceLocation))
-					.createScoped(GcpContextAutoConfiguration.CREDENTIALS_SCOPES_LIST);
+					.createScoped(
+							Collections.singleton(GcpContextAutoConfiguration.SQLADMIN_SCOPE));
 		}
 		catch (IOException ioe) {
 			LOGGER.warn("There was an error loading Cloud SQL credential.", ioe);


### PR DESCRIPTION
The SslSocketFactory uses the SQL Admin API and requires this scope. The
rest of the scope should be narrowed down only to what is required.

Fixes #119