### PR TITLE
Renamed to SimpleSpannerRepository so it isn't detected as bean

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/config/SpannerRepositoryConfigurationExtension.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/config/SpannerRepositoryConfigurationExtension.java
@@ -16,9 +16,15 @@
 
 package org.springframework.cloud.gcp.data.spanner.repository.config;
 
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Collections;
+
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.cloud.gcp.data.spanner.core.mapping.Table;
+import org.springframework.cloud.gcp.data.spanner.repository.SpannerRepository;
 import org.springframework.cloud.gcp.data.spanner.repository.support.SpannerRepositoryFactoryBean;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.data.config.ParsingUtils;
@@ -53,6 +59,16 @@ public class SpannerRepositoryConfigurationExtension
 		builder.addPropertyReference("spannerMappingContext",
 				attributes.getString("spannerMappingContextRef"));
 
+	}
+
+	@Override
+	protected Collection<Class<? extends Annotation>> getIdentifyingAnnotations() {
+		return Collections.singleton(Table.class);
+	}
+
+	@Override
+	protected Collection<Class<?>> getIdentifyingTypes() {
+		return Collections.singleton(SpannerRepository.class);
 	}
 
 	@Override

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SimpleSpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SimpleSpannerRepository.java
@@ -31,13 +31,13 @@ import org.springframework.util.Assert;
 /**
  * @author Chengyuan Zhao
  */
