### PR TITLE
Adds Spanner SpEL expressions for table name

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerMappingContext.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerMappingContext.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gcp.data.spanner.core.mapping;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerMappingContext.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerMappingContext.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.gcp.data.spanner.core.mapping;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.Property;
@@ -24,17 +28,21 @@ import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.TypeInformation;
 
 /**
- * A mapping context for Google Spanner that provides ways to create persistent entities and properties.
+ * A mapping context for Google Spanner that provides ways to create persistent entities
+ * and properties.
  *
  * @author Ray Tsang
  * @author Chengyuan Zhao
  */
 public class SpannerMappingContext extends
-		AbstractMappingContext<SpannerPersistentEntity<?>, SpannerPersistentProperty> {
+		AbstractMappingContext<SpannerPersistentEntity<?>, SpannerPersistentProperty> implements
+		ApplicationContextAware {
 
 	private static final FieldNamingStrategy DEFAULT_NAMING_STRATEGY = PropertyNameFieldNamingStrategy.INSTANCE;
 
 	private FieldNamingStrategy fieldNamingStrategy = DEFAULT_NAMING_STRATEGY;
+
+	private ApplicationContext applicationContext;
 
 	public SpannerMappingContext() {
 
@@ -61,6 +69,16 @@ public class SpannerMappingContext extends
 	@Override
 	protected <T> SpannerPersistentEntity<T> createPersistentEntity(
 			TypeInformation<T> typeInformation) {
+		SpannerPersistentEntityImpl<T> persistentEntity = constructPersistentEntity(typeInformation);
+		if (this.applicationContext != null) {
+			persistentEntity.setApplicationContext(this.applicationContext);
+		}
+		return persistentEntity;
+	}
+
+	@VisibleForTesting
+	protected <T> SpannerPersistentEntityImpl<T> constructPersistentEntity(
+			TypeInformation<T> typeInformation) {
 		return new SpannerPersistentEntityImpl<>(typeInformation);
 	}
 
@@ -69,5 +87,10 @@ public class SpannerMappingContext extends
 			SpannerPersistentEntity<?> owner, SimpleTypeHolder simpleTypeHolder) {
 		return new SpannerPersistentPropertyImpl(property, owner, simpleTypeHolder,
 				this.fieldNamingStrategy);
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
 	}
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerPersistentEntity.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerPersistentEntity.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gcp.data.spanner.core.mapping;
 
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.mapping.model.MutablePersistentEntity;
 
 /**
@@ -26,7 +27,7 @@ import org.springframework.data.mapping.model.MutablePersistentEntity;
  * @author Chengyuan Zhao
  */
 public interface SpannerPersistentEntity<T>
-		extends MutablePersistentEntity<T, SpannerPersistentProperty> {
+		extends MutablePersistentEntity<T, SpannerPersistentProperty>, ApplicationContextAware {
 
 	/**
 	 * Gets the name of the Spanner table.

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerMappingContextTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerMappingContextTests.java
@@ -19,13 +19,21 @@ package org.springframework.cloud.gcp.data.spanner.core.mapping;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.cloud.gcp.data.spanner.test.Trade;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * @author Chengyuan Zhao
@@ -49,4 +57,40 @@ public class SpannerMappingContextTests {
 		context.setFieldNamingStrategy(strat);
 		assertSame(strat, context.getFieldNamingStrategy());
 	}
+
+	@Test
+	public void testApplicationContextPassing() {
+		SpannerPersistentEntityImpl mockEntity = mock(SpannerPersistentEntityImpl.class);
+		SpannerMappingContext context = createSpannerMappingContextWith(mockEntity);
+		ApplicationContext applicationContext = mock(ApplicationContext.class);
+		context.setApplicationContext(applicationContext);
+
+		context.createPersistentEntity(mock(TypeInformation.class));
+
+		verify(mockEntity, times(1)).setApplicationContext(eq(applicationContext));
+	}
+
+
+	@Test
+	public void testApplicationContextIsNotSet() {
+		SpannerPersistentEntityImpl mockEntity = mock(SpannerPersistentEntityImpl.class);
+		SpannerMappingContext context = createSpannerMappingContextWith(mockEntity);
+
+		context.createPersistentEntity(mock(TypeInformation.class));
+
+		verifyZeroInteractions(mockEntity);
+	}
+
+
+	private SpannerMappingContext createSpannerMappingContextWith(
+			SpannerPersistentEntityImpl mockEntity) {
+		return new SpannerMappingContext() {
+			@Override
+			protected <T> SpannerPersistentEntityImpl<T> constructPersistentEntity(
+					TypeInformation<T> typeInformation) {
+				return mockEntity;
+			}
+		};
+	}
+
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerMappingContextTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerMappingContextTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.gcp.data.spanner.core.mapping;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.springframework.cloud.gcp.data.spanner.test.Trade;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
@@ -30,7 +29,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;


### PR DESCRIPTION
With this change, the user can resolve table names based on Spring Expression Langauage. For example to resolve `applicationContext` bean values: 

````
@SpannerTable("#{'table_'.concat(postfix)}")
class Pojo {
}
````

Will resolve `tableName()` to `"table_1234"` if the value of `postfix` bean is `"1234"` in the current Spring application context. 