### PR TITLE
Close the ResultSet

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplate.java
@@ -199,10 +199,12 @@ public class SpannerTemplate implements SpannerOperations {
 	public long count(Class entityClass) {
 		SpannerPersistentEntity<?> persistentEntity = this.mappingContext
 				.getPersistentEntity(entityClass);
-		ResultSet resultSet = this.databaseClient.singleUse().executeQuery(Statement.of(
-				String.format("select count(*) from %s", persistentEntity.tableName())));
-		resultSet.next();
-		return resultSet.getLong(0);
+		Statement statement = Statement.of(String.format(
+				"select count(*) from %s", persistentEntity.tableName()));
+		try (ResultSet resultSet = this.databaseClient.singleUse().executeQuery(statement)) {
+			resultSet.next();
+			return resultSet.getLong(0);
+		}
 	}
 
 	private <T, U> void applyMutationWithClass(BiFunction<T, U, Mutation> function,

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateTests.java
@@ -256,6 +256,7 @@ public class SpannerTemplateTests {
 		this.spannerTemplate.count(TestEntity.class);
 		verify(results, times(1)).next();
 		verify(results, times(1)).getLong(eq(0));
+		verify(results, times(1)).close();
 	}
 
 	@Test


### PR DESCRIPTION
This commit makes sure that the `ResultSet` internally created by `count` is closed.