### PR TITLE
Set BOM parent to a RELEASE version

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
-		<version>1.3.3.BUILD-SNAPSHOT</version>
+		<version>1.3.5.RELEASE</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
We can rely on Spring Cloud to select spring-cloud version dependencies
for us.