### PR TITLE
Change rewriteId(Long) to rewriteId(long)

### DIFF
--- a/spring-cloud-gcp-trace/src/main/java/org/springframework/cloud/gcp/trace/sleuth/StackdriverTraceSpanListener.java
+++ b/spring-cloud-gcp-trace/src/main/java/org/springframework/cloud/gcp/trace/sleuth/StackdriverTraceSpanListener.java
@@ -180,8 +180,8 @@ public class StackdriverTraceSpanListener implements SpanReporter {
 		}
 	}
 
-	private long rewriteId(Long id) {
-		if (id == null) {
+	private long rewriteId(long id) {
+		if (id == 0) {
 			return 0;
 		}
 		// To deterministically rewrite the ID, xor it with a random 64-bit constant.

--- a/spring-cloud-gcp-trace/src/test/java/org/springframework/cloud/gcp/trace/sleuth/StackdriverTraceSpanListenerTests.java
+++ b/spring-cloud-gcp-trace/src/test/java/org/springframework/cloud/gcp/trace/sleuth/StackdriverTraceSpanListenerTests.java
@@ -138,6 +138,7 @@ public class StackdriverTraceSpanListenerTests {
 
 		Assert.assertEquals(1, this.test.traceSpans.size());
 		TraceSpan traceSpan = this.test.traceSpans.get(0);
+		Assert.assertEquals(0, traceSpan.getParentSpanId());
 		Assert.assertEquals("http:parent", traceSpan.getName());
 		// Server side remote span should not report start/end time
 		Assert.assertEquals(Timestamp.getDefaultInstance(), traceSpan.getStartTime());
@@ -180,6 +181,7 @@ public class StackdriverTraceSpanListenerTests {
 	public void testClientServerSpans() {
 		Span clientSpan = Span.builder()
 				.traceId(123L)
+				.spanId(9999L)
 				.name("http:call")
 				.begin(beginTime - 1)
 				.end(endTime + 1)


### PR DESCRIPTION
changed Long type to long since object type is not necessary.
also, if input value is 0, it should not rewrite ID and simply return 0 as well.