### PR TITLE
Uses idomatic values for Config configuration

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigProperties.java
@@ -16,11 +16,14 @@
 
 package org.springframework.cloud.gcp.autoconfigure.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.cloud.gcp.core.Credentials;
 import org.springframework.cloud.gcp.core.CredentialsSupplier;
 import org.springframework.cloud.gcp.core.GcpScope;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 /**
  * Configuration for {@link GoogleConfigPropertySourceLocator}.
@@ -32,24 +35,45 @@ import org.springframework.cloud.gcp.core.GcpScope;
 @ConfigurationProperties("spring.cloud.gcp.config")
 public class GcpConfigProperties implements CredentialsSupplier {
 
-	/** Enables Spring Cloud GCP Config. */
+	/**
+	 *  Enables Spring Cloud GCP Config.
+	 */
 	private boolean enabled;
 
-	/** Name of the application. */
+	/**
+	 *  Name of the application.
+	 */
+	@Value("${spring.application.name:application}")
 	private String name;
 
-	/** Profile under which app is running (e.g., "prod", "dev", "test", etc.). */
-	private String profile = "default";
+	/**
+	 *  Comma-delimited string of profiles under which the app is running.
+	 */
+	private String profile;
 
-	/** Timeout for Google Runtime Configuration API calls. */
+	/**
+	 *  Timeout for Google Runtime Configuration API calls.
+	 */
 	private int timeoutMillis = 60000;
 
-	/** Overrides the GCP project ID specified in the Core module. */
+	/**
+	 *  Overrides the GCP project ID specified in the Core module.
+	 */
 	private String projectId;
 
-	/** Overrides the GCP OAuth2 credentials specified in the Core module. */
+	/**
+	 * Overrides the GCP OAuth2 credentials specified in the Core module.
+	 */
 	@NestedConfigurationProperty
 	private final Credentials credentials = new Credentials(GcpScope.RUNTIME_CONFIG_SCOPE.getUrl());
