### PR TITLE
Uses google-cloud-bom to retrieve versions for google-cloud-java artifacts

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,13 +16,10 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<google-cloud-core.version>1.2.3</google-cloud-core.version>
-		<google-cloud-pubsub.version>0.28.0-beta</google-cloud-pubsub.version>
-		<google-cloud-trace.version>0.28.0-beta</google-cloud-trace.version>
-		<google-cloud-storage.version>1.11.0</google-cloud-storage.version>
 		<cloud-trace-java.version>0.5.0</cloud-trace-java.version>
 		<spring-cloud-context.version>1.2.3.RELEASE</spring-cloud-context.version>
 		<spring-cloud-sleuth.version>1.2.5.RELEASE</spring-cloud-sleuth.version>
+		<google-cloud-bom.version>0.32.0-alpha</google-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>
@@ -51,26 +48,6 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-integration-gcp</artifactId>
 				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.cloud</groupId>
-				<artifactId>google-cloud-core</artifactId>
-				<version>${google-cloud-core.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.cloud</groupId>
-				<artifactId>google-cloud-pubsub</artifactId>
-				<version>${google-cloud-pubsub.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.cloud</groupId>
-				<artifactId>google-cloud-storage</artifactId>
-				<version>${google-cloud-storage.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.cloud</groupId>
-				<artifactId>google-cloud-trace</artifactId>
-				<version>${google-cloud-trace.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.cloud.trace.v1</groupId>
@@ -161,13 +138,6 @@
 				<version>${spring-cloud-context.version}</version>
 			</dependency>
 
-			<!-- spring-cloud-gcp-pubsub -->
-			<dependency>
-				<groupId>com.google.api</groupId>
-				<artifactId>gax</artifactId>
-				<version>1.14.0</version>
-			</dependency>
-
 			<!--Starters-->
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -198,6 +168,15 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-gcp-starter-trace</artifactId>
 				<version>${project.version}</version>
+			</dependency>
+
+			<!--google-cloud-java BOM-->
+			<dependency>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>google-cloud-bom</artifactId>
+				<version>${google-cloud-bom.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
This way, we're guaranteed to have a set of versions that work well with
each other.

Fixes #257