### PR TITLE
Scrubs documentation and adds missing docs for #129

### DIFF
--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
@@ -23,11 +23,11 @@ package org.springframework.cloud.gcp.core;
  */
 public enum GcpScope {
 	PUBSUB("https://www.googleapis.com/auth/pubsub"),
-	SQLADMIN("https://www.googleapis.com/auth/sqlservice.admin"),
 	STORAGE_READ_ONLY("https://www.googleapis.com/auth/devstorage.read_only"),
 	STORAGE_READ_WRITE("https://www.googleapis.com/auth/devstorage.read_write"),
 	RUNTIME_CONFIG_SCOPE("https://www.googleapis.com/auth/cloudruntimeconfig"),
-	TRACE_APPEND("https://www.googleapis.com/auth/trace.append");
+	TRACE_APPEND("https://www.googleapis.com/auth/trace.append"),
+	CLOUD_PLATFORM("https://www.googleapis.com/auth/cloud-platform");
 
 	private String url;
 

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
@@ -23,6 +23,7 @@ package org.springframework.cloud.gcp.core;
  */
 public enum GcpScope {
 	PUBSUB("https://www.googleapis.com/auth/pubsub"),
+	SQLADMIN("https://www.googleapis.com/auth/sqlservice.admin"),
 	STORAGE_READ_ONLY("https://www.googleapis.com/auth/devstorage.read_only"),
 	STORAGE_READ_WRITE("https://www.googleapis.com/auth/devstorage.read_write"),
 	RUNTIME_CONFIG_SCOPE("https://www.googleapis.com/auth/cloudruntimeconfig"),

--- a/spring-cloud-gcp-docs/src/main/asciidoc/core.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/core.adoc
@@ -97,11 +97,11 @@ service supported by Spring Cloud GCP.
 |===
 | Service | Scope
 | Pub/Sub | https://www.googleapis.com/auth/pubsub
-| SQL Admin | https://www.googleapis.com/auth/sqlservice.admin
 | Storage (Read Only) | https://www.googleapis.com/auth/devstorage.read_only
 | Storage (Write/Write) | https://www.googleapis.com/auth/devstorage.read_write
 | Runtime Config | https://www.googleapis.com/auth/cloudruntimeconfig
 | Trace (Append) | https://www.googleapis.com/auth/trace.append
+| Cloud Platform | https://www.googleapis.com/auth/cloud-platform
 |===
 
 The Spring Boot GCP Core starter allows you to configure a custom scope list for the provided

--- a/spring-cloud-gcp-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/index.adoc
@@ -17,6 +17,8 @@ Currently, Spring Cloud GCP lets you leverage the power and simplicity of the Sp
 2. Exchange messages with Spring Integration using Google Cloud Pub/Sub on the background
 3. Write and read from Spring Resources backed up by Google Cloud Storage
 4. Configure Spring JDBC with a few properties to use Google Cloud SQL on the background
+5. Trace the execution of your app with Spring Cloud Sleuth and Google Stackdriver Trace
+6. Configure your app with Spring Cloud Config, backed up by the Google Runtime Configuration API
 
 include::dependency-management.adoc[]
 

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -3,7 +3,7 @@
 Spring Cloud GCP provides a Spring abstraction layer to publish to and subscribe from Google Cloud
 Pub/Sub topics and to create, list or delete Google Cloud Pub/Sub topics and subscriptions.
 
-A Spring Boot starter is provided to auto-configure the various Pub/Sub components.
+A Spring Boot starter is provided to auto-configure the various required Pub/Sub components.
 
 Maven coordinates, using Spring Cloud GCP BOM:
 

--- a/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
@@ -57,7 +57,7 @@ There is also some configuration specific to Google Cloud SQL:
 | Property name | Description | Default value | Unused if specified property(ies)
 | `spring.cloud.gcp.sql.database-type` | The type of database used. Can either be `mysql` or
 `postgresql`. | `mysql` |
-| `spring.cloud.gcp.sql.credential-location` | File system path to the Google OAuth2 credentials
+| `spring.cloud.gcp.sql.credentials-location` | File system path to the Google OAuth2 credentials
 private key file. Used to authenticate and authorize new connections to a Google Cloud SQL instance.
 | default credentials provided by the Spring GCP Core Boot starter |
 | `spring.cloud.gcp.sql.database-name` | Name of the database to connect to. | |

--- a/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
@@ -50,7 +50,7 @@ public List<Map<String, Object>> listUsers() {
 ----
 
 This starter is configured through
-https://github.com/spring-projects/spring-boot/blob/v1.5.8.RELEASE/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java[`DataSourceProperties`].
+https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.html[`DataSourceProperties`].
 There is also some configuration specific to Google Cloud SQL:
 
 |===

--- a/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
@@ -57,14 +57,14 @@ There is also some configuration specific to Google Cloud SQL:
 | Property name | Description | Default value | Unused if specified property(ies)
 | `spring.cloud.gcp.sql.database-type` | The type of database used. Can either be `mysql` or
 `postgresql`. | `mysql` |
-| `spring.cloud.gcp.sql.credentials-location` | File system path to the Google OAuth2 credentials
-private key file. Used to authenticate and authorize new connections to a Google Cloud SQL instance.
-| default credentials provided by the Spring GCP Core Boot starter |
 | `spring.cloud.gcp.sql.database-name` | Name of the database to connect to. | |
 `spring.datasource.url`
 | `spring.cloud.gcp.sql.instance-connection-name` | A string containing a Google Cloud SQL
 instance's project ID, region and name, each separated by a colon. For example,
 `my-project-id:my-region:my-instance-name`. | | `spring.datasource.url`
+| `spring.cloud.gcp.sql.credentials.location` | File system path to the Google OAuth2 credentials
+private key file. Used to authenticate and authorize new connections to a Google Cloud SQL instance.
+| default credentials provided by the Spring GCP Core Boot starter |
 |===
 
 ==== `DataSource` creation flow

--- a/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/sql.adoc
@@ -32,6 +32,8 @@ dependencies {
 === Spring Boot Starter for Google Cloud SQL
 
 The Spring Boot Starter for Google Cloud SQL provides an auto-configured
+https://docs.oracle.com/javase/7/docs/api/javax/sql/DataSource.html[`DataSource`] object.
+Coupled with Spring JDBC, it provides a
 https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html#jdbc-JdbcTemplate[`JdbcTemplate`]
 object bean that allows for operations such as querying and modifying a database.
 
@@ -47,31 +49,25 @@ public List<Map<String, Object>> listUsers() {
 }
 ----
 
-`JdbcTemplate` is configured based on the following properties:
+This starter is configured through
+https://github.com/spring-projects/spring-boot/blob/v1.5.8.RELEASE/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java[`DataSourceProperties`].
+There is also some configuration specific to Google Cloud SQL:
 
 |===
 | Property name | Description | Default value | Unused if specified property(ies)
 | `spring.cloud.gcp.sql.database-type` | The type of database used. Can either be `mysql` or
 `postgresql`. | `mysql` |
-| `spring.cloud.gcp.sql.credentials-location` | File system path to the Google OAuth2 credentials
+| `spring.cloud.gcp.sql.credential-location` | File system path to the Google OAuth2 credentials
 private key file. Used to authenticate and authorize new connections to a Google Cloud SQL instance.
 | default credentials provided by the Spring GCP Core Boot starter |
-| `spring.cloud.gcp.sql.jdbc-url` | The full JDBC URL connection string. | |
-| `spring.cloud.gcp.sql.jdbc-driver` | The JDBC driver class name. |  `com.mysql.jdbc.Driver` for
-MySQL, `org.postgresql.Driver` for PostgreSQL or `com.mysql.jdbc.GoogleDriver` if MySQL is used
-within Google App Engine. |
 | `spring.cloud.gcp.sql.database-name` | Name of the database to connect to. | |
-`spring.cloud.gcp.sql.jdbc-url`
+`spring.datasource.url`
 | `spring.cloud.gcp.sql.instance-connection-name` | A string containing a Google Cloud SQL
 instance's project ID, region and name, each separated by a colon. For example,
-`my-project-id:my-region:my-instance-name`. | | `spring.cloud.gcp.sql.jdbc-url`
-| `spring.cloud.gcp.sql.user-name` | MySQL or PostgreSQL user name. | `root` |
-| `spring.cloud.gcp.sql.password` | MySQL or PostgreSQL password. | empty string |
-| `spring.cloud.gcp.sql.init-fail-fast` | If set to `true`, returns an exception if the minimum
-number of connections could not be created. | `false` |
+`my-project-id:my-region:my-instance-name`. | | `spring.datasource.url`
 |===
 
-==== `JdbcTemplate` creation flow
+==== `DataSource` creation flow
 
 Based on the previous properties, the Spring Boot starter for Google Cloud SQL creates a
 `CloudSqlJdbcInfoProvider` object which is used to obtain an instance's JDBC URL and driver class
@@ -84,18 +80,18 @@ in a system property to be `SqlCredentialFactory`.
 This is especially relevant if you want to provide your own `CloudSqlJdbcInfoProvider` bean, in
 which case you should also register the credentials factory class name under the
 `cloudSql.socketFactory.credentialFactory` system property.
+Otherwise, the
+https://developers.google.com/identity/protocols/application-default-credentials[application
+default credentials] are used by default to connect to Google Cloud SQL.
 
-The `CloudSqlJdbcInfoProvider` bean is used by the starter to create a `DataSource` object.
-This `DataSource` object is picked up by the Spring JDBC module to automatically configure a
-`JdbcTemplate` object.
-We chose HikariCP as the default connection pool implementation, but you're free to provide your own
-`DataSource` implementation using the provided `CloudSqlJdbcInfoProvider` bean to resolve an
-instance's JDBC URL and driver class name.
+`DataSource` creation is delegated to
+https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot].
+You can select the type of connection pool (e.g., Tomcat, HikariCP, etc.) by
+https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[adding
+their dependency to the classpath].
+Prior to `DataSource` creation, if no JDBC URL and/or driver class name are configured,
+they are resolved by a `CloudSqlJdbcInfoProvider` and applied to the `DataSource` configuration.
 
-It is in the `DataSource` creation step that the JDBC driver class is registered.
-This isn't relevant unless you want to provide your own `DataSource` bean, in which case, you should
-load the driver class so that the user doesn't have to.
-
-The result of this flow is a fully configured and operational `JdbcTemplate` object that you can
-use to interact with your SQL database.
+Using the created `DataSource` in conjunction with Spring JDBC provides you with a fully configured
+and operational `JdbcTemplate` object that you can use to interact with your SQL database.
 You can connect to your database with as little as a database and instance names!

--- a/spring-cloud-gcp-examples/spring-cloud-gcp-sql-example/README.adoc
+++ b/spring-cloud-gcp-examples/spring-cloud-gcp-sql-example/README.adoc
@@ -22,7 +22,7 @@ If you set a root password, you should also add a `spring.cloud.gcp.sql.password
 password as the value.
 
 4. https://cloud.google.com/sdk/gcloud/reference/auth/login[Authenticate in the Cloud SDK] or add
-a `spring.cloud.gcp.sql.credentials-location` property with the path on your local file system to
+a `spring.cloud.gcp.sql.credentials.location` property with the path on your local file system to
 a credentials file, prepended with `file:`.
 
 5. Run the `SqlApplication` Spring Boot app. The database will be populated based on the

--- a/spring-cloud-gcp-pubsub/README.adoc
+++ b/spring-cloud-gcp-pubsub/README.adoc
@@ -25,5 +25,5 @@ allows user code to be independent from the underlying Google Cloud Pub/Sub API 
 currently possible to publish messages to a Google Cloud Pub/Sub topic and to create new topics and
 subscriptions.
 
-You can refer to the `PubSubOperations` and `PubSubAdmin` classes for more details on the
+You can refer to the `PubSubTemplate` and `PubSubAdmin` classes for more details on the
 functionality provided by this module.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/README.adoc
@@ -80,8 +80,9 @@ spring.cloud.gcp.config.enabled=true #optional, default = true
 spring.cloud.gcp.config.name=myapp
 spring.cloud.gcp.config.profile=prod
 spring.cloud.gcp.config.timeout=120000 #optional
-spring.cloud.gcp.config.project-id=my-gcp-project-id
-spring.cloud.gcp.config.credentials-location=file:/path/to/my/local/creds.json
+spring.cloud.gcp.config.project-id=my-gcp-project-id #optional
+spring.cloud.gcp.config.credentials.location=file:/path/to/my/local/creds.json #optional
+spring.cloud.gcp.config.credentials.scopes=https://www.googleapis.com/auth/sqlservice.admin #optional
 ....
 +
 The  default value of `spring.cloud.config.profile` is `default`.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
@@ -16,8 +16,11 @@
 
 package org.springframework.cloud.gcp.config;
 
+import java.util.Collections;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.cloud.gcp.core.GcpScope;
 
 /**
  * Configuration for {@link GoogleConfigPropertySourceLocator}.
@@ -89,5 +92,8 @@ public class GcpConfigProperties {
 	}
 
 	public static class Credentials extends AbstractCredentialsProperty {
+		public Credentials() {
+			setScopes(Collections.singletonList(GcpScope.RUNTIME_CONFIG_SCOPE.getUrl()));
+		}
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GoogleConfigPropertySourceLocator.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GoogleConfigPropertySourceLocator.java
@@ -27,7 +27,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.GcpScope;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
@@ -75,10 +74,11 @@ public class GoogleConfigPropertySourceLocator implements PropertySourceLocator 
 		Assert.notNull(credentialsProvider, "Credentials provider cannot be null");
 		Assert.notNull(projectIdProvider, "Project ID provider cannot be null");
 		Assert.notNull(gcpConfigProperties, "Google Config properties must not be null");
+
 		this.credentials = gcpConfigProperties.getCredentials() != null
 				? GoogleCredentials.fromStream(
 						gcpConfigProperties.getCredentials().getLocation().getInputStream())
-				.createScoped(Collections.singletonList(GcpScope.RUNTIME_CONFIG_SCOPE.getUrl()))
+				.createScoped(gcpConfigProperties.getCredentials().getScopes())
 				: credentialsProvider.getCredentials();
 		this.projectId = gcpConfigProperties.getProjectId() != null
 				? gcpConfigProperties.getProjectId()

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/README.adoc
@@ -36,7 +36,7 @@ spring.cloud.gcp.credentials.scopes=[SCOPE_1],[SCOPE_2],[SCOPE_3]
 
 If `spring.cloud.gcp.project-id` is populated, the provided `GcpProjectIdProvider` returns that
 project ID. Otherwise, it uses google-cloud-java's
-http://googlecloudplatform.github.io/google-cloud-java/0.21.1/apidocs/com/google/cloud/ServiceOptions.html#getDefaultProjectId--[rules to discover the project ID].
+http://googlecloudplatform.github.io/google-cloud-java/latest/apidocs/com/google/cloud/ServiceOptions.html#getDefaultProjectId--[rules to discover the project ID].
 
 Similarly for `spring.cloud.gcp.credentials.location`, if a property is configured, the provided
 `CredentialsProvider` returns credentials for that private key. The value of

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/README.adoc
@@ -28,7 +28,8 @@ The following properties are optional:
 spring.cloud.gcp.pubsub.subscriber-executor-threads=[SUBSCRIBER_EXECUTOR_THREADS]
 spring.cloud.gcp.pubsub.publisher-executor-threads=[PUBLISHER_EXECUTOR_THREADS]
 spring.cloud.gcp.pubsub.project-id=[PUBSUB_GCP_PROJECT_ID]
-spring.cloud.gcp.pubsub.credentials-location=[CREDENTIALS_FILESYSTEM_PATH]
+spring.cloud.gcp.pubsub.credentials.location=[CREDENTIALS_FILESYSTEM_PATH]
+spring.cloud.gcp.pubsub.credentials.scopes=[COMMA_DELIMITED_SCOPE_LIST]
 ----
 
 `spring.cloud.gcp.pubsub.subscriber-executor-threads` is the number of threads used by the
@@ -37,7 +38,7 @@ Likewise, `spring.cloud.gcp.pubsub.publisher-executor-threads` is the number of 
 publisher executor.
 The default value for both of these properties is 4.
 
-`spring.cloud.gcp.pubsub.project-id` and `spring.cloud.gcp.pubsub.credentials-location` are
-overrides to the GCP project ID and credentials in the
-link:../spring-cloud-gcp-starter-core/README.adoc[Core Starter], in case the Google Cloud Pub/Sub service is
-hosted from a different GCP project ID.
+`spring.cloud.gcp.pubsub.project-id` and `spring.cloud.gcp.pubsub.credentials.location` and
+`spring.cloud.gcp.pubsub.credentials.scopes` are overrides to the GCP project ID and credentials in
+the link:../spring-cloud-gcp-starter-core/README.adoc[Core Starter], in case the Google Cloud
+Pub/Sub service is hosted from a different GCP project ID.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.gcp.pubsub;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.cloud.gcp.core.GcpScope;
+
+import java.util.Collections;
 
 @ConfigurationProperties("spring.cloud.gcp.pubsub")
 public class GcpPubSubProperties {
@@ -62,5 +65,8 @@ public class GcpPubSubProperties {
 	}
 
 	public static class Credentials extends AbstractCredentialsProperty {
+		public Credentials() {
+			setScopes(Collections.singletonList(GcpScope.PUBSUB.getUrl()));
+		}
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.gcp.pubsub;
 
+import java.util.Collections;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
 import org.springframework.cloud.gcp.core.GcpScope;
-
-import java.util.Collections;
 
 @ConfigurationProperties("spring.cloud.gcp.pubsub")
 public class GcpPubSubProperties {

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.gcp.pubsub.autoconfig;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.Executors;
 
 import com.google.api.gax.core.CredentialsProvider;
@@ -37,7 +36,6 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.GcpScope;
 import org.springframework.cloud.gcp.core.autoconfig.GcpContextAutoConfiguration;
 import org.springframework.cloud.gcp.pubsub.GcpPubSubProperties;
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
@@ -77,7 +77,7 @@ public class GcpPubSubAutoConfiguration {
 				? FixedCredentialsProvider.create(
 						GoogleCredentials.fromStream(
 								gcpPubSubProperties.getCredentials().getLocation().getInputStream())
-								.createScoped(Collections.singletonList(GcpScope.PUBSUB.getUrl())))
+								.createScoped(gcpPubSubProperties.getCredentials().getScopes()))
 				: credentialsProvider;
 	}
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -31,7 +31,7 @@ the starter provides a `CloudSqlJdbcInfoProvider` object that returns the correc
 JDBC URL and driver class name to be used.
 
 The starter uses Spring Boot to
-https://github.com/spring-projects/spring-boot/blob/v1.5.8.RELEASE/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java[configure
+https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.html[configure
 a DataSource].
 `spring.datasource.url` and `spring.datasource.driver-class-name` are automatically configured by
 the provided `CloudSqlJdbcInfoProvider`, unless they are explicitly configured.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -36,7 +36,7 @@ a DataSource].
 `spring.datasource.url` and `spring.datasource.driver-class-name` are automatically configured by
 the provided `CloudSqlJdbcInfoProvider`, unless they are explicitly configured.
 
-The starter requires the following properties:
+The following properties are required:
 
 [source,yaml]
 ----

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -20,17 +20,23 @@ dependencies {
 ----
 
 
-This starter provides the configuration sources: `CloudSqlJdbcInfoProvider` and `DataSource`.
+This starter provides the configuration sources `CloudSqlJdbcInfoProvider` and `DataSource`.
 
-It allows connections to second-generation only Google Cloud SQL instances.
+It only allows connections to second-generation Google Cloud SQL instances.
 
 Before using the starter, ensure that the Google Cloud SQL API is enabled in your GCP project.
 
-`CloudSqlJdbcInfoProvider` returns the JDBC information to be used, such as the JDBC driver name
-and connection string. A special `CloudSqlJdbcInfoProvider` is provided if an app is running on
-Google App Engine.
+Based on your environment (e.g., Google App Engine) or database type (e.g., MySQL, PostgreSQL),
+the starter provides a `CloudSqlJdbcInfoProvider` object that returns the correct values for the
+JDBC URL and driver class name to be used.
 
-`CloudSqlJdbcInfoProvider` requires the following properties:
+The starter uses Spring Boot to
+https://github.com/spring-projects/spring-boot/blob/v1.5.8.RELEASE/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java[configure
+a DataSource].
+`spring.datasource.url` and `spring.datasource.driver-class-name` are automatically configured by
+the provided `CloudSqlJdbcInfoProvider`, unless they are explicitly configured.
+
+The starter requires the following properties:
 
 [source,yaml]
 ----
@@ -40,31 +46,14 @@ spring.cloud.gcp.sql.instance-connection-name=[YOUR_CLOUD_SQL_INSTANCE_CONNECTIO
 
 `spring.cloud.gcp.sql.instance-connection-name` is your instance's
 https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql#google-cloud-sql-instance-connection-name[connection name].
-You can alternatively specify the full `spring.cloud.gcp.sql.jdbc-url`.
 
 The following properties are optional:
 
 [source,yaml]
 ----
-spring.cloud.gcp.sql.jdbc-url=[YOUR_JDBC_URL]
-spring.cloud.gcp.sql.jdbc-driver=[YOUR_JDBC_DRIVER]
-spring.cloud.gcp.sql.user-name=[YOUR_CLOUD_SQL_USERNAME]
-spring.cloud.gcp.sql.password=[YOUR_CLOUD_SQL_PASSWORD]
 spring.cloud.gcp.sql.database-type=[mysql or postgresql]
 spring.cloud.gcp.sql.credentials-location=[CREDENTIALS_FILESYSTEM_PATH]
 ----
-
-If `spring.cloud.gcp.sql.jdbc-url` is specified, it is used as the final JDBC URL and has precedence
-over `spring.cloud.gcp.sql.instance-connection-name`.
-
-If `spring.cloud.gcp.sql.jdbc-driver` isn't specified, `com.mysql.jdbc.Driver` is used if
-`spring.cloud.gcp.sql.database-type` is `mysql`, `org.postgresql.Driver` if
-`spring.cloud.gcp.sql.database-type` is `postgresql` or `com.mysql.jdbc.GoogleDriver` if running on
-Google App Engine.
-
-If `spring.cloud.gcp.sql.user-name` isn't specified, `root` is used by default.
-
-If `spring.cloud.gcp.sql.password` isn't specified, an empty string is used by default.
 
 `spring.cloud.gcp.sql.database-type` can either be `mysql` or `postgresql`. Any value that isn't
 those two will cause the configuration to error. `spring.cloud.gcp.sql.database-type` determines if
@@ -79,11 +68,6 @@ https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.
 it's possible to inject a fully configured `JdbcTemplate` object only from adding the required
 properties.
 
-The returned `DataSource` is an implementation of
-https://brettwooldridge.github.io/HikariCP/[HikariCP]. If you want to use another kind of
-`DataSource`, feel free to use the provided `CloudSqlJdbcInfoProvider` to provide your own
-`DataSource` bean.
-
 === Google Cloud SQL Instance Connection Name
 
 A Google Cloud SQL instance connection name is a string comprised of three elements:
@@ -96,8 +80,8 @@ You can find your instance's connection name in its Google Cloud Console page.
 
 If you're not able to connect to a database and see an endless loop of
 `Connecting to Cloud SQL instance [...] on IP [...]`, it's likely that exceptions are being thrown
-and logged at a level lower than your logger's level. This may be the case with HikariCP, the
-default DataSource used by this starter, if your logger is set to INFO or higher level.
+and logged at a level lower than your logger's level. This may be the case with HikariCP, if your
+logger is set to INFO or higher level.
 
 To see what's going on in the background, you should add a `logback.xml` file to your application
 resources folder, that looks like this:
@@ -135,8 +119,8 @@ To fix this, re-declare the dependency in its correct version. For example, in M
 This is usually a symptom that something isn't right with the permissions of your credentials or the Google Cloud SQL API is not enabled. Verify that the Google Cloud SQL API is enabled in the Cloud Console and that your service account has the
 https://cloud.google.com/sql/docs/mysql/project-access-control#roles[necessary IAM roles].
 
-To find out what's causing the issue, you can enable DEBUG logging level at HikariCP by adding the
-following logback.xml file to your application's resources, or only add the relevant set log level
+To find out what's causing the issue, you can enable DEBUG logging level by adding the following
+logback.xml file to your application's resources, or only add the relevant set log level
 line if you already have one logback.xml file:
 
 [source, xml]

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/README.adoc
@@ -52,14 +52,14 @@ The following properties are optional:
 [source,yaml]
 ----
 spring.cloud.gcp.sql.database-type=[mysql or postgresql]
-spring.cloud.gcp.sql.credentials-location=[CREDENTIALS_FILESYSTEM_PATH]
+spring.cloud.gcp.sql.credentials.location=[CREDENTIALS_FILESYSTEM_PATH]
 ----
 
 `spring.cloud.gcp.sql.database-type` can either be `mysql` or `postgresql`. Any value that isn't
 those two will cause the configuration to error. `spring.cloud.gcp.sql.database-type` determines if
 the resolved JDBC URL and driver class are for MySQL or PostgreSQL.
 
-`spring.cloud.gcp.sql.credentials-location` can be used to specify credentials for a GCP project ID
+`spring.cloud.gcp.sql.credentials.location` can be used to specify credentials for a GCP project ID
 different than the one configured in the link:../spring-cloud-gcp-starter-core/README.adoc[Core
 Starter].
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
@@ -70,7 +70,7 @@ public class GcpCloudSqlProperties {
 		private Resource location;
 
 		public Resource getLocation() {
-			return location;
+			return this.location;
 		}
 
 		public void setLocation(Resource location) {

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/GcpCloudSqlProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.gcp.sql;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.core.io.Resource;
 
 /**
  * Google Cloud SQL properties.
@@ -66,6 +66,15 @@ public class GcpCloudSqlProperties {
 		this.databaseType = databaseType;
 	}
 
-	public static class Credentials extends AbstractCredentialsProperty {
+	public static class Credentials {
+		private Resource location;
+
+		public Resource getLocation() {
+			return location;
+		}
+
+		public void setLocation(Resource location) {
+			this.location = location;
+		}
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
@@ -60,7 +60,7 @@ public class SqlCredentialFactory implements CredentialFactory {
 
 		try {
 			return GoogleCredential.fromStream(new FileInputStream(credentialResourceLocation))
-					.createScoped(Collections.singleton(GcpScope.CLOUD_PLATFORM.getUrl()));
+					.createScoped(Collections.singleton(GcpScope.SQLADMIN.getUrl()));
 		}
 		catch (IOException ioe) {
 			LOGGER.warn("There was an error loading Cloud SQL credential.", ioe);

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql/src/main/java/org/springframework/cloud/gcp/sql/SqlCredentialFactory.java
@@ -60,7 +60,7 @@ public class SqlCredentialFactory implements CredentialFactory {
 
 		try {
 			return GoogleCredential.fromStream(new FileInputStream(credentialResourceLocation))
-					.createScoped(Collections.singleton(GcpScope.SQLADMIN.getUrl()));
+					.createScoped(Collections.singleton(GcpScope.CLOUD_PLATFORM.getUrl()));
 		}
 		catch (IOException ioe) {
 			LOGGER.warn("There was an error loading Cloud SQL credential.", ioe);

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/README.adoc
@@ -25,8 +25,13 @@ bean to be used by an end-user.
 
 [options="header",]
 |=======================================================================
-|Setting |Optional |Default Value |Meaning
-|`spring.cloud.gcp.storage.credentials-location`|Yes|Configured in the link:../spring-cloud-gcp-starter-core/README.adoc[Core Starter]|the
-filesystem path for a credentials file
-|`spring.cloud.gcp.storage.auto-create-files`|Yes|`true`|If `true`, new file will be created at given URL if none exists when getting output stream
+| Setting | Optional | Default Value | Meaning
+| `spring.cloud.gcp.storage.credentials.location` | Yes | Location of the credentials for the
+Storage service, if different from those in the
+link:../spring-cloud-gcp-starter-core/README.adoc[Core Starter] | the filesystem path for a
+credentials private key file
+| `spring.cloud.gcp.storage.credentials.scopes` | Yes | List of scopes for this service-specific
+credentials |
+| `spring.cloud.gcp.storage.auto-create-files` | Yes | `true` | If `true`, new file will be created
+at given URL if none exists when getting output stream
 |=======================================================================

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.gcp.storage;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.cloud.gcp.core.GcpScope;
+
+import java.util.Collections;
 
 /**
  * @author João André Martins
@@ -36,5 +39,8 @@ public class GcpStorageProperties extends GoogleStorageProtocolResolverSettings 
 	}
 
 	public static class Credentials extends AbstractCredentialsProperty {
+		public Credentials() {
+			setScopes(Collections.singletonList(GcpScope.STORAGE_READ_WRITE.getUrl()));
+		}
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.gcp.storage;
 
+import java.util.Collections;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
 import org.springframework.cloud.gcp.core.GcpScope;
-
-import java.util.Collections;
 
 /**
  * @author João André Martins

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.gcp.storage.autoconfig;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -28,7 +27,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.core.GcpProperties;
-import org.springframework.cloud.gcp.core.GcpScope;
 import org.springframework.cloud.gcp.storage.GcpStorageProperties;
 import org.springframework.cloud.gcp.storage.GoogleStorageProtocolResolver;
 import org.springframework.cloud.gcp.storage.GoogleStorageProtocolResolverSettings;

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
@@ -61,8 +61,7 @@ public class StorageAutoConfiguration {
 						? GoogleCredentials
 								.fromStream(gcpStorageProperties.getCredentials()
 										.getLocation().getInputStream())
-								.createScoped(Collections.singletonList(
-										GcpScope.STORAGE_READ_WRITE.getUrl()))
+								.createScoped(gcpStorageProperties.getCredentials().getScopes())
 						: credentialsProvider.getCredentials())
 				.build().getService();
 	}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/README.adoc
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/README.adoc
@@ -22,7 +22,7 @@ dependencies {
 This starter uses Spring Cloud Sleuth and provides a `SpanReporter` that sends the Sleuth's trace information to Stackdriver Trace.
 
 All configurations are optional. You can override a number of default configuration values in addition to the core
-`spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials-location`.
+`spring.cloud.gcp.project-id` and `spring.cloud.gcp.credentials.location`.
 
 By default, this starter will send trace asynchronously using a flushable trace consumer that auto-flushes when
 its buffered trace messages exceed its buffer size or have been buffered for longer than its scheduled delay.
@@ -45,7 +45,8 @@ spring.cloud.gcp.trace.scheduled-delay-seconds=[SCHEDULED_DELAY_SECONDS]
 spring.cloud.gcp.trace.project-id=[TRACE_GCP_PROJECT_ID]
 
 # Credentials for the trace service
-spring.cloud.gcp.trace.credentials-location=[CREDENTIALS_FILESYSTEM_LOCATION]
+spring.cloud.gcp.trace.credentials.location=[CREDENTIALS_FILESYSTEM_LOCATION]
+spring.cloud.gcp.trace.credentials.scope=[COMMA_DELIMITED_SCOPE_LIST]
 ----
 
 You can use core Spring Cloud Sleuth properties to control Sleuth's sampling rate, etc.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.cloud.gcp.trace;
 
+import java.util.Collections;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
 import org.springframework.cloud.gcp.core.GcpScope;
-
-import java.util.Collections;
 
 /**
  * Stackdriver Trace Properties.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
@@ -17,6 +17,9 @@ package org.springframework.cloud.gcp.trace;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.cloud.gcp.core.GcpScope;
+
+import java.util.Collections;
 
 /**
  * Stackdriver Trace Properties.
@@ -106,5 +109,8 @@ public class GcpTraceProperties {
 	}
 
 	public static class Credentials extends AbstractCredentialsProperty {
+		public Credentials() {
+			setScopes(Collections.singletonList(GcpScope.TRACE_APPEND.getUrl()));
+		}
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/autoconfig/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/autoconfig/StackdriverTraceAutoConfiguration.java
@@ -89,7 +89,7 @@ public class StackdriverTraceAutoConfiguration {
 		this.finalCredentialsProvider = gcpTraceProperties.getCredentials() != null
 				? FixedCredentialsProvider.create(GoogleCredentials.fromStream(
 						gcpTraceProperties.getCredentials().getLocation().getInputStream())
-				.createScoped(Collections.singletonList(GcpScope.TRACE_APPEND.getUrl())))
+				.createScoped(gcpTraceProperties.getCredentials().getScopes()))
 				: credentialsProvider;
 	}
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/autoconfig/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/autoconfig/StackdriverTraceAutoConfiguration.java
@@ -17,7 +17,6 @@ package org.springframework.cloud.gcp.trace.autoconfig;
 
 import java.io.IOException;
 import java.security.SecureRandom;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Executors;
@@ -43,7 +42,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.commons.util.IdUtils;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.GcpScope;
 import org.springframework.cloud.gcp.trace.GcpTraceProperties;
 import org.springframework.cloud.gcp.trace.TraceServiceClientTraceConsumer;
 import org.springframework.cloud.gcp.trace.sleuth.LabelExtractor;


### PR DESCRIPTION
This change also replaces the SQL Admin OAuth scope by the generic
Cloud Platform one.