### PR TITLE
Removes unnecessary Trace dependencies

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -153,20 +153,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-trace</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>io.zipkin.gcp</groupId>
             <artifactId>zipkin-sender-stackdriver</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.cloud.trace.v1</groupId>
-            <artifactId>sink</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -156,6 +156,12 @@
             <groupId>io.zipkin.gcp</groupId>
             <artifactId>zipkin-sender-stackdriver</artifactId>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -23,7 +23,6 @@ import brave.http.HttpServerParser;
 import brave.sampler.Sampler;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.rpc.HeaderProvider;
-import com.google.cloud.trace.v1.consumer.TraceConsumer;
 import io.grpc.CallOptions;
 import io.grpc.auth.MoreCallCredentials;
 import zipkin2.Span;
@@ -62,7 +61,7 @@ import org.springframework.context.annotation.Primary;
 @EnableConfigurationProperties(
 		{ SamplerProperties.class, GcpTraceProperties.class, SleuthProperties.class })
 @ConditionalOnProperty(value = "spring.cloud.gcp.trace.enabled", matchIfMissing = true)
-@ConditionalOnClass(TraceConsumer.class)
+@ConditionalOnClass(StackdriverSender.class)
 @AutoConfigureBefore({ ZipkinAutoConfiguration.class })
 public class StackdriverTraceAutoConfiguration {
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
@@ -24,6 +24,12 @@
 		<dependency>
 			<groupId>io.zipkin.gcp</groupId>
 			<artifactId>zipkin-sender-stackdriver</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- Reporter auto-configuration -->
 		<dependency>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
@@ -22,14 +22,6 @@
 			<artifactId>spring-cloud-starter-sleuth</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.google.cloud</groupId>
-			<artifactId>google-cloud-trace</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.google.cloud.trace.v1</groupId>
-			<artifactId>sink</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.zipkin.gcp</groupId>
 			<artifactId>zipkin-sender-stackdriver</artifactId>
 		</dependency>


### PR DESCRIPTION
After starting to use StackdriverSender, we no longer depend on the
Stackdriver Trace client libraries.