### PR TITLE
Make GcpConfig configuration explicitly bootstrap

### DIFF
--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -43,11 +43,10 @@ Configuration's Spring profile (e.g., prod) | Yes | `default`
 | `spring.cloud.gcp.config.timeout-millis` | Timeout in milliseconds for connecting to the Google
 Runtime Configuration API | Yes | `60000`
 | `spring.cloud.gcp.config.project-id` | GCP project ID where the Google Runtime Configuration API
-is hosted, if different from the one in the <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>>
+is hosted
 | Yes |
 | `spring.cloud.gcp.config.credentials.location` | OAuth2 credentials for authenticating with the
-Google Runtime Configuration API, if different from the ones in the
-<<spring-cloud-gcp-core,Spring Cloud GCP Core Module>> | Yes |
+Google Runtime Configuration API | Yes |
 | `spring.cloud.gcp.config.credentials.scopes` |
 https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Cloud GCP
 Config credentials | Yes | https://www.googleapis.com/auth/cloudruntimeconfig
@@ -56,6 +55,9 @@ Config credentials | Yes | https://www.googleapis.com/auth/cloudruntimeconfig
 NOTE: These properties should be specified in a
 http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context[`bootstrap.yml`/`bootstrap.properties`]
 file, rather than the usual `applications.yml`/`application.properties`.
+
+NOTE: Also note that core properties as described in <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>>
+do not apply to Spring Cloud GCP Config.
 
 === Quick start
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 original author or authors.
+ *  Copyright 2017-2018 original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,29 +22,27 @@ import com.google.api.gax.core.CredentialsProvider;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
-import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
+import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 /**
  * Bootstrap auto configuration for Google Cloud Runtime Configurator Starter.
  *
  * @author Jisha Abubaker
  * @author João André Martins
+ * @author Mike Eltsufin
  */
 @Configuration
-@Import(GcpContextAutoConfiguration.class)
 @EnableConfigurationProperties(GcpConfigProperties.class)
 public class GcpConfigBootstrapConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(prefix = "spring.cloud.gcp.config", name = "enabled", havingValue = "true")
-	public GoogleConfigPropertySourceLocator googleConfigPropertySourceLocator(GcpProjectIdProvider projectIdProvider,
-			CredentialsProvider credentialsProvider,
+	public GoogleConfigPropertySourceLocator googleConfigPropertySourceLocator(CredentialsProvider credentialsProvider,
 			GcpConfigProperties configProperties) throws IOException {
-		return new GoogleConfigPropertySourceLocator(projectIdProvider, credentialsProvider, configProperties);
+		return new GoogleConfigPropertySourceLocator(new DefaultGcpProjectIdProvider(), credentialsProvider,
+				configProperties);
 	}
 }
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigBootstrapConfiguration.java
@@ -20,13 +20,13 @@ import java.io.IOException;
 
 import com.google.api.gax.core.CredentialsProvider;
 
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * Bootstrap auto configuration for Google Cloud Runtime Configurator Starter.
@@ -35,9 +35,9 @@ import org.springframework.context.annotation.Configuration;
  * @author João André Martins
  */
 @Configuration
-@AutoConfigureAfter(GcpContextAutoConfiguration.class)
+@Import(GcpContextAutoConfiguration.class)
 @EnableConfigurationProperties(GcpConfigProperties.class)
-public class GcpConfigAutoConfiguration {
+public class GcpConfigBootstrapConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(prefix = "spring.cloud.gcp.config", name = "enabled", havingValue = "true")

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironment.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironment.java
@@ -52,7 +52,7 @@ class GoogleConfigEnvironment {
 		return config;
 	}
 
-	private static class Variable {
+	static class Variable {
 
 		private String name;
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 original author or authors.
+ *  Copyright 2017-2018 original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import com.google.auth.oauth2.UserCredentials;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.core.Credentials;
@@ -55,7 +54,6 @@ import org.springframework.util.StringUtils;
  * @author João André Martins
  */
 @Configuration
-@ConditionalOnClass(GoogleCredentials.class)
 @EnableConfigurationProperties(GcpProperties.class)
 public class GcpContextAutoConfiguration {
 	private static final String DEFAULT_SCOPES_PLACEHOLDER = "DEFAULT_SCOPES";

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -7,6 +7,4 @@ org.springframework.cloud.gcp.autoconfigure.storage.GcpStorageAutoConfiguration,
 org.springframework.cloud.gcp.autoconfigure.trace.StackdriverTraceAutoConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
-org.springframework.cloud.gcp.autoconfigure.config.GcpConfigAutoConfiguration,\
-org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration,\
-org.springframework.cloud.gcp.autoconfigure.config.GoogleConfigPropertySourceLocator
+org.springframework.cloud.gcp.autoconfigure.config.GcpConfigBootstrapConfiguration

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigBootstrapConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigBootstrapConfigurationTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertFalse;
 /**
  * @author Jisha Abubaker
  */
-public class GcpConfigAutoConfigurationTest {
+public class GcpConfigBootstrapConfigurationTest {
 	private AnnotationConfigApplicationContext context;
 
 	@After
@@ -66,7 +66,7 @@ public class GcpConfigAutoConfigurationTest {
 	private void loadEnvironment(String... environment) {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 		TestPropertyValues.of(environment).applyTo(context);
-		context.register(GcpConfigAutoConfiguration.class);
+		context.register(GcpConfigBootstrapConfiguration.class);
 		context.refresh();
 		this.context = context;
 	}


### PR DESCRIPTION
It isn't AutoConfiguration so it shouldn't use those features.
There is a remaining potential issue to do with
GcpProperties (there might be 2 instances, one in bootstrap
and one in the main context, or maybe that's not an issue). Also
possibly an issue: the bootstrap configuration requires
GoogleCredentials, but isn't conditional on that class. It isn't
an issue if that class is always available, but then if it is,
why is GcpContextAutoConfiguration conditional on it?