### PR TITLE
Document that Cloud SQL API must be enabled

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
@@ -35,6 +35,8 @@ The Spring Boot Starter for Google Cloud SQL provides an auto-configured
 https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html#jdbc-JdbcTemplate[`JdbcTemplate`]
 object bean that allows for operations such as querying and modifying a database.
 
+Note that this starter requires the Google Cloud SQL API to be enabled in in your GCP project.
+
 [source,java]
 ----
 @Autowired

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -35,24 +35,23 @@ Google App Engine.
 [source,yaml]
 ----
 spring.cloud.gcp.sql.database-name=[YOUR_CLOUD_SQL_DATABASE_NAME]
-# spring.cloud.gcp.sql.instance-connection-name OR spring.cloud.gcp.sql.jdbc-url (See below)
+spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
 ----
+
+`spring.cloud.gcp.sql.instance-connection-name` is your instance's
+https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql#google-cloud-sql-instance-connection-name[connection name].
+You can alternatively specify the full `spring.cloud.gcp.sql.jdbc-url`.
 
 The following properties are optional:
 
 [source,yaml]
 ----
-spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
 spring.cloud.gcp.sql.jdbc-url=[YOUR_JDBC_URL]
 spring.cloud.gcp.sql.jdbc-driver=[YOUR_JDBC_DRIVER]
 spring.cloud.gcp.sql.user-name=[YOUR_CLOUD_SQL_USERNAME]
 spring.cloud.gcp.sql.password=[YOUR_CLOUD_SQL_PASSWORD]
 spring.cloud.gcp.sql.database-type=[mysql or postgresql]
 ----
-
-`spring.cloud.gcp.sql.instance-connection-name` is your instance's
-https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql#google-cloud-sql-instance-connection-name[connection name].
-Required if `spring.cloud.gcp.sql.jdbc-url` isn't specified.
 
 If `spring.cloud.gcp.sql.jdbc-url` is specified, it is used as the final JDBC URL and has precedence
 over `spring.cloud.gcp.sql.instance-connection-name`.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -24,15 +24,24 @@ This starter provides the configuration sources: `CloudSqlJdbcInfoProvider` and 
 
 It allows connections to second-generation only Google Cloud SQL instances.
 
+Before using the starter, ensure that the Google Cloud SQL API is enabled in your GCP project.
+
 `CloudSqlJdbcInfoProvider` returns the JDBC information to be used, such as the JDBC driver name
 and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on
 Google App Engine.
 
-`CloudSqlJdbcInfoProvider` uses the following properties:
+`CloudSqlJdbcInfoProvider` requires the following properties:
 
 [source,yaml]
 ----
 spring.cloud.gcp.sql.database-name=[YOUR_CLOUD_SQL_DATABASE_NAME]
+# spring.cloud.gcp.sql.instance-connection-name OR spring.cloud.gcp.sql.jdbc-url (See below)
+----
+
+The following properties are optional:
+
+[source,yaml]
+----
 spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTION_NAME]
 spring.cloud.gcp.sql.jdbc-url=[YOUR_JDBC_URL]
 spring.cloud.gcp.sql.jdbc-driver=[YOUR_JDBC_DRIVER]
@@ -119,8 +128,7 @@ To fix this, re-declare the dependency in its correct version. For example, in M
 
 === I'm seeing a lot of log lines similar to "c.g.cloud.sql.core.SslSocketFactory : Re-throwing cached exception due to attempt to refresh instance information too soon after error." in a loop and I can't connect to my database
 
-This is usually a symptom that something isn't right with the permissions of your credentials. For
-example, your service account doesn't have the
+This is usually a symptom that something isn't right with the permissions of your credentials or the Google Cloud SQL API is not enabled. Verify that the Google Cloud SQL API is enabled in the Cloud Console and that your service account has the
 https://cloud.google.com/sql/docs/mysql/project-access-control#roles[necessary IAM roles].
 
 To find out what's causing the issue, you can enable DEBUG logging level at HikariCP by adding the


### PR DESCRIPTION
The Cloud SQL starter doesn't work unless the Cloud SQL API is enabled.
Also, clarifies that either `instance-connection-name` or `jdbc-url` must be provided.

Fixes #152