### PR TITLE
Polish

### DIFF
--- a/spring-cloud-gcp-examples/spring-cloud-gcp-config-example/README.adoc
+++ b/spring-cloud-gcp-examples/spring-cloud-gcp-config-example/README.adoc
@@ -18,10 +18,10 @@ Then set the variables that your application will load:
 +
 ....
   gcloud beta runtime-config configs variables set \
-queue_size 25 \
+myapp.queue-size 25 \
 --config-name myapp_prod
   gcloud beta runtime-config configs variables set \
-feature_x_enabled true \
+myapp.feature-x-enabled true \
 --config-name myapp_prod
 ....
 
@@ -32,21 +32,13 @@ spring.cloud.gcp.config.enabled=true #optional, default = true
 spring.cloud.gcp.config.name=myapp
 spring.cloud.gcp.config.profile=prod #default profile = default
 ....
-5.  Notice the Spring-managed configuration variables in
-link:src/main/java/com/example/SampleConfig.java[SampleConfig.java].
-+
-....
-@Value("${queue_size}")
-private int queueSize;
-
-@Value("${feature_x_enabled}")
-private boolean isFeatureXEnabled;
-....
+5.  Notice that link:src/main/java/com/example/MyAppProperties.java[MyAppProperties.java]
+uses `@ConfigurationProperties` to bind the `myapp` namespace from the environment.
 6.  Update a property with `gcloud`:
 +
 ....
   gcloud beta runtime-config configs variables set \
-     queue_size 200 \
+     myapp.queue-size 200 \
      --config-name myapp_prod
 ....
 7.  Send a POST request to the `/refresh` endpoint:

--- a/spring-cloud-gcp-examples/spring-cloud-gcp-config-example/src/main/java/com/example/Application.java
+++ b/spring-cloud-gcp-examples/spring-cloud-gcp-config-example/src/main/java/com/example/Application.java
@@ -18,6 +18,7 @@ package com.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 /**
 * Sample spring boot application.
@@ -25,6 +26,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 * @author Jisha Abubaker
 */
 @SpringBootApplication
+@EnableConfigurationProperties(MyAppProperties.class)
 public class Application {
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);

--- a/spring-cloud-gcp-examples/spring-cloud-gcp-config-example/src/main/java/com/example/HelloController.java
+++ b/spring-cloud-gcp-examples/spring-cloud-gcp-config-example/src/main/java/com/example/HelloController.java
@@ -16,7 +16,6 @@
 
 package com.example;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,8 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HelloController {
 
-	@Autowired
-	SampleConfig sampleConfig;
+	private final MyAppProperties sampleConfig;
+
+	public HelloController(MyAppProperties sampleConfig) {
+		this.sampleConfig = sampleConfig;
+	}
 
 	@RequestMapping("/")
 	public String index() {

--- a/spring-cloud-gcp-examples/spring-cloud-gcp-config-example/src/main/java/com/example/MyAppProperties.java
+++ b/spring-cloud-gcp-examples/spring-cloud-gcp-config-example/src/main/java/com/example/MyAppProperties.java
@@ -16,22 +16,21 @@
 
 package com.example;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Sample Configuration class with property values loaded using the Runtime Configurator API.
+ *
  * @author Jisha Abubaker
+ * @author Stephane Nicoll
  */
 @RefreshScope
-@Configuration
-public class SampleConfig {
+@ConfigurationProperties("myapp")
+public class MyAppProperties {
 
-	@Value("${queue_size}")
 	private int queueSize;
 
-	@Value("${feature_x_enabled}")
 	private boolean isFeatureXEnabled;
 
 	public int getQueueSize() {


### PR DESCRIPTION
This commit changes the config example to use @ConfigurationProperties
rather than @Value. Spring Boot users are more familiar with the former
and it is the recommended way to bind properties from the Environment.