### PR TITLE
Allows default credential scopes to be parameterised

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,5 +63,5 @@ them for you. For details on how Spring Boot finds these properties, refer to th
 README.
 
 If your app is running on Google App Engine or Google Compute Engine, in most cases, you should omit
-the `spring.cloud.gcp.credentials-location` property and, instead, let the Spring Cloud GCP Core
+the `spring.cloud.gcp.credentials.location` property and, instead, let the Spring Cloud GCP Core
 Starter get the correct credentials for those environments.

--- a/README.adoc
+++ b/README.adoc
@@ -54,7 +54,8 @@ example, a properties file:
 [source, yaml]
 ----
 spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
-spring.cloud.gcp.credentials-location=file:[LOCAL_PRIVATE_KEY_FILE]
+spring.cloud.gcp.credentials.location=file:[LOCAL_PRIVATE_KEY_FILE]
+spring.cloud.gcp.credentials.scopes=[SCOPE_1],[SCOPE_2],[SCOPE_3]
 ----
 
 These properties are optional and, if not specified, Spring Boot will attempt to automatically find

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -30,16 +30,22 @@ file:
 [source,yaml]
 ----
 spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
-spring.cloud.gcp.credentials-location=file:[LOCAL_PRIVATE_KEY_FILE]
+spring.cloud.gcp.credentials.location=file:[LOCAL_PRIVATE_KEY_FILE]
+spring.cloud.gcp.credentials.scopes=[SCOPE_1],[SCOPE_2],[SCOPE_3]
 ----
 
 If `spring.cloud.gcp.project-id` is populated, the provided `GcpProjectIdProvider` returns that
 project ID. Otherwise, it uses google-cloud-java's
 http://googlecloudplatform.github.io/google-cloud-java/0.21.1/apidocs/com/google/cloud/ServiceOptions.html#getDefaultProjectId--[rules to discover the project ID].
 
-Similarly for `spring.cloud.gcp.credentials-location`, if a property is configured, the provided
+Similarly for `spring.cloud.gcp.credentials.location`, if a property is configured, the provided
 `CredentialsProvider` returns credentials for that private key. The value of
-`spring.cloud.gcp.credentials-location` is a Spring Resource, so you can specify
+`spring.cloud.gcp.credentials.location` is a Spring Resource, so you can specify
 https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html#resources-implementations[file system paths, HTTP URLs, etc.]
 If no property is configured, the provided `CredentialsProvider` returns the
 http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
+
+`spring.cloud.gcp.credentials.scopes` is a comma-delimited list of Google OAuth2 scopes for Google
+Cloud Platform services (e.g., `https://www.googleapis.com/auth/pubsub` for Google Cloud Pub/Sub)
+that the credentials returned by the provided `CredentialsProvider` support. If unspecified, list of
+default scopes for every service supported by this project is used.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -46,7 +46,7 @@ If no property is configured, the provided `CredentialsProvider` returns the
 http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
 
 If your app is running on Google App Engine or Google Compute Engine, in most cases, you should omit
-the `spring.cloud.gcp.credentials-location` property and, instead, let the Spring Cloud GCP Core
+the `spring.cloud.gcp.credentials.location` property and, instead, let the Spring Cloud GCP Core
 Starter get the correct credentials for those environments. On App Engine Standard, the
 https://cloud.google.com/appengine/docs/standard/java/appidentity/[App Identity service account credentials]
 are used, on App Engine Flexible, the

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
@@ -16,18 +16,21 @@
 
 package org.springframework.cloud.gcp.core;
 
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Vinicius Carvalho
+ * @author João André Martins
  */
 @ConfigurationProperties("spring.cloud.gcp")
 public class GcpProperties {
 
 	private String projectId;
 
-	private Resource credentialsLocation;
+	private Credentials credentials = new Credentials();
 
 	public String getProjectId() {
 		return this.projectId;
@@ -37,12 +40,32 @@ public class GcpProperties {
 		this.projectId = projectId;
 	}
 
-	public Resource getCredentialsLocation() {
-		return this.credentialsLocation;
+	public Credentials getCredentials() {
+		return this.credentials;
 	}
 
-	public void setCredentialsLocation(Resource credentialsLocation) {
-		this.credentialsLocation = credentialsLocation;
+	public void setCredentials(Credentials credentials) {
+		this.credentials = credentials;
 	}
 
+	public class Credentials {
+		private Resource location;
+		private List<String> scopes;
+
+		public Resource getLocation() {
+			return this.location;
+		}
+
+		public void setLocation(Resource location) {
+			this.location = location;
+		}
+
+		public List<String> getScopes() {
+			return this.scopes;
+		}
+
+		public void setScopes(List<String> scopes) {
+			this.scopes = scopes;
+		}
+	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
@@ -23,9 +23,6 @@ dependencies {
 
 This starter provides Pub/Sub key classes `PubSubTemplate` and `PubSubAdmin`.
 
-It requires the `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`
-properties.
-
 The following properties are optional:
 [source,yaml]
 ----

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -26,7 +26,6 @@ This starter provides the configuration sources: `CloudSqlJdbcInfoProvider` and 
 and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on
 Google App Engine.
 
-Besides `spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`,
 `CloudSqlJdbcInfoProvider` requires the following properties:
 
 [source,yaml]

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
@@ -59,7 +59,7 @@ public class SqlCredentialFactory implements CredentialFactory {
 
 		try {
 			return GoogleCredential.fromStream(new FileInputStream(credentialResourceLocation))
-					.createScoped(GcpContextAutoConfiguration.CREDENTIALS_SCOPES_LIST);
+					.createScoped(GcpContextAutoConfiguration.DEFAULT_CREDENTIAL_SCOPES);
 		}
 		catch (IOException ioe) {
 			LOGGER.warn("There was an error loading Cloud SQL credential.", ioe);

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
@@ -170,11 +170,12 @@ public class GcpCloudSqlAutoConfiguration {
 			}
 			// Then, the global credential.
 			else if (this.gcpProperties != null
-					&& this.gcpProperties.getCredentialsLocation() != null
-					&& this.gcpProperties.getCredentialsLocation().exists()) {
+					&& this.gcpProperties.getCredentials() != null
+					&& this.gcpProperties.getCredentials().getLocation() != null
+					&& this.gcpProperties.getCredentials().getLocation().exists()) {
 				// A resource might not be in the filesystem, but the Cloud SQL credential must.
 				File credentialsLocationFile =
-						this.gcpProperties.getCredentialsLocation().getFile();
+						this.gcpProperties.getCredentials().getLocation().getFile();
 
 				// This should happen if the Spring resource isn't in the filesystem, but a URL,
 				// classpath file, etc.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
@@ -22,5 +22,3 @@ dependencies {
 
 This starter provides the underpinnings of the Spring Cloud GCP Storage. It doesn't provide any
 bean to be used by an end-user.
-
-It requires the `spring.cloud.gcp.credentials-location` property.


### PR DESCRIPTION
Scopes list was static so far. Useful to limit credentials power in
case not every service is used.

Fixes #118