+
+	public GcpConfigProperties(Environment environment) {
+		String[] profiles = environment.getActiveProfiles();
+		if (profiles.length == 0) {
+			profiles = environment.getDefaultProfiles();
+		}
+		this.profile = StringUtils.arrayToCommaDelimitedString(profiles);
+	}
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigBootstrapConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/GcpConfigBootstrapConfigurationTest.java
@@ -36,7 +36,7 @@ public class GcpConfigBootstrapConfigurationTest {
 	public void testConfigurationValueDefaultsAreAsExpected() {
 		this.contextRunner.run(context -> {
 			GcpConfigProperties config = context.getBean(GcpConfigProperties.class);
-			assertThat(config.getName()).isNull();
+			assertThat(config.getName()).isEqualTo("application");
 			assertThat(config.getProfile()).isEqualTo("default");
 			assertThat(config.getTimeoutMillis()).isEqualTo(60000);
 			assertThat(config.isEnabled()).isFalse();
@@ -45,8 +45,8 @@ public class GcpConfigBootstrapConfigurationTest {
 
 	@Test
 	public void testConfigurationValuesAreCorrectlyLoaded() {
-		this.contextRunner.withPropertyValues("spring.cloud.gcp.config.name=myapp",
-				"spring.cloud.gcp.config.profile=prod",
+		this.contextRunner.withPropertyValues("spring.application.name=myapp",
+				"spring.profiles.active=prod",
 				"spring.cloud.gcp.config.timeoutMillis=120000",
 				"spring.cloud.gcp.config.enabled=false",
 				"spring.cloud.gcp.config.project-id=pariah")

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/it/GcpConfigIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/it/GcpConfigIntegrationTests.java
@@ -54,8 +54,8 @@ public class GcpConfigIntegrationTests {
 				.sources(GcpContextAutoConfiguration.class, GcpConfigBootstrapConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.properties("spring.cloud.gcp.config.enabled=true",
-						"spring.cloud.gcp.config.name=myapp",
-						"spring.cloud.gcp.config.profile=prod")
+						"spring.application.name=myapp",
+						"spring.profiles.active=prod")
 				.run();
 
 		assertThat(this.context.getEnvironment().getProperty("myapp.queue-size"))

--- a/spring-cloud-gcp-docs/src/main/asciidoc/config.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/config.adoc
@@ -36,20 +36,12 @@ The following parameters are configurable in Spring Cloud GCP Config:
 |===
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.config.enabled` | Enables the Config client | No | `false`
-| `spring.cloud.gcp.config.name` |
-Name of your application | Yes |
-| `spring.cloud.gcp.config.profile` |
-Configuration's Spring profile (e.g., prod) | No | `default`
-| `spring.cloud.gcp.config.timeout-millis` | Timeout in milliseconds for connecting to the Google
-Runtime Configuration API | No | `60000`
-| `spring.cloud.gcp.config.project-id` | GCP project ID where the Google Runtime Configuration API
-is hosted
-| No |
-| `spring.cloud.gcp.config.credentials.location` | OAuth2 credentials for authenticating with the
-Google Runtime Configuration API | No |
-| `spring.cloud.gcp.config.credentials.scopes` |
-https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Cloud GCP
-Config credentials | No | https://www.googleapis.com/auth/cloudruntimeconfig
+| `spring.cloud.gcp.config.name` | Name of your application | No | Value of the `spring.application.name` property
+| `spring.cloud.gcp.config.profile` | Comma-delimited list of active profiles | No | Value of the `spring.profiles.active` property
+| `spring.cloud.gcp.config.timeout-millis` | Timeout in milliseconds for connecting to the Google Runtime Configuration API | No | `60000`
+| `spring.cloud.gcp.config.project-id` | GCP project ID where the Google Runtime Configuration API is hosted | No |
+| `spring.cloud.gcp.config.credentials.location` | OAuth2 credentials for authenticating with the Google Runtime Configuration API | No |
+| `spring.cloud.gcp.config.credentials.scopes` | https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Cloud GCP Config credentials | No | https://www.googleapis.com/auth/cloudruntimeconfig
 |===
 
 NOTE: These properties should be specified in a
@@ -61,14 +53,10 @@ do not apply to Spring Cloud GCP Config.
 
 === Quick start
 
-1. Create a configuration in the Google Runtime Configuration API that is called
-`${spring.cloud.gcp.config.name}_${spring.cloud.gcp.config.profile}`.
-In other words, if `spring.cloud.gcp.config.name` is `myapp` and `spring.cloud.gcp.config.profile`
-is prod, the configuration should be called `myapp_prod`.
+1. Create a configuration in the Google Runtime Configuration API that is called `${spring.application.name}_${spring.profiles.active}`.
+In other words, if `spring.cloud.gcp.config.name` is `myapp` and `spring.cloud.gcp.config.profile` is prod, the configuration should be called `myapp_prod`.
 +
-In order to do that, you should have the
-https://cloud.google.com/sdk/[Google Cloud SDK] installed, own a Google Cloud Project and run the
-following command:
+In order to do that, you should have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, own a Google Cloud Project and run the following command:
 +
 ----
 gcloud init # if this is your first Google Cloud SDK run.
@@ -79,8 +67,8 @@ gcloud beta runtime-config configs variables set myapp.queue-size 25 --config-na
 2. Configure your `bootstrap.properties` file with your application's configuration data:
 +
 ----
-spring.cloud.gcp.config.name=myapp
-spring.cloud.gcp.config.profile=prod
+spring.application.name=myapp
+spring.profiles.active=prod
 ----
 3. Add the `@ConfigurationProperties` annotation to a Spring-managed bean:
 +

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/src/main/resources/bootstrap.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/src/main/resources/bootstrap.properties
@@ -1,11 +1,9 @@
 # Sample bootstrap configuration
 spring.cloud.gcp.config.enabled=true
 
-# required
-spring.cloud.gcp.config.name=myapp
+spring.application.name=myapp
 
-# default profile = "default"
-spring.cloud.gcp.config.profile=prod
+spring.profiles.active=prod
 
 # Config server API timeout in milliseconds, default : 60000 (1 minute)
 spring.cloud.gcp.config.timeout-millis=120000


### PR DESCRIPTION
Application name is now obtained from the spring.application.name
property. Likewise, the profile is also now the comma-delimited list
of the active profiles from spring.profiles.active property.

Fixes #244