### PR TITLE
Improves lack of core credentials message

### DIFF
--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/DefaultCredentialsProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/DefaultCredentialsProvider.java
@@ -125,7 +125,9 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
 			}
 		}
 		catch (IOException ioe) {
-			LOGGER.error("No core credentials are set.");
+			LOGGER.warn("No core credentials are set. Service-specific credentials " +
+					"(e.g., spring.cloud.gcp.pubsub.credentials.*) should be used if your app uses "
+					+ "services that require credentials.");
 		}
 	}
 

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/DefaultCredentialsProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/DefaultCredentialsProvider.java
@@ -125,7 +125,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
 			}
 		}
 		catch (IOException ioe) {
-			LOGGER.error("No credentials were found.", ioe);
+			LOGGER.error("No core credentials are set.");
 		}
 	}
 


### PR DESCRIPTION
Currently, if no core credentials are set, but either the app doesn't
need them or they're set at the service level, an error message is
printed with a stack trace.

This leads users to believe there is an error with the app, when things
are actually fine. Only saying no core credentials are set is fine,
things will blow up when a service actually needs credentials but
doesn't have them.