### PR TITLE
Provides mock Credentials for unit tests so no exceptions are logged

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/test/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfigurationTests.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/test/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfigurationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.core.autoconfig;
 
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
 import org.junit.After;
 import org.junit.Test;
 
@@ -23,13 +25,17 @@ import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author João André Martins
  */
+@Configuration
 public class GcpContextAutoConfigurationTests {
 
 	private AnnotationConfigApplicationContext context;
@@ -59,8 +65,14 @@ public class GcpContextAutoConfigurationTests {
 	private void loadEnvironment(String... environment) {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 		context.register(GcpContextAutoConfiguration.class);
+		context.register(this.getClass());
 		EnvironmentTestUtils.addEnvironment(context, environment);
 		context.refresh();
 		this.context = context;
+	}
+
+	@Bean
+	public CredentialsProvider googleCredentials() {
+		return () -> mock(Credentials.class);
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlTestConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/test/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlTestConfiguration.java
@@ -18,8 +18,10 @@ package org.springframework.cloud.gcp.sql.autoconfig;
 
 import java.io.IOException;
 
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.services.sqladmin.SQLAdmin;
 import com.google.api.services.sqladmin.model.DatabaseInstance;
+import com.google.auth.Credentials;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,5 +53,10 @@ public class GcpCloudSqlTestConfiguration {
 		databaseInstance.setRegion("reg");
 
 		return mockSqlAdmin;
+	}
+
+	@Bean
+	public CredentialsProvider googleCredentials() {
+		return () -> mock(Credentials.class);
 	}
 }


### PR DESCRIPTION
Some unit tests are failing because the default CredentialsProvider
can't find suitable Credentials and exceptions are being logged.

Fixes #143 