### PR TITLE
Rolls back adding spring-jdbc dependency in #125

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/pom.xml
@@ -47,11 +47,5 @@
 			<artifactId>mysql-socket-factory</artifactId>
 		</dependency>
 
-		<!-- JdbcTemplate -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-jdbc</artifactId>
-		</dependency>
-
 	</dependencies>
 </project>


### PR DESCRIPTION
Users might want to use DataSource without JdbcTemplate. Also,
dependency is always pulled in, even when other dependencies also
pull it in. README doesn't need updating as it is already worded in a
way that conveys a requirement on Spring JDBC.

Fixes #125