### PR TITLE
Upgrade to Google Cloud bom 0.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
 				<artifactId>logback-json-classic</artifactId>
 				<version>0.1.5</version>
 			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>20.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<google-cloud-bom.version>0.33.0-alpha</google-cloud-bom.version>
+		<google-cloud-bom.version>0.38.0-alpha</google-cloud-bom.version>
 		<cloud-trace-java.version>0.5.0</cloud-trace-java.version>
 	</properties>
 
@@ -174,23 +174,6 @@
 						<artifactId>guava</artifactId>
 					</exclusion>
 				</exclusions>
-			</dependency>
-
-			<!-- google-cloud-logging-logback is not in the google-cloud-java BOM yet -->
-			<!-- See: https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2745 -->
-			<dependency>
-				<groupId>com.google.cloud</groupId>
-				<artifactId>google-cloud-logging-logback</artifactId>
-				<version>0.32.0-alpha</version>
-			</dependency>
-
-			<!-- google-cloud-bom is setting the version of netty-tcnative-boringssl-static which is incompatible
-			with SB2.
-			Remove when https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2781 is resolved. -->
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-tcnative-boringssl-static</artifactId>
-				<version>2.0.7.Final</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
@@ -22,18 +22,17 @@ import java.util.List;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
-import com.google.cloud.pubsub.v1.PagedResponseWrappers;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import com.google.common.collect.Lists;
 import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
-import com.google.pubsub.v1.SubscriptionName;
 import com.google.pubsub.v1.Topic;
-import com.google.pubsub.v1.TopicName;
 
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.util.Assert;
@@ -93,7 +92,8 @@ public class PubSubAdmin {
 	public Topic createTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		return this.topicAdminClient.createTopic(TopicName.of(this.projectId, topicName));
+		return this.topicAdminClient.createTopic(ProjectTopicName.of(this.projectId,
+				topicName));
 	}
 
 	/**
@@ -106,7 +106,8 @@ public class PubSubAdmin {
 		Assert.hasText(topicName, "No topic name was specified.");
 
 		try {
-			return this.topicAdminClient.getTopic(TopicName.of(this.projectId, topicName));
+			return this.topicAdminClient.getTopic(ProjectTopicName.of(this.projectId,
+					topicName));
 		}
 		catch (ApiException aex) {
 			if (aex.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
@@ -125,7 +126,7 @@ public class PubSubAdmin {
 	public void deleteTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		this.topicAdminClient.deleteTopic(TopicName.of(this.projectId, topicName));
+		this.topicAdminClient.deleteTopic(ProjectTopicName.of(this.projectId, topicName));
 	}
 
 	/**
@@ -134,7 +135,7 @@ public class PubSubAdmin {
 	 * <p>If there are multiple pages, they will all be merged into the same result.
 	 */
 	public List<Topic> listTopics() {
-		PagedResponseWrappers.ListTopicsPagedResponse topicListPage =
+		TopicAdminClient.ListTopicsPagedResponse topicListPage =
 				this.topicAdminClient.listTopics(ProjectName.of(this.projectId));
 
 		return Lists.newArrayList(topicListPage.iterateAll());
@@ -208,8 +209,8 @@ public class PubSubAdmin {
 		}
 
 		return this.subscriptionAdminClient.createSubscription(
-				SubscriptionName.of(this.projectId, subscriptionName),
-				TopicName.of(this.projectId, topicName),
+				ProjectSubscriptionName.of(this.projectId, subscriptionName),
+				ProjectTopicName.of(this.projectId, topicName),
 				pushConfigBuilder.build(),
 				finalAckDeadline);
 	}
@@ -225,7 +226,7 @@ public class PubSubAdmin {
 
 		try {
 			return this.subscriptionAdminClient.getSubscription(
-					SubscriptionName.of(this.projectId, subscriptionName));
+					ProjectSubscriptionName.of(this.projectId, subscriptionName));
 		}
 		catch (ApiException aex) {
 			if (aex.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
@@ -245,7 +246,7 @@ public class PubSubAdmin {
 		Assert.hasText(subscriptionName, "No subscription name was specified");
 
 		this.subscriptionAdminClient.deleteSubscription(
-				SubscriptionName.of(this.projectId, subscriptionName));
+				ProjectSubscriptionName.of(this.projectId, subscriptionName));
 	}
 
 	/**
@@ -254,7 +255,7 @@ public class PubSubAdmin {
 	 * <p>If there are multiple pages, they will all be merged into the same result.
 	 */
 	public List<Subscription> listSubscriptions() {
-		PagedResponseWrappers.ListSubscriptionsPagedResponse subscriptionsPage =
+		SubscriptionAdminClient.ListSubscriptionsPagedResponse subscriptionsPage =
 				this.subscriptionAdminClient.listSubscriptions(ProjectName.of(this.projectId));
 
 		return Lists.newArrayList(subscriptionsPage.iterateAll());

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -28,7 +28,7 @@ import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.ProjectTopicName;
 
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.cloud.gcp.pubsub.core.PubSubException;
@@ -124,7 +124,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 		return this.publishers.computeIfAbsent(topic, key -> {
 			try {
 				Publisher.Builder publisherBuilder =
-						Publisher.newBuilder(TopicName.of(this.projectId, key));
+						Publisher.newBuilder(ProjectTopicName.of(this.projectId, key));
 
 				if (this.executorProvider != null) {
 					publisherBuilder.setExecutorProvider(this.executorProvider);

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactory.java
@@ -27,11 +27,11 @@ import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PullRequest;
-import com.google.pubsub.v1.SubscriptionName;
 import org.threeten.bp.Duration;
 
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
@@ -153,7 +153,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 	@Override
 	public Subscriber createSubscriber(String subscriptionName, MessageReceiver receiver) {
 		Subscriber.Builder subscriberBuilder = Subscriber.newBuilder(
-				SubscriptionName.of(this.projectId, subscriptionName), receiver);
+				ProjectSubscriptionName.of(this.projectId, subscriptionName), receiver);
 
 		if (this.channelProvider != null) {
 			subscriberBuilder.setChannelProvider(this.channelProvider);
@@ -196,8 +196,8 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 		Assert.hasLength(subscriptionName, "The subscription name must be provided.");
 
 		PullRequest.Builder pullRequestBuilder =
-				PullRequest.newBuilder().setSubscription(
-						SubscriptionName.of(this.projectId, subscriptionName).toString());
+				PullRequest.newBuilder().setSubscription(ProjectSubscriptionName.of(
+						this.projectId, subscriptionName).toString());
 
 		if (maxMessages != null) {
 			pullRequestBuilder.setMaxMessages(maxMessages);
@@ -212,8 +212,8 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 
 	@Override
 	public SubscriberStub createSubscriberStub(RetrySettings retrySettings) {
-		SubscriptionAdminSettings.Builder subscriptionAdminSettingsBuilder =
-				SubscriptionAdminSettings.newBuilder();
+		SubscriberStubSettings.Builder subscriptionAdminSettingsBuilder =
+				SubscriberStubSettings.newBuilder();
 
 		if (this.credentialsProvider != null) {
 			subscriptionAdminSettingsBuilder.setCredentialsProvider(this.credentialsProvider);


### PR DESCRIPTION
This commit upgrades to the latest Google Cloud bom. As that bom does
not provide dependency management for third party librarires, overrides
can be removed.

Also, as Guava isn't managed anymore, this project chooses a Guava
version for internal use.