### PR TITLE
Adds credential information for GCP compute environments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,6 +61,6 @@ These properties are optional and, if not specified, Spring Boot will attempt to
 them for you. For details on how Spring Boot finds these properties, refer to the desired starter
 README.
 
-If your app is running on Google App Engine or Google Compute Engine, you should omit the
-`spring.cloud.gcp.credentials-location` property and, instead, let the Spring Cloud GCP Core Starter
-get the correct credentials for those environments.
+If your app is running on Google App Engine or Google Compute Engine, in most cases, you should omit
+the `spring.cloud.gcp.credentials-location` property and, instead, let the Spring Cloud GCP Core
+Starter get the correct credentials for those environments.

--- a/README.adoc
+++ b/README.adoc
@@ -60,3 +60,7 @@ spring.cloud.gcp.credentials-location=file:[LOCAL_PRIVATE_KEY_FILE]
 These properties are optional and, if not specified, Spring Boot will attempt to automatically find
 them for you. For details on how Spring Boot finds these properties, refer to the desired starter
 README.
+
+If your app is running on Google App Engine or Google Compute Engine, you should omit the
+`spring.cloud.gcp.credentials-location` property and, instead, let the Spring Cloud GCP Core Starter
+get the correct credentials for those environments.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -43,3 +43,13 @@ Similarly for `spring.cloud.gcp.credentials-location`, if a property is configur
 https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html#resources-implementations[file system paths, HTTP URLs, etc.]
 If no property is configured, the provided `CredentialsProvider` returns the
 http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
+
+If your app is running on Google App Engine or Google Compute Engine, you should omit the
+`spring.cloud.gcp.credentials-location` property and, instead, let the Spring Cloud GCP Core Starter
+get the correct credentials for those environments. On App Engine Standard, the
+https://cloud.google.com/appengine/docs/standard/java/appidentity/[App Identity service account credentials]
+are used, on App Engine Flexible, the
+https://cloud.google.com/appengine/docs/flexible/java/service-account[Flexible service account credential]
+are used and on Google Compute Engine, the
+https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#using_the_compute_engine_default_service_account[Compute Engine Default Service Account]
+is used.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -44,9 +44,9 @@ https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resou
 If no property is configured, the provided `CredentialsProvider` returns the
 http://google.github.io/google-auth-library-java/releases/0.7.1/apidocs/com/google/auth/oauth2/GoogleCredentials.html#getApplicationDefault()[application default credentials].
 
-If your app is running on Google App Engine or Google Compute Engine, you should omit the
-`spring.cloud.gcp.credentials-location` property and, instead, let the Spring Cloud GCP Core Starter
-get the correct credentials for those environments. On App Engine Standard, the
+If your app is running on Google App Engine or Google Compute Engine, in most cases, you should omit
+the `spring.cloud.gcp.credentials-location` property and, instead, let the Spring Cloud GCP Core
+Starter get the correct credentials for those environments. On App Engine Standard, the
 https://cloud.google.com/appengine/docs/standard/java/appidentity/[App Identity service account credentials]
 are used, on App Engine Flexible, the
 https://cloud.google.com/appengine/docs/flexible/java/service-account[Flexible service account credential]


### PR DESCRIPTION
Aims to ease the friction customers with local service accounts have
when deploying to Google App Engine.

Fixes #130