### PR TITLE
Revert "Resets spring-cloud-sleuth version (#179)"

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -22,7 +22,7 @@
 		<google-cloud-storage.version>1.2.1</google-cloud-storage.version>
 		<cloud-trace-java.version>0.4.0</cloud-trace-java.version>
 		<spring-cloud-context.version>1.2.3.RELEASE</spring-cloud-context.version>
-		<spring-cloud-sleuth.version>1.3.0.M1</spring-cloud-sleuth.version>
+		<spring-cloud-sleuth.version>1.2.5.RELEASE</spring-cloud-sleuth.version>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/README.adoc
@@ -19,33 +19,6 @@ dependencies {
 }
 ----
 
-Since a Milestone version of a Spring Cloud dependency is used, you will also need to add the Spring
-Milestones repository to your build file.
-
-`pom.xml`
-[source]
-----
-<repositories>
-    <repository>
-        <id>spring-milestones</id>
-        <name>Spring Milestones</name>
-        <url>https://repo.spring.io/libs-milestone-local</url>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-    </repository>
-</repositories>
-----
-
-`build.gradle`
-[source]
-----
-repositories {
-    mavenCentral()
-    maven { url "http://repo.spring.io/libs-milestone" }
-}
-----
-
 This starter uses Spring Cloud Sleuth and provides a `SpanReporter` that sends the Sleuth's trace information to Stackdriver Trace.
 
 All configurations are optional. You can override a number of default configuration values in addition to the core


### PR DESCRIPTION
Sets new 1.2.5 spring-cloud-sleuth GA version so users don't have to
use the Milestones repo.

Tested and made sure spring-cloud/spring-cloud-sleuth#684 doesn't creep back.