### PR TITLE
Adds consumer and producer trace kind mappings

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/sleuth/SpanTranslator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/sleuth/SpanTranslator.java
@@ -47,6 +47,8 @@ public class SpanTranslator {
 		Map<Span.Kind, SpanKind> map = new HashMap<>();
 		map.put(Span.Kind.CLIENT, SpanKind.RPC_CLIENT);
 		map.put(Span.Kind.SERVER, SpanKind.RPC_SERVER);
+		map.put(Span.Kind.CONSUMER, SpanKind.RPC_CLIENT);
+		map.put(Span.Kind.PRODUCER, SpanKind.RPC_SERVER);
 		this.SPAN_KIND_MAP = Collections.unmodifiableMap(map);
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/sleuth/SpanTranslator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/sleuth/SpanTranslator.java
@@ -47,8 +47,8 @@ public class SpanTranslator {
 		Map<Span.Kind, SpanKind> map = new HashMap<>();
 		map.put(Span.Kind.CLIENT, SpanKind.RPC_CLIENT);
 		map.put(Span.Kind.SERVER, SpanKind.RPC_SERVER);
-		map.put(Span.Kind.CONSUMER, SpanKind.RPC_CLIENT);
-		map.put(Span.Kind.PRODUCER, SpanKind.RPC_SERVER);
+		map.put(Span.Kind.CONSUMER, SpanKind.SPAN_KIND_UNSPECIFIED);
+		map.put(Span.Kind.PRODUCER, SpanKind.SPAN_KIND_UNSPECIFIED);
 		this.SPAN_KIND_MAP = Collections.unmodifiableMap(map);
 	}
 


### PR DESCRIPTION
Trace currently crashes when span kind is consumer or producer because
there is no mapping of that kind to google-cloud-trace.

Fixes #638