### PR TITLE
Waits for Pub/Sub emulator to create its aux files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
   - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_script:
   - gcloud beta emulators pubsub start &
+  - while [ ! -f ~/.config/gcloud/emulators/pubsub/env.yaml ]; do sleep 1; done
   - $(gcloud beta emulators pubsub env-init)


### PR DESCRIPTION
Should fix "(gcloud.beta.emulators.pubsub.env-init) Unable to find
 env.yaml in the data_dir
 [/home/travis/.config/gcloud/emulators/pubsub].
 Please ensure you have started the appropriate emulator."