### PR TITLE
Stream Binder refdoc section

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/index.adoc
@@ -36,6 +36,8 @@ include::sql.adoc[]
 
 include::spring-integration.adoc[]
 
+include::spring-stream.adoc[]
+
 include::trace.adoc[]
 
 include::logging.adoc[]

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -246,6 +246,7 @@ public List<String> listSubscriptions() {
 }
 ----
 
+[#pubsub-configuration]
 === Configuration
 
 The Spring Boot starter for Google Cloud Pub/Sub provides the following configuration options:

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -1,0 +1,35 @@
+== Spring Cloud Stream
+
+Spring Cloud GCP provides a https://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream] binder to Google Cloud Pub/Sub.
+
+The provided binder relies on the https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration[Spring Integration Channel Adapters for Google Cloud Pub/Sub].
+
+Maven coordinates, using Spring Cloud GCP BOM:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-pubsub-stream-binder</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+[source,subs="normal"]
+----
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-pubsub-stream-binder'
+}
+----
+
+=== Getting started
+
+There is a link:../spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample[code sample] that demonstrates how to build a simple app to send messages over a Spring Cloud Stream Binder for Google Cloud Pub/Sub.
+
+NOTE: Partitioning and consumer groups are not currently supported by this binder.
+
+=== Configuration
+
+You can configure the Spring Cloud Stream Binder for Google Cloud Pub/Sub to automatically generate the underlying resources, like the Google Cloud Pub/Sub subscriptions for the consumers.
+For that, you can use the `spring.cloud.stream.gcp.pubsub.bindings.[CHANNEL-NAME].consumer.auto-create-resources` property, which is turned ON by default.

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -27,11 +27,25 @@ dependencies {
 
 There is a link:../spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample[code sample] that demonstrates how to build a simple app to send messages over a Spring Cloud Stream Binder for Google Cloud Pub/Sub.
 
+=== Overview
+
+This binder binds producers to Google Cloud Pub/Sub topics and consumers to subscriptions.
+
 NOTE: Partitioning and consumer groups are not currently supported by this binder.
 
 === Configuration
 
 You can configure the Spring Cloud Stream Binder for Google Cloud Pub/Sub to automatically generate the underlying resources, like the Google Cloud Pub/Sub subscriptions for the consumers.
 For that, you can use the `spring.cloud.stream.gcp.pubsub.bindings.[CHANNEL-NAME].consumer.auto-create-resources` property, which is turned ON by default.
+
+If automatic resource creation is turned ON and the subscription and the topic do not exist for a consumer, a subscription and a topic will be created with the same name.
+For example, for the following configuration, a topic and a subscription called `myConsumer` would be created.
+
+.application.properties
+----
+spring.cloud.stream.bindings.output.destination=myConsumer
+
+spring.cloud.stream.gcp.pubsub.bindings.output.consumer.auto-create-resources=true
+----
 
 If you are using Pub/Sub auto-configuration from the Spring Cloud GCP Pub/Sub Starter, you should refer to the <<pubsub-configuration,configuration>> section for other Pub/Sub parameters.

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -33,3 +33,5 @@ NOTE: Partitioning and consumer groups are not currently supported by this binde
 
 You can configure the Spring Cloud Stream Binder for Google Cloud Pub/Sub to automatically generate the underlying resources, like the Google Cloud Pub/Sub subscriptions for the consumers.
 For that, you can use the `spring.cloud.stream.gcp.pubsub.bindings.[CHANNEL-NAME].consumer.auto-create-resources` property, which is turned ON by default.
+
+If you are using Pub/Sub auto-configuration from the Spring Cloud GCP Pub/Sub Starter, you should refer to the <<pubsub-configuration,configuration>> section for other Pub/Sub parameters.


### PR DESCRIPTION
Adds a section about the Spring Cloud Stream Binder for Google Cloud
Pub/Sub to the reference document.

Fixes #293