### PR TITLE
No longer set outbound channel adapter to sync in SI code sample

### DIFF
--- a/spring-cloud-gcp-examples/spring-cloud-gcp-integration-pubsub-example/spring-cloud-gcp-integration-pubsub-example-sender/src/main/java/com/example/SenderApplication.java
+++ b/spring-cloud-gcp-examples/spring-cloud-gcp-integration-pubsub-example/spring-cloud-gcp-integration-pubsub-example-sender/src/main/java/com/example/SenderApplication.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -41,7 +41,7 @@ public class SenderApplication {
 
 	@Bean
 	@ServiceActivator(inputChannel = "pubsubOutputChannel")
-	public MessageHandler messageSender(PubSubOperations pubsubTemplate) {
+	public MessageHandler messageSender(PubSubTemplate pubsubTemplate) {
 		return new PubSubMessageHandler(pubsubTemplate, "exampleTopic");
 	}
 

--- a/spring-cloud-gcp-examples/spring-cloud-gcp-integration-pubsub-example/spring-cloud-gcp-integration-pubsub-example-sender/src/main/java/com/example/SenderApplication.java
+++ b/spring-cloud-gcp-examples/spring-cloud-gcp-integration-pubsub-example/spring-cloud-gcp-integration-pubsub-example-sender/src/main/java/com/example/SenderApplication.java
@@ -42,11 +42,7 @@ public class SenderApplication {
 	@Bean
 	@ServiceActivator(inputChannel = "pubsubOutputChannel")
 	public MessageHandler messageSender(PubSubOperations pubsubTemplate) {
-		PubSubMessageHandler outboundAdapter =
-				new PubSubMessageHandler(pubsubTemplate, "exampleTopic");
-		// Lets us see errors if there are any.
-		outboundAdapter.setSync(true);
-		return outboundAdapter;
+		return new PubSubMessageHandler(pubsubTemplate, "exampleTopic");
 	}
 
 	@MessagingGateway(defaultRequestChannel = "pubsubOutputChannel")


### PR DESCRIPTION
With the changes in #178, errors are now logged, even on async mode.