### PR TITLE
Turns on the Pub/Sub emulator from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ install:
   - tar -xvzf google-cloud-sdk-189.0.0-linux-x86_64.tar.gz
   - export PATH=$PWD/google-cloud-sdk/bin:$PATH
   - gcloud components update --quiet
-  - gcloud components install beta --quiet
-  - gcloud components install pubsub-emulator --quiet
-script:
+  - gcloud components install beta pubsub-emulator --quiet
+before_script:
   - gcloud beta emulators pubsub start &
   - $(gcloud beta emulators pubsub env-init)
+#script:
+#  - ./mvnw clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - export PATH=$PWD/google-cloud-sdk/bin:$PATH
   - gcloud components update --quiet
   - gcloud components install beta pubsub-emulator --quiet
+  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_script:
   - gcloud beta emulators pubsub start &
   - $(gcloud beta emulators pubsub env-init)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,14 @@ jdk:
 branches:
   only:
     - master
+install:
+  # Install Cloud SDK
+  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-189.0.0-linux-x86_64.tar.gz
+  - tar -xvzf google-cloud-sdk-189.0.0-linux-x86_64.tar.gz
+  - export PATH=$PWD/google-cloud-sdk/bin:$PATH
+  - gcloud components update --quiet
+  - gcloud components install beta --quiet
+  - gcloud components install pubsub-emulator --quiet
+script:
+  - gcloud beta emulators pubsub start &
+  - $(gcloud beta emulators pubsub env-init)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,3 @@ install:
 before_script:
   - gcloud beta emulators pubsub start &
   - $(gcloud beta emulators pubsub env-init)
-#script:
-#  - ./mvnw clean install


### PR DESCRIPTION
This PR installs the Google Cloud SDK along with the Pub/Sub emulator,
starts the emulator in a separate process and then sets the required
environment variables so that the integration tests pick it up and run.