### PR TITLE
Adds spring-jdbc dependency so that user doesn't have to

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/pom.xml
@@ -47,5 +47,11 @@
 			<artifactId>mysql-socket-factory</artifactId>
 		</dependency>
 
+		<!-- JdbcTemplate -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jdbc</artifactId>
+		</dependency>
+
 	</dependencies>
 </project>


### PR DESCRIPTION
Currently, users need to manually add this dependency.

Unclear what the value of adding spring-boot-starter-jdbc instead is, but let me know if I'm missing anything.

@jabubake fyi