### PR TITLE
Adds spring-boot-starter to all Spring Cloud GCP Boot starters

### DIFF
--- a/spring-cloud-gcp-starters/pom.xml
+++ b/spring-cloud-gcp-starters/pom.xml
@@ -27,11 +27,4 @@
 		<module>spring-cloud-gcp-starter-sql</module>
 		<module>spring-cloud-gcp-starter-trace</module>
 	</modules>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-	</dependencies>
 </project>

--- a/spring-cloud-gcp-starters/pom.xml
+++ b/spring-cloud-gcp-starters/pom.xml
@@ -27,4 +27,11 @@
 		<module>spring-cloud-gcp-starter-sql</module>
 		<module>spring-cloud-gcp-starter-trace</module>
 	</modules>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/pom.xml
@@ -44,5 +44,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/pom.xml
@@ -42,11 +42,6 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
As recommended in https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-custom-starter-module-starter