### PR TITLE
Fixes checkstyle configuration

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,25 +1,28 @@
 = Code formatting guidelines
 
-* The directory ./src/eclipse has two files for use with code formatting,
-`eclipse-code-formatter.xml` for the majority of the code formatting rules and `eclipse.importorder`
-to order the import statements.
+The directory src/eclipse has two files for use with code formatting, `eclipse-code-formatter.xml`
+for the majority of the code formatting rules and `eclipse.importorder` to order the import
+statements.
 
-* In Eclipse you import these files by navigating `Windows -> Preferences` and then the menu items
+== Eclipse
+Import these files by navigating `Windows -> Preferences` and then the menu items
 `Preferences > Java > Code Style > Formatter` and `Preferences > Java > Code Style >
 Organize Imports` respectively.
 
-* In IntelliJ IDEA, install the plugin `Eclipse Code Formatter`.  You can find it by searching in
-"Browse Repositories", under `Settings > Plugins` within IDEA (Once installed, you will need to
-reboot IDEA for it to take effect).
+== IntelliJ IDEA
+Install the plugin `Eclipse Code Formatter`. You can find it by searching in "Browse Repositories",
+under `Settings > Plugins` within IDEA (Once installed, you will need to reboot IDEA for it to take
+effect).
+
 Then navigate to `Settings > Other Settings` (this might be under `Preferences` on Mac) and select
 the Eclipse Code Formatter. Select the `eclipse-code-formatter.xml` file for the field `Eclipse Java
 Formatter config file` and the file `eclipse.importorder` for the field `Import order`.
 Enable the `Eclipse code formatter` by clicking `Use the Eclipse code formatter` radio button at the
 top of the page, then click the *OK* button.
 
-** NOTE: If you configure the `Eclipse Code Formatter` from `File > Other Settings > Default
+* NOTE: If you configure the `Eclipse Code Formatter` from `File > Other Settings > Default
 Settings`, it will set this policy across all of your IDEA projects.
 
-** IDEA's "Optimize imports on the fly" option turned on interferes with the Eclipse code formatter
+* IDEA's "Optimize imports on the fly" option turned on interferes with the Eclipse code formatter
 import optimization. Consider disabling the option if optimization does not yield the expected
 results.

--- a/pom.xml
+++ b/pom.xml
@@ -103,24 +103,26 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>2.17</version>
+				<configuration>
+					<configLocation>src/checkstyle/checkstyle.xml</configLocation>
+					<headerLocation>src/checkstyle/checkstyle-header.txt</headerLocation>
+					<encoding>UTF-8</encoding>
+					<consoleOutput>true</consoleOutput>
+					<failsOnError>true</failsOnError>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
+					<failOnViolation>true</failOnViolation>
+					<violationSeverity>warning</violationSeverity>
+				</configuration>
 				<executions>
 					<execution>
 						<id>checkstyle-validation</id>
 						<phase>validate</phase>
-						<configuration>
-							<encoding>UTF-8</encoding>
-							<failOnViolation>true</failOnViolation>
-							<violationSeverity>warning</violationSeverity>
-							<includeTestSourceDirectory>true</includeTestSourceDirectory>
-							<configLocation>src/checkstyle/checkstyle.xml</configLocation>
-						</configuration>
 						<goals>
 							<goal>check</goal>
 						</goals>
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
 

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -5,7 +5,7 @@
 <module name="Checker">
     <!-- Root Checks -->
     <module name="RegexpHeader">
-        <property name="headerFile" value="src/checkstyle/checkstyle-header.txt"/>
+        <property name="headerFile" value="${checkstyle.header.file}"/>
         <property name="fileExtensions" value="java"/>
     </module>
     <module name="NewlineAtEndOfFile">


### PR DESCRIPTION
It is now possible to build from any sub-module without getting the
annoying checkstyle warning.

Fixes #131