### PR TITLE
Integrate Error Prone checking to spring-gcp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,8 @@
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
+						<compilerId>javac-with-errorprone</compilerId>
+						<forceJavacCompilerUse>true</forceJavacCompilerUse>
 						<compilerArgs>
 							<!-- Enable all warnings -->
 							<compilerArg>-Xlint:all</compilerArg>
@@ -121,6 +123,18 @@
 							<!--compilerArg>-Werror</compilerArg-->
 						</compilerArgs>
 					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>org.codehaus.plexus</groupId>
+							<artifactId>plexus-compiler-javac-errorprone</artifactId>
+							<version>2.8.3</version>
+						</dependency>
+						<dependency>
+							<groupId>com.google.errorprone</groupId>
+							<artifactId>error_prone_core</artifactId>
+							<version>2.2.0</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/MappingSpannerWriteConverter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/MappingSpannerWriteConverter.java
@@ -235,7 +235,8 @@ public class MappingSpannerWriteConverter extends AbstractSpannerCustomConverter
 		if (toMethod == null) {
 			return false;
 		}
-		toMethod.apply(valueBinder, convert(value, targetType));
+		// We're just checking for the bind to have succeeded, we don't need to chain the result.
+		Object ignored = toMethod.apply(valueBinder, convert(value, targetType));
 		return true;
 	}
 }

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/integration/inbound/GcsInboundFileSynchronizerTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/integration/inbound/GcsInboundFileSynchronizerTests.java
@@ -68,14 +68,16 @@ public class GcsInboundFileSynchronizerTests {
 
 		if (Files.exists(testDirectory)) {
 			if (Files.isDirectory(testDirectory)) {
-				Files.list(testDirectory).forEach(path -> {
-					try {
-						Files.delete(path);
-					}
-					catch (IOException ioe) {
-						LOGGER.info("Error deleting test file.", ioe);
-					}
-				});
+				try (Stream<Path> files = Files.list(testDirectory)) {
+					files.forEach(path -> {
+						try {
+							Files.delete(path);
+						}
+						catch (IOException ioe) {
+							LOGGER.info("Error deleting test file.", ioe);
+						}
+					});
+				}
 			}
 
 			Files.delete(testDirectory);


### PR DESCRIPTION
Integrates Error Prone (http://errorprone.info) to the compilation process for spring-gcp.

This detects issues at compile time. 

Here, we make an explicit capture of an ignored return value with a comment: http://errorprone.info/bugpattern/CheckReturnValue
Additionally, in a test where a Stream is opened with Files.list(), we use try-with-resources to ensure the directory stream is closed (per documentation): http://errorprone.info/bugpattern/StreamResourceLeak