### PR TITLE
Use correct properties on Config sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/src/main/resources/bootstrap.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/src/main/resources/bootstrap.properties
@@ -11,5 +11,5 @@ spring.cloud.gcp.config.profile=prod
 spring.cloud.gcp.config.timeout-millis=120000
 
 # Provide project id, credentials to override default
-#spring.cloud.gcp.project-id=my-gcp-project-id
-#spring.cloud.gcp.credentials.location=my-credentials-file-location
+#spring.cloud.gcp.config.project-id=my-gcp-project-id
+#spring.cloud.gcp.config.credentials.location=my-credentials-file-location


### PR DESCRIPTION
Spring Cloud GCP Config cannot use the Core properties.