### PR TITLE
Fixes issue with Pub/Sub inbound CA payload

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -85,7 +85,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 							? MessageBuilder.withPayload(pubsubMessage.getData().toByteArray())
 							.copyHeaders(messageHeaders)
 							.build()
-							: this.messageConverter.toMessage(pubsubMessage.getData().toByteArray(),
+							: this.messageConverter.toMessage(pubsubMessage.getData().toStringUtf8(),
 							new MessageHeaders(messageHeaders));
 
 			sendMessage(internalMessage);


### PR DESCRIPTION
The string message converter cannot convert from a byte array. This
PR reverts to the status when the channel adapter was working.