### PR TITLE
Set NoCredentialsProvider on tests configuration

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfiguration.java
@@ -53,10 +53,4 @@ public class GcpPubSubEmulatorConfiguration {
 				.build();
 		return FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
 	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	public CredentialsProvider credentialsProvider() {
-		return NoCredentialsProvider.create();
-	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.gcp.autoconfigure.pubsub;
 
-import com.google.api.gax.core.CredentialsProvider;
-import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfigurationTests.java
@@ -26,9 +26,11 @@ import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 
 /**
  * @author Andreas Berger
+ * @author João André Martins
  */
 public class GcpPubSubEmulatorConfigurationTests {
 
@@ -37,7 +39,8 @@ public class GcpPubSubEmulatorConfigurationTests {
 					"spring.cloud.gcp.projectId=test-project")
 			.withConfiguration(AutoConfigurations.of(GcpPubSubEmulatorConfiguration.class,
 					GcpContextAutoConfiguration.class,
-					GcpPubSubAutoConfiguration.class));
+					GcpPubSubAutoConfiguration.class))
+			.withUserConfiguration(NoCredentialsTestConfiguration.class);
 
 	@Test
 	public void testEmulatorConfig() {
@@ -52,4 +55,11 @@ public class GcpPubSubEmulatorConfigurationTests {
 		});
 	}
 
+	static class NoCredentialsTestConfiguration {
+
+		@Bean
+		public CredentialsProvider noCredentialsProvider() {
+			return new NoCredentialsProvider();
+		}
+	}
 }


### PR DESCRIPTION
Previously, if an app used Pub/Sub and another service that requires
credentials, using the emulator would prevent credentials to be normally
passed to that service.