-public class SpannerRepositoryImpl<T> implements SpannerRepository<T> {
+public class SimpleSpannerRepository<T> implements SpannerRepository<T> {
 
 	private final SpannerOperations spannerOperations;
 
 	private final Class entityType;
 
-	public SpannerRepositoryImpl(SpannerOperations spannerOperations, Class entityType) {
+	public SimpleSpannerRepository(SpannerOperations spannerOperations, Class entityType) {
 		Assert.notNull(spannerOperations,
 				"A valid SpannerOperations object is required.");
 		Assert.notNull(entityType, "A valid entity type is required.");

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryFactory.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryFactory.java
@@ -82,7 +82,7 @@ public class SpannerRepositoryFactory extends RepositoryFactorySupport {
 
 	@Override
 	protected Class<?> getRepositoryBaseClass(RepositoryMetadata metadata) {
-		return SpannerRepositoryImpl.class;
+		return SimpleSpannerRepository.class;
 	}
 
 	@Override

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryFactoryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryFactoryTests.java
@@ -84,16 +84,16 @@ public class SpannerRepositoryFactoryTests {
 	public void getTargetRepositoryTest() {
 		RepositoryInformation repoInfo = mock(RepositoryInformation.class);
 		when(repoInfo.getRepositoryBaseClass())
-				.thenReturn((Class) SpannerRepositoryImpl.class);
+				.thenReturn((Class) SimpleSpannerRepository.class);
 		when(repoInfo.getDomainType()).thenReturn((Class) TestEntity.class);
 		Object repo = this.spannerRepositoryFactory.getTargetRepository(repoInfo);
-		assertEquals(SpannerRepositoryImpl.class, repo.getClass());
+		assertEquals(SimpleSpannerRepository.class, repo.getClass());
 	}
 
 	@Test
 	public void getRepositoryBaseClassTest() {
 		Class baseClass = this.spannerRepositoryFactory.getRepositoryBaseClass(null);
-		assertEquals(SpannerRepositoryImpl.class, baseClass);
+		assertEquals(SimpleSpannerRepository.class, baseClass);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryImplTests.java
@@ -48,59 +48,59 @@ public class SpannerRepositoryImplTests {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorNullSpannerOperationsTest() {
-		new SpannerRepositoryImpl(null, Object.class);
+		new SimpleSpannerRepository(null, Object.class);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorNullEntityTypeTest() {
-		new SpannerRepositoryImpl(mock(SpannerOperations.class), null);
+		new SimpleSpannerRepository(mock(SpannerOperations.class), null);
 	}
 
 	@Test
 	public void getSpannerOperationsTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
-		assertSame(operations, new SpannerRepositoryImpl(operations, Object.class)
+		assertSame(operations, new SimpleSpannerRepository(operations, Object.class)
 				.getSpannerOperations());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void saveNullObjectTest() {
-		new SpannerRepositoryImpl(mock(SpannerOperations.class), Object.class).save(null);
+		new SimpleSpannerRepository(mock(SpannerOperations.class), Object.class).save(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void findNullIdTest() {
-		new SpannerRepositoryImpl(mock(SpannerOperations.class), Object.class)
+		new SimpleSpannerRepository(mock(SpannerOperations.class), Object.class)
 				.findById(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void existsNullIdTest() {
-		new SpannerRepositoryImpl(mock(SpannerOperations.class), Object.class)
+		new SimpleSpannerRepository(mock(SpannerOperations.class), Object.class)
 				.existsById(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void deleteNullIdTest() {
-		new SpannerRepositoryImpl(mock(SpannerOperations.class), Object.class)
+		new SimpleSpannerRepository(mock(SpannerOperations.class), Object.class)
 				.deleteById(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void deleteNullEntityTest() {
-		new SpannerRepositoryImpl(mock(SpannerOperations.class), Object.class)
+		new SimpleSpannerRepository(mock(SpannerOperations.class), Object.class)
 				.delete(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void deleteAllNullEntityTest() {
-		new SpannerRepositoryImpl(mock(SpannerOperations.class), Object.class)
+		new SimpleSpannerRepository(mock(SpannerOperations.class), Object.class)
 				.deleteAll(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void saveAllNullEntityTest() {
-		new SpannerRepositoryImpl(mock(SpannerOperations.class), Object.class)
+		new SimpleSpannerRepository(mock(SpannerOperations.class), Object.class)
 				.saveAll(null);
 	}
 
@@ -108,7 +108,7 @@ public class SpannerRepositoryImplTests {
 	public void saveTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
 		Object ob = new Object();
-		assertEquals(ob, new SpannerRepositoryImpl(operations, Object.class).save(ob));
+		assertEquals(ob, new SimpleSpannerRepository(operations, Object.class).save(ob));
 		verify(operations, times(1)).upsert(eq(ob));
 	}
 
@@ -117,7 +117,7 @@ public class SpannerRepositoryImplTests {
 		SpannerOperations operations = mock(SpannerOperations.class);
 		Object ob = new Object();
 		Object ob2 = new Object();
-		Iterable<Object> ret = new SpannerRepositoryImpl(operations, Object.class)
+		Iterable<Object> ret = new SimpleSpannerRepository(operations, Object.class)
 				.saveAll(Arrays.asList(ob, ob2));
 		assertThat(ret, containsInAnyOrder(ob, ob2));
 		verify(operations, times(1)).upsert(eq(ob));
@@ -131,7 +131,7 @@ public class SpannerRepositoryImplTests {
 		Object ret = new Object();
 		when(operations.find(eq(Object.class), eq(key))).thenReturn(ret);
 		assertEquals(ret,
-				new SpannerRepositoryImpl(operations, Object.class).findById(key).get());
+				new SimpleSpannerRepository(operations, Object.class).findById(key).get());
 		verify(operations, times(1)).find(eq(Object.class), eq(key));
 	}
 
@@ -141,7 +141,7 @@ public class SpannerRepositoryImplTests {
 		Key key = Key.of("key");
 		Object ret = new Object();
 		when(operations.find(eq(Object.class), eq(key))).thenReturn(ret);
-		assertTrue(new SpannerRepositoryImpl(operations, Object.class).existsById(key));
+		assertTrue(new SimpleSpannerRepository(operations, Object.class).existsById(key));
 	}
 
 	@Test
@@ -149,14 +149,14 @@ public class SpannerRepositoryImplTests {
 		SpannerOperations operations = mock(SpannerOperations.class);
 		when(operations.find(eq(Object.class), (Key) any())).thenReturn(null);
 		assertFalse(
-				new SpannerRepositoryImpl(operations, Object.class)
+				new SimpleSpannerRepository(operations, Object.class)
 						.existsById(Key.of("key")));
 	}
 
 	@Test
 	public void findAllTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
-		new SpannerRepositoryImpl(operations, Object.class).findAll();
+		new SimpleSpannerRepository(operations, Object.class).findAll();
 		verify(operations, times(1)).findAll(eq(Object.class));
 	}
 
@@ -164,7 +164,7 @@ public class SpannerRepositoryImplTests {
 	public void findAllSortTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
 		Sort sort = mock(Sort.class);
-		new SpannerRepositoryImpl(operations, Object.class).findAll(sort);
+		new SimpleSpannerRepository(operations, Object.class).findAll(sort);
 		verify(operations, times(1)).findAll(eq(Object.class), same(sort));
 	}
 
@@ -172,7 +172,7 @@ public class SpannerRepositoryImplTests {
 	public void findAllPageableTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
 		Pageable pageable = mock(Pageable.class);
-		new SpannerRepositoryImpl(operations, Object.class).findAll(pageable);
+		new SimpleSpannerRepository(operations, Object.class).findAll(pageable);
 		verify(operations, times(1)).findAll(eq(Object.class), same(pageable));
 	}
 
@@ -185,14 +185,14 @@ public class SpannerRepositoryImplTests {
 					containsInAnyOrder(Key.of("key2"), Key.of("key1")));
 			return null;
 		});
-		new SpannerRepositoryImpl(operations, Object.class)
+		new SimpleSpannerRepository(operations, Object.class)
 				.findAllById(Arrays.asList(Key.of("key1"), Key.of("key2")));
 	}
 
 	@Test
 	public void countTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
-		new SpannerRepositoryImpl(operations, Object.class).count();
+		new SimpleSpannerRepository(operations, Object.class).count();
 		verify(operations, times(1)).count(eq(Object.class));
 	}
 
@@ -200,7 +200,7 @@ public class SpannerRepositoryImplTests {
 	public void deleteByIdTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
 		Key key = Key.of("key");
-		new SpannerRepositoryImpl(operations, Object.class).deleteById(key);
+		new SimpleSpannerRepository(operations, Object.class).deleteById(key);
 		verify(operations, times(1)).delete(eq(Object.class), eq(key));
 	}
 
@@ -208,7 +208,7 @@ public class SpannerRepositoryImplTests {
 	public void deleteTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
 		Object ob = new Object();
-		new SpannerRepositoryImpl(operations, Object.class).delete(ob);
+		new SimpleSpannerRepository(operations, Object.class).delete(ob);
 		verify(operations, times(1)).delete(eq(ob));
 	}
 
@@ -221,13 +221,13 @@ public class SpannerRepositoryImplTests {
 			assertThat(toDelete, containsInAnyOrder("ob1", "ob2"));
 			return null;
 		}).when(operations).delete(eq(String.class), same(obs));
-		new SpannerRepositoryImpl(operations, Object.class).deleteAll(obs);
+		new SimpleSpannerRepository(operations, Object.class).deleteAll(obs);
 	}
 
 	@Test
 	public void deleteAllTest() {
 		SpannerOperations operations = mock(SpannerOperations.class);
-		new SpannerRepositoryImpl(operations, Object.class).deleteAll();
+		new SimpleSpannerRepository(operations, Object.class).deleteAll();
 		verify(operations, times(1)).delete(eq(Object.class), eq(KeySet.all()));
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/TradeRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/TradeRepository.java
@@ -18,11 +18,9 @@ package org.springframework.cloud.gcp.data.spanner.test.domain;
 
 import java.util.List;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.cloud.gcp.data.spanner.repository.SpannerRepository;
 
-@Repository
-public interface TradeRepository extends PagingAndSortingRepository<Trade, String> {
+public interface TradeRepository extends SpannerRepository<Trade> {
 
 	List<Trade> findByTraderId(String traderId);
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/java/com/example/TradeRepository.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/java/com/example/TradeRepository.java
@@ -18,17 +18,13 @@ package com.example;
 
 import java.util.List;
 
-import com.google.cloud.spanner.Key;
-
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.cloud.gcp.data.spanner.repository.SpannerRepository;
 
 /**
  * @author Ray Tsang
  * @author Chengyuan Zhao
  */
-@Repository
-public interface TradeRepository extends PagingAndSortingRepository<Trade, Key> {
+public interface TradeRepository extends SpannerRepository<Trade> {
 
 	List<Trade> findTop3DistinctByActionAndSymbolOrTraderIdOrderBySymbolDesc(
 			String action, String symbol, String traderId);


### PR DESCRIPTION
renamed so Spring does not try to create an instance of the repository as a bean. repository should only be created via the factory class