### PR TITLE
Moves Pub/Sub Spring Integration to pubsub folder

### DIFF
--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/pubsub/AckMode.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/pubsub/AckMode.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package org.springframework.integration.gcp;
+package org.springframework.integration.gcp.pubsub;
 
 /**
  * Determines acknowledgement policy for incoming messages from Google Cloud Pub/Sub.

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/pubsub/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/pubsub/inbound/PubSubInboundChannelAdapter.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package org.springframework.integration.gcp.inbound;
+package org.springframework.integration.gcp.pubsub.inbound;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +26,7 @@ import com.google.pubsub.v1.PubsubMessage;
 import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
 import org.springframework.cloud.gcp.pubsub.support.GcpHeaders;
 import org.springframework.integration.endpoint.MessageProducerSupport;
-import org.springframework.integration.gcp.AckMode;
+import org.springframework.integration.gcp.pubsub.AckMode;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.converter.StringMessageConverter;

--- a/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/pubsub/outbound/PubSubMessageHandler.java
+++ b/spring-integration-gcp/src/main/java/org/springframework/integration/gcp/pubsub/outbound/PubSubMessageHandler.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package org.springframework.integration.gcp.outbound;
+package org.springframework.integration.gcp.pubsub.outbound;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;

--- a/spring-integration-gcp/src/test/java/org/springframework/integration/gcp/pubsub/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-integration-gcp/src/test/java/org/springframework/integration/gcp/pubsub/inbound/PubSubInboundChannelAdapterTests.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package org.springframework.integration.gcp.inbound;
+package org.springframework.integration.gcp.pubsub.inbound;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-integration-gcp/src/test/java/org/springframework/integration/gcp/pubsub/outbound/PubSubMessageHandlerTests.java
+++ b/spring-integration-gcp/src/test/java/org/springframework/integration/gcp/pubsub/outbound/PubSubMessageHandlerTests.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package org.springframework.integration.gcp.outbound;
+package org.springframework.integration.gcp.pubsub.outbound;
 
 import java.nio.charset.Charset;
 import java.util.Map;


### PR DESCRIPTION
In the future, other Spring Integrations can be added to other folders
(e.g., Storage to storage folder).