### PR TITLE
Adds support for creating relative files for GCS

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -142,7 +142,9 @@ public class GoogleStorageResource implements WritableResource {
 
 	@Override
 	public Resource createRelative(String relativePath) throws IOException {
-		throw new UnsupportedOperationException("Directory creation not supported");
+		int lastSlashIndex = this.location.lastIndexOf("/");
+		String absolutePath = this.location.substring(0, lastSlashIndex + 1) + relativePath;
+		return new GoogleStorageResource(this.storage, absolutePath);
 	}
 
 	@Override

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gcp.storage;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.OutputStream;
 
 import com.google.cloud.WriteChannel;
@@ -155,6 +156,24 @@ public class GoogleStorageTests {
 		Storage storage = Mockito.mock(Storage.class);
 		GoogleStorageResource resource = new GoogleStorageResource(storage, location);
 		Assert.assertTrue(resource.isCreateBlobIfNotExists());
+	}
+
+	@Test
+	public void testCreateRelative() throws IOException {
+		String location = "gs://test-spring/test.png";
+		Storage storage = Mockito.mock(Storage.class);
+		GoogleStorageResource resource = new GoogleStorageResource(storage, location);
+		GoogleStorageResource relative = (GoogleStorageResource) resource.createRelative("relative.png");
+		Assert.assertEquals("gs://test-spring/relative.png", relative.getURI().toString());
+	}
+
+	@Test
+	public void testCreateRelativeSubdirs() throws IOException {
+		String location = "gs://test-spring/t1/test.png";
+		Storage storage = Mockito.mock(Storage.class);
+		GoogleStorageResource resource = new GoogleStorageResource(storage, location);
+		GoogleStorageResource relative = (GoogleStorageResource) resource.createRelative("r1/relative.png");
+		Assert.assertEquals("gs://test-spring/t1/r1/relative.png", relative.getURI().toString());
 	}
 
 	@Configuration


### PR DESCRIPTION
GoogleStorageResource.createRelative(String) now works to
create files in the same bucket or logical directory as another
resource.

Fixes #193.