### PR TITLE
Calls setApplicationName on SQLAdmin builder and adds useSSL to MySQL

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/DefaultCloudSqlJdbcInfoProvider.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/DefaultCloudSqlJdbcInfoProvider.java
@@ -70,7 +70,7 @@ public class DefaultCloudSqlJdbcInfoProvider implements CloudSqlJdbcInfoProvider
 			}
 
 			String jdbcUrl = String.format("jdbc:mysql://google/%s?cloudSqlInstance=%s&"
-					+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
+					+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false",
 					this.properties.getDatabaseName(),
 					this.properties.getInstanceConnectionName());
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/DefaultCloudSqlJdbcInfoProvider.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/DefaultCloudSqlJdbcInfoProvider.java
@@ -70,7 +70,7 @@ public class DefaultCloudSqlJdbcInfoProvider implements CloudSqlJdbcInfoProvider
 			}
 
 			String jdbcUrl = String.format("jdbc:mysql://google/%s?cloudSqlInstance=%s&"
-					+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory",
+					+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
 					this.properties.getDatabaseName(),
 					this.properties.getInstanceConnectionName());
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
@@ -88,7 +88,8 @@ public class GcpCloudSqlAutoConfiguration {
 
 		return new SQLAdmin.Builder(httpTransport, jsonFactory,
 				new HttpCredentialsAdapter(credentialsProvider.getCredentials()))
-						.build();
+				.setApplicationName("spring")
+				.build();
 	}
 
 	@Bean

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfigurationMockTests.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfigurationMockTests.java
@@ -61,7 +61,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		@Override
 		public void test() {
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=proj:reg:test-instance"
-					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory",
+					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
 		}
@@ -77,7 +77,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 			HikariDataSource dataSource = (HikariDataSource) this.dataSource;
 			assertEquals("com.mysql.jdbc.Driver", dataSource.getDriverClassName());
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=proj:reg:test-instance"
-					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory",
+					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("root", dataSource.getUsername());
 			assertEquals("", dataSource.getPassword());
@@ -124,7 +124,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 			HikariDataSource dataSource = (HikariDataSource) this.dataSource;
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance="
 					+ "proj:siberia:test-instance&"
-					+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory",
+					+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("root", dataSource.getUsername());
 			assertEquals("", dataSource.getPassword());
@@ -144,7 +144,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		public void test() {
 			HikariDataSource dataSource = (HikariDataSource) this.dataSource;
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=proj:reg:test-instance"
-					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory",
+					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("watchmaker", dataSource.getUsername());
 			assertEquals("pass", dataSource.getPassword());
@@ -161,7 +161,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		@Override
 		public void test() {
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=world:asia:japan"
-							+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory",
+							+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
 		}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfigurationMockTests.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfigurationMockTests.java
@@ -61,7 +61,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		@Override
 		public void test() {
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=proj:reg:test-instance"
-					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
+					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
 		}
@@ -77,7 +77,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 			HikariDataSource dataSource = (HikariDataSource) this.dataSource;
 			assertEquals("com.mysql.jdbc.Driver", dataSource.getDriverClassName());
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=proj:reg:test-instance"
-					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
+					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("root", dataSource.getUsername());
 			assertEquals("", dataSource.getPassword());
@@ -124,7 +124,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 			HikariDataSource dataSource = (HikariDataSource) this.dataSource;
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance="
 					+ "proj:siberia:test-instance&"
-					+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
+					+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("root", dataSource.getUsername());
 			assertEquals("", dataSource.getPassword());
@@ -144,7 +144,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		public void test() {
 			HikariDataSource dataSource = (HikariDataSource) this.dataSource;
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=proj:reg:test-instance"
-					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
+					+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("watchmaker", dataSource.getUsername());
 			assertEquals("pass", dataSource.getPassword());
@@ -161,7 +161,7 @@ public abstract class GcpCloudSqlAutoConfigurationMockTests {
 		@Override
 		public void test() {
 			assertEquals("jdbc:mysql://google/test-database?cloudSqlInstance=world:asia:japan"
-							+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=true",
+							+ "&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false",
 					this.urlProvider.getJdbcUrl());
 			assertEquals("com.mysql.jdbc.Driver", this.urlProvider.getJdbcDriverClass());
 		}


### PR DESCRIPTION
...connection string

We might get usage metrics from SQLAdmin from setApplicationName and
the warning logs will now be silenced.

Fixes #124