### PR TITLE
Allows for "credentials.location" notation in property names

### DIFF
--- a/spring-cloud-gcp-core/pom.xml
+++ b/spring-cloud-gcp-core/pom.xml
@@ -18,5 +18,9 @@
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-core</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/AbstractCredentialsProperty.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/AbstractCredentialsProperty.java
@@ -25,7 +25,7 @@ import org.springframework.core.io.Resource;
  *
  * @author João Andre Martins
  */
-public abstract class CredentialsProperty {
+public abstract class AbstractCredentialsProperty {
 
 	private Resource location;
 	private List<String> scopes;

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/AbstractCredentialsProperty.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/AbstractCredentialsProperty.java
@@ -21,7 +21,8 @@ import java.util.List;
 import org.springframework.core.io.Resource;
 
 /**
- * To be extended by property class subclasses and allow e.g., a "credentials.location" notation.
+ * To be extended by property class subclasses and allow e.g., a "credentials.location" property
+ * notation.
  *
  * @author João Andre Martins
  */

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/CredentialsProperty.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/CredentialsProperty.java
@@ -14,27 +14,35 @@
  *  limitations under the License.
  */
 
-package org.springframework.cloud.gcp.storage;
+package org.springframework.cloud.gcp.core;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.CredentialsProperty;
+import java.util.List;
+
+import org.springframework.core.io.Resource;
 
 /**
- * @author João André Martins
+ * To be extended by property class subclasses and allow e.g., a "credentials.location" notation.
+ *
+ * @author João Andre Martins
  */
-@ConfigurationProperties("spring.cloud.gcp.storage")
-public class GcpStorageProperties extends GoogleStorageProtocolResolverSettings {
+public abstract class CredentialsProperty {
 
-	private Credentials credentials;
+	private Resource location;
+	private List<String> scopes;
 
-	public Credentials getCredentials() {
-		return this.credentials;
+	public Resource getLocation() {
+		return this.location;
 	}
 
-	public void setCredentials(Credentials credentials) {
-		this.credentials = credentials;
+	public void setLocation(Resource location) {
+		this.location = location;
 	}
 
-	public class Credentials extends CredentialsProperty {
+	public List<String> getScopes() {
+		return this.scopes;
+	}
+
+	public void setScopes(List<String> scopes) {
+		this.scopes = scopes;
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
@@ -88,6 +88,6 @@ public class GcpConfigProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends AbstractCredentialsProperty {
+	public static class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.gcp.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.CredentialsProperty;
+import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
 
 /**
  * Configuration for {@link GoogleConfigPropertySourceLocator}.
@@ -88,6 +88,6 @@ public class GcpConfigProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends CredentialsProperty {
+	public class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.gcp.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.core.io.Resource;
+import org.springframework.cloud.gcp.core.CredentialsProperty;
 
 /**
  * Configuration for {@link GoogleConfigPropertySourceLocator}.
@@ -38,7 +38,7 @@ public class GcpConfigProperties {
 
 	private String projectId;
 
-	private Resource credentialsLocation;
+	private Credentials credentials;
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
@@ -80,11 +80,14 @@ public class GcpConfigProperties {
 		this.projectId = projectId;
 	}
 
-	public Resource getCredentialsLocation() {
-		return this.credentialsLocation;
+	public Credentials getCredentials() {
+		return this.credentials;
 	}
 
-	public void setCredentialsLocation(Resource credentialsLocation) {
-		this.credentialsLocation = credentialsLocation;
+	public void setCredentials(Credentials credentials) {
+		this.credentials = credentials;
+	}
+
+	public class Credentials extends CredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GoogleConfigPropertySourceLocator.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GoogleConfigPropertySourceLocator.java
@@ -75,9 +75,9 @@ public class GoogleConfigPropertySourceLocator implements PropertySourceLocator 
 		Assert.notNull(credentialsProvider, "Credentials provider cannot be null");
 		Assert.notNull(projectIdProvider, "Project ID provider cannot be null");
 		Assert.notNull(gcpConfigProperties, "Google Config properties must not be null");
-		this.credentials = gcpConfigProperties.getCredentialsLocation() != null
+		this.credentials = gcpConfigProperties.getCredentials() != null
 				? GoogleCredentials.fromStream(
-						gcpConfigProperties.getCredentialsLocation().getInputStream())
+						gcpConfigProperties.getCredentials().getLocation().getInputStream())
 				.createScoped(Collections.singletonList(GcpScope.RUNTIME_CONFIG_SCOPE.getUrl()))
 				: credentialsProvider.getCredentials();
 		this.projectId = gcpConfigProperties.getProjectId() != null

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
@@ -16,10 +16,7 @@
 
 package org.springframework.cloud.gcp.core;
 
-import java.util.List;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.core.io.Resource;
 
 /**
  * @author Vinicius Carvalho
@@ -48,24 +45,6 @@ public class GcpProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials {
-		private Resource location;
-		private List<String> scopes;
-
-		public Resource getLocation() {
-			return this.location;
-		}
-
-		public void setLocation(Resource location) {
-			this.location = location;
-		}
-
-		public List<String> getScopes() {
-			return this.scopes;
-		}
-
-		public void setScopes(List<String> scopes) {
-			this.scopes = scopes;
-		}
+	public class Credentials extends CredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
@@ -45,6 +45,6 @@ public class GcpProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends CredentialsProperty {
+	public class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
@@ -45,6 +45,6 @@ public class GcpProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends AbstractCredentialsProperty {
+	public static class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
@@ -61,6 +61,6 @@ public class GcpPubSubProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends AbstractCredentialsProperty {
+	public static class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.gcp.pubsub;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.CredentialsProperty;
+import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
 
 @ConfigurationProperties("spring.cloud.gcp.pubsub")
 public class GcpPubSubProperties {
@@ -61,6 +61,6 @@ public class GcpPubSubProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends CredentialsProperty {
+	public class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.gcp.pubsub;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.core.io.Resource;
+import org.springframework.cloud.gcp.core.CredentialsProperty;
 
 @ConfigurationProperties("spring.cloud.gcp.pubsub")
 public class GcpPubSubProperties {
@@ -27,7 +27,7 @@ public class GcpPubSubProperties {
 
 	private String projectId;
 
-	private Resource credentialsLocation;
+	private Credentials credentials;
 
 	public int getSubscriberExecutorThreads() {
 		return this.subscriberExecutorThreads;
@@ -53,11 +53,14 @@ public class GcpPubSubProperties {
 		this.projectId = projectId;
 	}
 
-	public Resource getCredentialsLocation() {
-		return this.credentialsLocation;
+	public Credentials getCredentials() {
+		return this.credentials;
 	}
 
-	public void setCredentialsLocation(Resource credentialsLocation) {
-		this.credentialsLocation = credentialsLocation;
+	public void setCredentials(Credentials credentials) {
+		this.credentials = credentials;
+	}
+
+	public class Credentials extends CredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
@@ -73,10 +73,10 @@ public class GcpPubSubAutoConfiguration {
 		this.finalProjectIdProvider = gcpPubSubProperties.getProjectId() != null
 				? gcpPubSubProperties::getProjectId
 				: gcpProjectIdProvider;
-		this.finalCredentialsProvider = gcpPubSubProperties.getCredentialsLocation() != null
+		this.finalCredentialsProvider = gcpPubSubProperties.getCredentials() != null
 				? FixedCredentialsProvider.create(
 						GoogleCredentials.fromStream(
-								gcpPubSubProperties.getCredentialsLocation().getInputStream())
+								gcpPubSubProperties.getCredentials().getLocation().getInputStream())
 								.createScoped(Collections.singletonList(GcpScope.PUBSUB.getUrl())))
 				: credentialsProvider;
 	}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.gcp.sql;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.CredentialsProperty;
+import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
 
 /**
  * Google Cloud SQL properties.
@@ -117,6 +117,6 @@ public class GcpCloudSqlProperties {
 		this.databaseType = databaseType;
 	}
 
-	public class Credentials extends CredentialsProperty {
+	public class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
@@ -66,6 +66,6 @@ public class GcpCloudSqlProperties {
 		this.databaseType = databaseType;
 	}
 
-	public class Credentials extends AbstractCredentialsProperty {
+	public static class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
@@ -16,9 +16,8 @@
 
 package org.springframework.cloud.gcp.sql;
 
-import java.nio.file.Path;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.gcp.core.CredentialsProperty;
 
 /**
  * Google Cloud SQL properties.
@@ -42,7 +41,7 @@ public class GcpCloudSqlProperties {
 
 	private boolean initFailFast;
 
-	private Path credentialsLocation;
+	private Credentials credentials;
 
 	private DatabaseType databaseType = DatabaseType.MYSQL;
 
@@ -102,12 +101,12 @@ public class GcpCloudSqlProperties {
 		this.initFailFast = initFailFast;
 	}
 
-	public Path getCredentialsLocation() {
-		return this.credentialsLocation;
+	public Credentials getCredentials() {
+		return this.credentials;
 	}
 
-	public void setCredentialsLocation(Path credentialsLocation) {
-		this.credentialsLocation = credentialsLocation;
+	public void setCredentials(Credentials credentials) {
+		this.credentials = credentials;
 	}
 
 	public DatabaseType getDatabaseType() {
@@ -116,5 +115,8 @@ public class GcpCloudSqlProperties {
 
 	public void setDatabaseType(DatabaseType databaseType) {
 		this.databaseType = databaseType;
+	}
+
+	public class Credentials extends CredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
@@ -172,7 +172,7 @@ public class GcpCloudSqlAutoConfiguration {
 			}
 		}
 		catch (IOException ioe) {
-			LOGGER.info(" Error reading Cloud SQL credentials file.", ioe);
+			LOGGER.info("Error reading Cloud SQL credentials file.", ioe);
 			return;
 		}
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
@@ -150,44 +150,45 @@ public class GcpCloudSqlAutoConfiguration {
 	 * using the application default credentials by default. So we don't need to do anything.
 	 */
 	private void setCredentialsProperty() {
+		File credentialsLocationFile;
+
 		try {
 			// First tries the SQL configuration credential.
 			if (this.gcpCloudSqlProperties != null
 					&& this.gcpCloudSqlProperties.getCredentials() != null) {
-				System.setProperty(SqlCredentialFactory.CREDENTIAL_LOCATION_PROPERTY_NAME,
-						this.gcpCloudSqlProperties.getCredentials().getLocation().getFile()
-								.getAbsolutePath());
+				credentialsLocationFile =
+						this.gcpCloudSqlProperties.getCredentials().getLocation().getFile();
 			}
 			// Then, the global credential.
 			else if (this.gcpProperties != null
-					&& this.gcpProperties.getCredentials().getLocation() != null
-					&& this.gcpProperties.getCredentials().getLocation().exists()) {
+					&& this.gcpProperties.getCredentials().getLocation() != null) {
 				// A resource might not be in the filesystem, but the Cloud SQL credential must.
-				File credentialsLocationFile = this.gcpProperties.getCredentials().getLocation().getFile();
-
-				// This should happen if the Spring resource isn't in the filesystem, but a URL,
-				// classpath file, etc.
-				if (credentialsLocationFile == null) {
-					if (LOGGER.isWarnEnabled()) {
-						LOGGER.warn("The private key of the Google Cloud SQL credential must "
-								+ "be in a file on the filesystem.");
-					}
-					return;
-				}
-				System.setProperty(SqlCredentialFactory.CREDENTIAL_LOCATION_PROPERTY_NAME,
-						credentialsLocationFile.getAbsolutePath());
+				credentialsLocationFile =
+						this.gcpProperties.getCredentials().getLocation().getFile();
 			}
 			else {
+				// Do nothing, let sockets factory use application default credentials.
 				return;
 			}
-
-			// If there are specified credentials, tell sockets factory to use them.
-			System.setProperty(CredentialFactory.CREDENTIAL_FACTORY_PROPERTY,
-					SqlCredentialFactory.class.getName());
 		}
 		catch (IOException ioe) {
-			// Do nothing, let sockets factory use application default credentials.
-			LOGGER.debug(" Error reading Cloud SQL credentials file.", ioe);
+			LOGGER.info(" Error reading Cloud SQL credentials file.", ioe);
+			return;
 		}
+
+		// This should happen if the Spring resource isn't in the filesystem, but a URL,
+		// classpath file, etc.
+		if (credentialsLocationFile == null) {
+			LOGGER.info("The private key of the Google Cloud SQL credential must "
+					+ "be in a file on the filesystem.");
+			return;
+		}
+
+		System.setProperty(SqlCredentialFactory.CREDENTIAL_LOCATION_PROPERTY_NAME,
+				credentialsLocationFile.getAbsolutePath());
+
+		// If there are specified credentials, tell sockets factory to use them.
+		System.setProperty(CredentialFactory.CREDENTIAL_FACTORY_PROPERTY,
+				SqlCredentialFactory.class.getName());
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/autoconfig/GcpCloudSqlAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.gcp.sql.autoconfig;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.security.GeneralSecurityException;
 
 import javax.sql.DataSource;
@@ -146,10 +145,10 @@ public class GcpCloudSqlAutoConfiguration {
 		try {
 			// First tries the SQL configuration credential.
 			if (this.gcpCloudSqlProperties != null
-					&& this.gcpCloudSqlProperties.getCredentialsLocation() != null
-					&& Files.exists(this.gcpCloudSqlProperties.getCredentialsLocation())) {
+					&& this.gcpCloudSqlProperties.getCredentials() != null) {
 				System.setProperty(SqlCredentialFactory.CREDENTIAL_LOCATION_PROPERTY_NAME,
-						this.gcpCloudSqlProperties.getCredentialsLocation().toString());
+						this.gcpCloudSqlProperties.getCredentials().getLocation().getFile()
+								.getAbsolutePath());
 			}
 			// Then, the global credential.
 			else if (this.gcpProperties != null

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
@@ -35,6 +35,6 @@ public class GcpStorageProperties extends GoogleStorageProtocolResolverSettings 
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends AbstractCredentialsProperty {
+	public static class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.gcp.storage;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.CredentialsProperty;
+import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
 
 /**
  * @author João André Martins
@@ -35,6 +35,6 @@ public class GcpStorageProperties extends GoogleStorageProtocolResolverSettings 
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends CredentialsProperty {
+	public class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
@@ -57,10 +57,10 @@ public class StorageAutoConfiguration {
 	public static Storage storage(CredentialsProvider credentialsProvider,
 			GcpStorageProperties gcpStorageProperties) throws IOException {
 		return StorageOptions.newBuilder()
-				.setCredentials(gcpStorageProperties.getCredentialsLocation() != null
+				.setCredentials(gcpStorageProperties.getCredentials() != null
 						? GoogleCredentials
-								.fromStream(gcpStorageProperties.getCredentialsLocation()
-										.getInputStream())
+								.fromStream(gcpStorageProperties.getCredentials()
+										.getLocation().getInputStream())
 								.createScoped(Collections.singletonList(
 										GcpScope.STORAGE_READ_WRITE.getUrl()))
 						: credentialsProvider.getCredentials())

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
@@ -105,6 +105,6 @@ public class GcpTraceProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends AbstractCredentialsProperty {
+	public static class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
@@ -16,7 +16,7 @@
 package org.springframework.cloud.gcp.trace;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.CredentialsProperty;
+import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
 
 /**
  * Stackdriver Trace Properties.
@@ -105,6 +105,6 @@ public class GcpTraceProperties {
 		this.credentials = credentials;
 	}
 
-	public class Credentials extends CredentialsProperty {
+	public class Credentials extends AbstractCredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
@@ -16,7 +16,7 @@
 package org.springframework.cloud.gcp.trace;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.core.io.Resource;
+import org.springframework.cloud.gcp.core.CredentialsProperty;
 
 /**
  * Stackdriver Trace Properties.
@@ -49,7 +49,7 @@ public class GcpTraceProperties {
 
 	private String projectId;
 
-	private Resource credentialsLocation;
+	private Credentials credentials;
 
 	/**
 	 * A utility method to determine x% of total memory based on Zipkin's AsyncReporter.
@@ -97,11 +97,14 @@ public class GcpTraceProperties {
 		this.projectId = projectId;
 	}
 
-	public Resource getCredentialsLocation() {
-		return this.credentialsLocation;
+	public Credentials getCredentials() {
+		return this.credentials;
 	}
 
-	public void setCredentialsLocation(Resource credentialsLocation) {
-		this.credentialsLocation = credentialsLocation;
+	public void setCredentials(Credentials credentials) {
+		this.credentials = credentials;
+	}
+
+	public class Credentials extends CredentialsProperty {
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/autoconfig/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/autoconfig/StackdriverTraceAutoConfiguration.java
@@ -86,9 +86,9 @@ public class StackdriverTraceAutoConfiguration {
 		this.finalProjectIdProvider = gcpTraceProperties.getProjectId() != null
 				? gcpTraceProperties::getProjectId
 				: gcpProjectIdProvider;
-		this.finalCredentialsProvider = gcpTraceProperties.getCredentialsLocation() != null
+		this.finalCredentialsProvider = gcpTraceProperties.getCredentials() != null
 				? FixedCredentialsProvider.create(GoogleCredentials.fromStream(
-						gcpTraceProperties.getCredentialsLocation().getInputStream())
+						gcpTraceProperties.getCredentials().getLocation().getInputStream())
 				.createScoped(Collections.singletonList(GcpScope.TRACE_APPEND.getUrl())))
 				: credentialsProvider;
 	}


### PR DESCRIPTION
Creates an abstract CredentialsProperty class that is extended by
nested classes in each properties class.