### PR TITLE
disabling integration tests for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - while [ ! -f ~/.config/gcloud/emulators/pubsub/env.yaml ]; do sleep 1; done
   - $(gcloud beta emulators pubsub env-init)
 before_install:
-  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  - if [ "$encrypted_1ef8dfbdb114_key" != "" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;
         export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true";

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ before_script:
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
+        tar -xzf travis.tar.gz;
         export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true";
       fi
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   - source $HOME/google-cloud-sdk/path.bash.inc
   - gcloud components install beta pubsub-emulator --quiet
-  - tar -xzf travis.tar.gz
   - gcloud config set project spring-cloud-gcp-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ cache:
     - $HOME/google-cloud-sdk
     - $HOME/.m2
 script:
-  - ./mvnw test -B -Dit.spanner=true
-  - ./mvnw test -B -Dit.storage=true
+  - ./mvnw test -B ${INTEGRATION_TEST_FLAGS}
 install:
   - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_script:
@@ -20,7 +19,10 @@ before_script:
   - while [ ! -f ~/.config/gcloud/emulators/pubsub/env.yaml ]; do sleep 1; done
   - $(gcloud beta emulators pubsub env-init)
 before_install:
-  - openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+        openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
+        export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true"
+      fi
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   - source $HOME/google-cloud-sdk/path.bash.inc
   - gcloud components install beta pubsub-emulator --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
-        export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true"
+        export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true";
       fi
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   - source $HOME/google-cloud-sdk/path.bash.inc

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - while [ ! -f ~/.config/gcloud/emulators/pubsub/env.yaml ]; do sleep 1; done
   - $(gcloud beta emulators pubsub env-init)
 before_install:
-  - if [ "$encrypted_1ef8dfbdb114_key" != "" ]; then
+  - if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;
         export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true";

--- a/spring-cloud-gcp-data-spanner/pom.xml
+++ b/spring-cloud-gcp-data-spanner/pom.xml
@@ -44,17 +44,4 @@
 			<artifactId>spring-tx</artifactId>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<environmentVariables>
-						<forceIntegrationTests>${it.spanner}</forceIntegrationTests>
-					</environmentVariables>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/spring-cloud-gcp-storage/pom.xml
+++ b/spring-cloud-gcp-storage/pom.xml
@@ -35,17 +35,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <environmentVariables>
-            <forceIntegrationTests>${it.storage}</forceIntegrationTests>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
This PR is from a fork and it skips the integration tests.
The branch version of this PR runs the integration tests.

![image](https://user-images.githubusercontent.com/635073/38507706-37e2d540-3beb-11e8-9dfe-c1b2c1fcc2e8.png)

from fork: https://travis-ci.org/spring-cloud/spring-cloud-gcp/builds/364171963
from branch: https://travis-ci.org/spring-cloud/spring-cloud-gcp/builds/364173471

It is leveraging [`TRAVIS_SECURE_ENV_VARS`](https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables) to determine if it is possible to decrypt the credentials required for integration tests on Travis.

With travis, there is just simply no way to run integration tests on forks that require the encrypted variables for cloud credentials. Emulator based tests will still work though.
Running integration tests would be still highly recommended. One way to de-risk broken integration tests in master would be to stage the changes in a local branch (after a thorough review) and have them checked on travis. Until someone comes up with a better idea, this can work, currently fork PRs are just simply broken.