### PR TITLE
Adds nativeHeaders to filtered headers

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/PubSubHeaderMapper.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/PubSubHeaderMapper.java
@@ -24,15 +24,16 @@ import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.util.PatternMatchUtils;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 import org.springframework.util.Assert;
 
 /**
  * Maps headers from {@link com.google.pubsub.v1.PubsubMessage}s to
  * {@link org.springframework.messaging.Message}s and vice-versa.
  *
- * <p>By default, filters out headers called "id", "timestamp" or "gcp_pubsub_acknowledgement" on
- * the {@link org.springframework.messaging.Message} to {@link com.google.pubsub.v1.PubsubMessage}
- * header conversion.
+ * <p>By default, filters out headers called "id", "timestamp", "gcp_pubsub_acknowledgement" or
+ * "nativeHeaders" on the {@link org.springframework.messaging.Message} to
+ * {@link com.google.pubsub.v1.PubsubMessage} header conversion.
  *
  * @author João André Martins
  */
@@ -46,6 +47,7 @@ public class PubSubHeaderMapper implements HeaderMapper<Map<String, String>> {
 			"!" + MessageHeaders.ID,
 			"!" + MessageHeaders.TIMESTAMP,
 			"!" + GcpPubSubHeaders.ACKNOWLEDGEMENT,
+			"!" + NativeMessageHeaderAccessor.NATIVE_HEADERS,
 			"*"};
 
 	/**

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/PubSubHeaderMapperTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/PubSubHeaderMapperTests.java
@@ -36,7 +36,7 @@ public class PubSubHeaderMapperTests {
 		PubSubHeaderMapper mapper = new PubSubHeaderMapper();
 		Map<String, Object> originalHeaders = new HashMap<>();
 		originalHeaders.put("my header", "pantagruel's nativity");
-		 originalHeaders.put(NativeMessageHeaderAccessor.NATIVE_HEADERS, "deerhunter");
+		originalHeaders.put(NativeMessageHeaderAccessor.NATIVE_HEADERS, "deerhunter");
 		MessageHeaders internalHeaders = new MessageHeaders(originalHeaders);
 
 		Map<String, String> filteredHeaders = new HashMap<>();

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/PubSubHeaderMapperTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/PubSubHeaderMapperTests.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,6 +36,7 @@ public class PubSubHeaderMapperTests {
 		PubSubHeaderMapper mapper = new PubSubHeaderMapper();
 		Map<String, Object> originalHeaders = new HashMap<>();
 		originalHeaders.put("my header", "pantagruel's nativity");
+		 originalHeaders.put(NativeMessageHeaderAccessor.NATIVE_HEADERS, "deerhunter");
 		MessageHeaders internalHeaders = new MessageHeaders(originalHeaders);
 
 		Map<String, String> filteredHeaders = new HashMap<>();


### PR DESCRIPTION
Using SI with Sleuth, we're finding that a nativeHeaders header with
a Map value is being added to the headers.
When a message is sent to Pub/Sub from a channel adapter, the map is
transformed to a string.
When the message returns from Pub/Sub, Sleuth casts the String to Map,
throwing an error in the process.

This is a stop-gap solution while we don't serialize Objects into
Strings, if we ever do.

Fixes #434