### PR TITLE
Logs errors on publish

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration.adoc
@@ -115,6 +115,5 @@ The provided `PubSubTemplate` contains all the necessary configuration to publis
 GCP Pub/Sub topic.
 
 `PubSubMessageHandler` publishes messages asynchronously by default.
-On asynchronous mode, publish errors are not displayed.
 A publish timeout can be configured for synchronous publishing. If none is provided, the adapter
 waits indefinitely for a response.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -26,6 +26,8 @@ import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
@@ -40,6 +42,8 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @author João André Martins
  */
 public class PubSubTemplate implements PubSubOperations, InitializingBean {
+
+	private static final Log LOGGER = LogFactory.getLog(PubSubTemplate.class);
 
 	private final PublisherFactory publisherFactory;
 
@@ -90,11 +94,13 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 
 			@Override
 			public void onFailure(Throwable throwable) {
+				LOGGER.warn("Publishing to " + topic + " topic failed.", throwable);
 				settableFuture.setException(throwable);
 			}
 
 			@Override
 			public void onSuccess(String result) {
+				LOGGER.debug("Publishing to " + topic + " was successful. Message ID: " + result);
 				settableFuture.set(result);
 			}
 

--- a/spring-integration-gcp/README.adoc
+++ b/spring-integration-gcp/README.adoc
@@ -25,7 +25,6 @@ Makes extensive use of the constructs provided by the Spring Cloud GCP Pub/Sub m
 `PubSubOperations`.
 
 The outbound channel adapter, `PubSubMessageHandler`, publishes messages asynchronously by default.
-On asynchronous mode, publish errors are not displayed.
 A publish timeout can be configured for synchronous publishing. If none is provided, the adapter
 waits indefinitely for a response.
 


### PR DESCRIPTION
Errors on async publish are currently not logged, which can be confusing
to users.

Fixes #81