### PR TITLE
Adding paging

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerOperations.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerOperations.java
@@ -17,12 +17,15 @@
 package org.springframework.cloud.gcp.data.spanner.core;
 
 import java.util.List;
+import java.util.OptionalLong;
 
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Statement;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 /**
@@ -98,6 +101,33 @@ public interface SpannerOperations {
 	 * empty list is returned.
 	 */
 	<T> List<T> findAll(Class<T> entityClass, Sort sort, Options.QueryOption... options);
+
+	/**
+	 * Finds all objects of the given type.
+	 * @param entityClass the type of the object to retrieve.
+	 * @param sort the sorting used for the results.
+	 * @param limit the number of elements to get at maximum.
+	 * @param offset the number of elements to skip from the beginning according to the
+	 * sort.
+	 * @param options Spanner query options with which to conduct the query operation.
+	 * @param <T> the type of the object to retrieve.
+	 * @return a list of all objects stored of the given type. If there are no objects an
+	 * empty list is returned.
+	 */
+	<T> List<T> findAll(Class<T> entityClass, Sort sort, OptionalLong limit,
+			OptionalLong offset, Options.QueryOption... options);
+
+	/**
+	 * Finds all objects of the given type.
+	 * @param entityClass the type of the object to retrieve.
+	 * @param pageable the paging options for this request.
+	 * @param options Spanner query options with which to conduct the query operation.
+	 * @param <T> the type of the object to retrieve.
+	 * @return a list of all objects stored of the given type. If there are no objects an
+	 * empty list is returned.
+	 */
+	<T> Page<T> findAll(Class<T> entityClass, Pageable pageable,
+			Options.QueryOption... options);
 
 	/**
 	 * Deletes an object based on a key.

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryImpl.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryImpl.java
@@ -127,7 +127,6 @@ public class SpannerRepositoryImpl implements SpannerRepository {
 
 	@Override
 	public Page findAll(Pageable pageable) {
-		throw new UnsupportedOperationException(
-				"Retrieving all entities in pages is not currently supported");
+		return this.spannerOperations.findAll(this.entityType, pageable);
 	}
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryImplTests.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.KeySet;
 import org.junit.Test;
 
 import org.springframework.cloud.gcp.data.spanner.core.SpannerOperations;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -164,6 +165,14 @@ public class SpannerRepositoryImplTests {
 		Sort sort = mock(Sort.class);
 		new SpannerRepositoryImpl(operations, Object.class).findAll(sort);
 		verify(operations, times(1)).findAll(eq(Object.class), same(sort));
+	}
+
+	@Test
+	public void findAllPageableTest() {
+		SpannerOperations operations = mock(SpannerOperations.class);
+		Pageable pageable = mock(Pageable.class);
+		new SpannerRepositoryImpl(operations, Object.class).findAll(pageable);
+		verify(operations, times(1)).findAll(eq(Object.class), same(pageable));
 	}
 
 	@Test


### PR DESCRIPTION
Added paging. Each page is a separate query with offset and limit. getting neighbor pages depends on the state of the DB at that time (not at the time of the very first-retrieved page), just like in the other spring-data projects (jpa and mongo, (jdbc is actually just a crud repo, not paging and sorting)). 