### PR TITLE
Polish credentials configuration

### DIFF
--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/Credentials.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/Credentials.java
@@ -16,27 +16,26 @@
 
 package org.springframework.cloud.gcp.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.core.io.Resource;
 
 /**
- * To be extended by property class subclasses and allow e.g., a "credentials.location" property
- * notation.
+ * Credentials configuration
  *
  * @author João Andre Martins
+ * @author Stephane Nicoll
  */
-public abstract class AbstractCredentialsProperty {
+public class Credentials {
+
+	private List<String> scopes = new ArrayList<>();
 
 	private Resource location;
-	private List<String> scopes;
 
-	public Resource getLocation() {
-		return this.location;
-	}
-
-	public void setLocation(Resource location) {
-		this.location = location;
+	public Credentials(String... defaultScopes) {
+		this.scopes.addAll(Arrays.asList(defaultScopes));
 	}
 
 	public List<String> getScopes() {
@@ -46,4 +45,13 @@ public abstract class AbstractCredentialsProperty {
 	public void setScopes(List<String> scopes) {
 		this.scopes = scopes;
 	}
+
+	public Resource getLocation() {
+		return this.location;
+	}
+
+	public void setLocation(Resource location) {
+		this.location = location;
+	}
+
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GcpConfigProperties.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.gcp.config;
 
-import java.util.Collections;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.cloud.gcp.core.Credentials;
 import org.springframework.cloud.gcp.core.GcpScope;
 
 /**
@@ -41,7 +40,8 @@ public class GcpConfigProperties {
 
 	private String projectId;
 
-	private Credentials credentials;
+	@NestedConfigurationProperty
+	private final Credentials credentials = new Credentials(GcpScope.RUNTIME_CONFIG_SCOPE.getUrl());
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
@@ -87,13 +87,4 @@ public class GcpConfigProperties {
 		return this.credentials;
 	}
 
-	public void setCredentials(Credentials credentials) {
-		this.credentials = credentials;
-	}
-
-	public static class Credentials extends AbstractCredentialsProperty {
-		public Credentials() {
-			setScopes(Collections.singletonList(GcpScope.RUNTIME_CONFIG_SCOPE.getUrl()));
-		}
-	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GoogleConfigPropertySourceLocator.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/src/main/java/org/springframework/cloud/gcp/config/GoogleConfigPropertySourceLocator.java
@@ -76,7 +76,7 @@ public class GoogleConfigPropertySourceLocator implements PropertySourceLocator 
 		if (gcpConfigProperties.isEnabled()) {
 			Assert.notNull(credentialsProvider, "Credentials provider cannot be null");
 			Assert.notNull(projectIdProvider, "Project ID provider cannot be null");
-			this.credentials = gcpConfigProperties.getCredentials() != null
+			this.credentials = gcpConfigProperties.getCredentials().getLocation() != null
 					? GoogleCredentials.fromStream(
 					gcpConfigProperties.getCredentials().getLocation().getInputStream())
 					.createScoped(gcpConfigProperties.getCredentials().getScopes())

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/GcpProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gcp.core;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * @author Vinicius Carvalho
@@ -27,7 +28,8 @@ public class GcpProperties {
 
 	private String projectId;
 
-	private Credentials credentials = new Credentials();
+	@NestedConfigurationProperty
+	private final Credentials credentials = new Credentials();
 
 	public String getProjectId() {
 		return this.projectId;
@@ -41,10 +43,4 @@ public class GcpProperties {
 		return this.credentials;
 	}
 
-	public void setCredentials(Credentials credentials) {
-		this.credentials = credentials;
-	}
-
-	public static class Credentials extends AbstractCredentialsProperty {
-	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpContextAutoConfiguration.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.core.GoogleCredentialsProvider;
-import com.google.auth.Credentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -40,12 +39,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.gcp.core.Credentials;
 import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.GcpProperties;
 import org.springframework.cloud.gcp.core.GcpScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -74,8 +75,8 @@ public class GcpContextAutoConfiguration {
 	private GcpProperties gcpProperties;
 
 	protected List<String> resolveScopes() {
-		GcpProperties.Credentials propertyCredentials = this.gcpProperties.getCredentials();
-		if (propertyCredentials != null && propertyCredentials.getScopes() != null) {
+		Credentials propertyCredentials = this.gcpProperties.getCredentials();
+		if (!ObjectUtils.isEmpty(propertyCredentials.getScopes())) {
 			Set<String> resolvedScopes = new HashSet<>();
 			propertyCredentials.getScopes().forEach(scope -> {
 				if (DEFAULT_SCOPES_PLACEHOLDER.equals(scope)) {
@@ -97,12 +98,11 @@ public class GcpContextAutoConfiguration {
 	public CredentialsProvider googleCredentials() throws Exception {
 		CredentialsProvider credentialsProvider;
 
-		GcpProperties.Credentials propertyCredentials = this.gcpProperties.getCredentials();
+		Credentials propertyCredentials = this.gcpProperties.getCredentials();
 
 		List<String> scopes = resolveScopes();
 
-		if (propertyCredentials != null
-				&& !StringUtils.isEmpty(propertyCredentials.getLocation())) {
+		if (!StringUtils.isEmpty(propertyCredentials.getLocation())) {
 			credentialsProvider = FixedCredentialsProvider
 					.create(GoogleCredentials.fromStream(
 							propertyCredentials.getLocation().getInputStream())
@@ -115,7 +115,7 @@ public class GcpContextAutoConfiguration {
 		}
 
 		try {
-			Credentials credentials = credentialsProvider.getCredentials();
+			com.google.auth.Credentials credentials = credentialsProvider.getCredentials();
 
 			if (LOGGER.isInfoEnabled()) {
 				if (credentials instanceof UserCredentials) {

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/GcpPubSubProperties.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.gcp.pubsub;
 
-import java.util.Collections;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.cloud.gcp.core.Credentials;
 import org.springframework.cloud.gcp.core.GcpScope;
 
 @ConfigurationProperties("spring.cloud.gcp.pubsub")
@@ -30,7 +29,8 @@ public class GcpPubSubProperties {
 
 	private String projectId;
 
-	private Credentials credentials;
+	@NestedConfigurationProperty
+	private final Credentials credentials = new Credentials(GcpScope.PUBSUB.getUrl());
 
 	public int getSubscriberExecutorThreads() {
 		return this.subscriberExecutorThreads;
@@ -60,13 +60,4 @@ public class GcpPubSubProperties {
 		return this.credentials;
 	}
 
-	public void setCredentials(Credentials credentials) {
-		this.credentials = credentials;
-	}
-
-	public static class Credentials extends AbstractCredentialsProperty {
-		public Credentials() {
-			setScopes(Collections.singletonList(GcpScope.PUBSUB.getUrl()));
-		}
-	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/autoconfig/GcpPubSubAutoConfiguration.java
@@ -72,7 +72,7 @@ public class GcpPubSubAutoConfiguration {
 		this.finalProjectIdProvider = gcpPubSubProperties.getProjectId() != null
 				? gcpPubSubProperties::getProjectId
 				: gcpProjectIdProvider;
-		this.finalCredentialsProvider = gcpPubSubProperties.getCredentials() != null
+		this.finalCredentialsProvider = gcpPubSubProperties.getCredentials().getLocation() != null
 				? FixedCredentialsProvider.create(
 						GoogleCredentials.fromStream(
 								gcpPubSubProperties.getCredentials().getLocation().getInputStream())

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/GcpStorageProperties.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.gcp.storage;
 
-import java.util.Collections;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.cloud.gcp.core.Credentials;
 import org.springframework.cloud.gcp.core.GcpScope;
 
 /**
@@ -28,19 +27,11 @@ import org.springframework.cloud.gcp.core.GcpScope;
 @ConfigurationProperties("spring.cloud.gcp.storage")
 public class GcpStorageProperties extends GoogleStorageProtocolResolverSettings {
 
-	private Credentials credentials;
+	@NestedConfigurationProperty
+	private final Credentials credentials  = new Credentials(GcpScope.STORAGE_READ_WRITE.getUrl());
 
 	public Credentials getCredentials() {
 		return this.credentials;
 	}
 
-	public void setCredentials(Credentials credentials) {
-		this.credentials = credentials;
-	}
-
-	public static class Credentials extends AbstractCredentialsProperty {
-		public Credentials() {
-			setScopes(Collections.singletonList(GcpScope.STORAGE_READ_WRITE.getUrl()));
-		}
-	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/src/main/java/org/springframework/cloud/gcp/storage/autoconfig/StorageAutoConfiguration.java
@@ -55,7 +55,7 @@ public class StorageAutoConfiguration {
 	public static Storage storage(CredentialsProvider credentialsProvider,
 			GcpStorageProperties gcpStorageProperties) throws IOException {
 		return StorageOptions.newBuilder()
-				.setCredentials(gcpStorageProperties.getCredentials() != null
+				.setCredentials(gcpStorageProperties.getCredentials().getLocation() != null
 						? GoogleCredentials
 								.fromStream(gcpStorageProperties.getCredentials()
 										.getLocation().getInputStream())

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/GcpTraceProperties.java
@@ -15,10 +15,9 @@
  */
 package org.springframework.cloud.gcp.trace;
 
-import java.util.Collections;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.gcp.core.AbstractCredentialsProperty;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.cloud.gcp.core.Credentials;
 import org.springframework.cloud.gcp.core.GcpScope;
 
 /**
@@ -52,7 +51,8 @@ public class GcpTraceProperties {
 
 	private String projectId;
 
-	private Credentials credentials;
+	@NestedConfigurationProperty
+	private final Credentials credentials = new Credentials(GcpScope.TRACE_APPEND.getUrl());
 
 	/**
 	 * A utility method to determine x% of total memory based on Zipkin's AsyncReporter.
@@ -104,13 +104,4 @@ public class GcpTraceProperties {
 		return this.credentials;
 	}
 
-	public void setCredentials(Credentials credentials) {
-		this.credentials = credentials;
-	}
-
-	public static class Credentials extends AbstractCredentialsProperty {
-		public Credentials() {
-			setScopes(Collections.singletonList(GcpScope.TRACE_APPEND.getUrl()));
-		}
-	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/autoconfig/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/src/main/java/org/springframework/cloud/gcp/trace/autoconfig/StackdriverTraceAutoConfiguration.java
@@ -84,7 +84,7 @@ public class StackdriverTraceAutoConfiguration {
 		this.finalProjectIdProvider = gcpTraceProperties.getProjectId() != null
 				? gcpTraceProperties::getProjectId
 				: gcpProjectIdProvider;
-		this.finalCredentialsProvider = gcpTraceProperties.getCredentials() != null
+		this.finalCredentialsProvider = gcpTraceProperties.getCredentials().getLocation() != null
 				? FixedCredentialsProvider.create(GoogleCredentials.fromStream(
 						gcpTraceProperties.getCredentials().getLocation().getInputStream())
 				.createScoped(gcpTraceProperties.getCredentials().getScopes()))


### PR DESCRIPTION
This commit renames AbstractCredentialsProperty to Credentials and offer
a way to initialize it with default scopes. Rather than creating a class
just for the purpose of setting them, all configuration properties
simply reuse the class now.

Also, this commit fixes a potential bug as we were previously relying on
the fact that the Credentials object was initialized when a property was
set. Arguably, we could initialize it by setting a scope (and not a
location, leading to a NPE).

Finally, this commit generates proper metadata for the credentials
sub-namespaces.