### PR TITLE
Return PubSubTemplate rather than PubSubOperations

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
@@ -42,7 +42,6 @@ import org.springframework.cloud.gcp.core.autoconfig.GcpContextAutoConfiguration
 import org.springframework.cloud.gcp.pubsub.GcpPubSubProperties;
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
 import org.springframework.cloud.gcp.pubsub.core.PubSubException;
-import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
@@ -117,7 +116,7 @@ public class GcpPubSubAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public PubSubOperations pubSubTemplate(PublisherFactory publisherFactory,
+	public PubSubTemplate pubSubTemplate(PublisherFactory publisherFactory,
 			SubscriberFactory subscriberFactory) {
 		return new PubSubTemplate(publisherFactory, subscriberFactory);
 	}


### PR DESCRIPTION
For the autoconfiguration, return PubSubTemplate. This is inline w/ other starter templates, e.g. RabbitMQ Template, MongoTemplate, etc.