### PR TITLE
Fix reference doc glitch

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/dependency-management.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/dependency-management.adoc
@@ -27,3 +27,4 @@ GCP BOM and the dependency versions are omitted.
 Gradle users can achieve the same kind of BOM experience using Spring's
 https://github.com/spring-gradle-plugins/dependency-management-plugin[dependency-management-plugin]
 Gradle plugin.
+


### PR DESCRIPTION
The Spring GCP Core section isn't showing up as a section right now.