### PR TITLE
Improves the SQL and JPA code sample text

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/README.adoc
@@ -24,14 +24,15 @@ step 1.
 +
 If you set a root password, add the `spring.datasource.password` property with the root password as the value.
 
-5. https://cloud.google.com/sdk/gcloud/reference/auth/login[If
-you are authenticated in the Cloud SDK], your project ID and credentials will be automatically found
-by the Spring Boot Starter for Google Cloud SQL.
+5. https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If
+you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring
+Boot Starter for Google Cloud SQL.
 +
-Alternatively, uncomment the `spring.cloud.gcp.sql.project-id` and
-`spring.cloud.gcp.sql.credentials.location` properties in the
-link:src/main/resources/application.properties file and fill the values with your project ID and
-the path to your service account credentials on your local file system, prepended with `file:`.
+Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account
+from the Google Cloud Console] and download its private key.
+Then, uncomment the `spring.cloud.gcp.sql.credentials.location` property in the
+link:src/main/resources/application.properties file and fill its value with the path to your service
+account private key on your local file system, prepended with `file:`.
 
 == Running the application
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/README.adoc
@@ -25,14 +25,15 @@ step 1.
 If you set a root password, add the `spring.datasource.password` property with the root password as the value.
 
 
-5. https://cloud.google.com/sdk/gcloud/reference/auth/login[If
-you are authenticated in the Cloud SDK], your project ID and credentials will be automatically found
-by the Spring Boot Starter for Google Cloud SQL.
+5. https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If
+you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring
+Boot Starter for Google Cloud SQL.
 +
-Alternatively, uncomment the `spring.cloud.gcp.sql.project-id` and
-`spring.cloud.gcp.sql.credentials.location` properties in the
-link:src/main/resources/application.properties file and fill the values with your project ID and
-the path to your service account credentials on your local file system, prepended with `file:`.
+Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account
+from the Google Cloud Console] and download its private key.
+Then, uncomment the `spring.cloud.gcp.sql.credentials.location` property in the
+link:src/main/resources/application.properties file and fill its value with the path to your service
+account private key on your local file system, prepended with `file:`.
 
 == Running the application
 


### PR DESCRIPTION
Adds link to ADC credentials instead of regular auth.
Removes project ID property, which isn't used in Cloud SQL integration.