### PR TITLE
Fixes spring-cloud-sleuth version not to be a milestone

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -20,9 +20,9 @@
 		<google-cloud-pubsub.version>0.20.1-beta</google-cloud-pubsub.version>
 		<google-cloud-trace.version>0.20.1-alpha</google-cloud-trace.version>
 		<google-cloud-storage.version>1.2.1</google-cloud-storage.version>
-		<spring-cloud-context.version>1.2.3.RELEASE</spring-cloud-context.version>
 		<cloud-trace-java.version>0.4.0</cloud-trace-java.version>
-		<spring-cloud-sleuth.version>1.3.0.M1</spring-cloud-sleuth.version>
+		<spring-cloud-context.version>1.2.3.RELEASE</spring-cloud-context.version>
+		<spring-cloud-sleuth.version>1.2.4.RELEASE</spring-cloud-sleuth.version>
 	</properties>
 
 	<dependencyManagement>
@@ -124,17 +124,6 @@
 			</dependency>
 
 			<!-- spring-cloud-gcp-starter-sql -->
-			<dependency>
-				<groupId>com.google.apis</groupId>
-				<artifactId>google-api-services-sqladmin</artifactId>
-				<version>v1beta4-rev45-1.22.0</version>
-				<exclusions>
-					<exclusion>
-						<groupId>com.google.guava</groupId>
-						<artifactId>guava-jdk5</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
 
 			<dependency>
 				<groupId>com.google.cloud.sql</groupId>


### PR DESCRIPTION
We currently don't tell users to add the Pivotal milestone repo.
We should probably also not depend on a milestone version when there is
an available GA.

@jabubake fyi