### PR TITLE
Adds publish() without headers

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
@@ -110,9 +110,9 @@ public class PubSubTemplateIntegrationTests {
 
 			PubSubTemplate pubSubTemplate = context.getBean(PubSubTemplate.class);
 
-			pubSubTemplate.publish(topicName, "free-hand", null);
-			pubSubTemplate.publish(topicName, "valedictory", null);
-			pubSubTemplate.publish(topicName, "the-runaway", null);
+			pubSubTemplate.publish(topicName, "free-hand");
+			pubSubTemplate.publish(topicName, "valedictory");
+			pubSubTemplate.publish(topicName, "the-runaway");
 
 			List<AcknowledgeablePubsubMessage> ackableMessages =
 					pubSubTemplate.pull(subscriptionName, 4, true);

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -46,8 +46,8 @@ utilization.
 ==== Publishing to a topic
 
 `PubSubTemplate` provides asynchronous methods to publish messages to a Google Cloud Pub/Sub topic.
-It supports different types of payloads, including `Strings` with different encodings, `byte[]`,
-`ByteString`, POJOs, and `PubsubMessage`.
+It supports different types of payloads, including `Strings` with different encodings, `byte[]`, `ByteString`, POJOs, and `PubsubMessage`.
+For each type of payload, there are equivalent `publish()` methods without headers.
 
 [source,java]
 ----

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -46,24 +46,13 @@ utilization.
 ==== Publishing to a topic
 
 `PubSubTemplate` provides asynchronous methods to publish messages to a Google Cloud Pub/Sub topic.
-It supports different types of payloads, including `Strings` with different encodings, `byte[]`, `ByteString`, POJOs, and `PubsubMessage`.
-For each type of payload, there are equivalent `publish()` methods without headers.
+The `publish()` method takes in a topic name to post the message to, a payload of a generic type and, optionally, a map with the message headers.
 
-[source,java]
-----
-public ListenableFuture<String> publish(String topic, String payload, Map<String, String> headers)
-
-public ListenableFuture<String> publish(String topic, String payload, Map<String, String> headers,
-Charset charset)
-
-public ListenableFuture<String> publish(String topic, byte[] payload, Map<String, String> headers)
-
-public ListenableFuture<String> publish(String topic, ByteString payload, Map<String, String> headers)
-
-public ListenableFuture<String> publish(String topic, PubsubMessage pubsubMessage)
-
-public <T> ListenableFuture<String> publish(String topic, T payload, Map<String, String> headers)
-----
+* If the payload is a string, it is decoded using the active character set.
+** A character set can be set using the `setCharset()` method in `PubSubTemplate`.
+* If the payload is a `ByteString`, it is sent as-is.
+* If the payload is a `byte[]`, then a `ByteString` is created from it.
+* Otherwise, the payload is serialized into JSON and sent.
 
 Here is an example of how to publish a message to a Google Cloud Pub/Sub topic:
 
@@ -73,7 +62,6 @@ public void publishMessage() {
     this.pubSubTemplate.publish("topic", "your message payload", ImmutableMap.of("key1", "val1"));
 }
 ----
-
 
 The default serialization and deserialization of POJOs uses Jackson JSON via the `JacksonMessageConverter` class.
 

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -52,7 +52,7 @@ The `publish()` method takes in a topic name to post the message to, a payload o
 ** A character set can be set using the `setCharset()` method in `PubSubTemplate`.
 * If the payload is a `ByteString`, it is sent as-is.
 * If the payload is a `byte[]`, then a `ByteString` is created from it.
-* Otherwise, the payload is serialized into JSON and sent.
+* Otherwise, the payload is serialized and sent.
 
 Here is an example of how to publish a message to a Google Cloud Pub/Sub topic:
 
@@ -64,6 +64,7 @@ public void publishMessage() {
 ----
 
 The default serialization and deserialization of POJOs uses Jackson JSON via the `JacksonMessageConverter` class.
+To set a new message converter in `PubSubTemplate`, use the `setMessageConverter()` method.
 
 
 ==== Subscribing to a subscription

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
@@ -44,7 +44,7 @@ public interface PubSubOperations {
 	 * @return the listenable future of the call
 	 */
 	<T> ListenableFuture<String> publish(String topic, T payload,
-			Map<String, String> headers) throws IOException;
+			Map<String, String> headers);
 
 	/**
 	 * Send a message to Pub/Sub.
@@ -52,7 +52,7 @@ public interface PubSubOperations {
 	 * @param payload an object that will be serialized and sent
 	 * @return the listenable future of the call
 	 */
-	<T> ListenableFuture<String> publish(String topic, T payload) throws IOException;
+	<T> ListenableFuture<String> publish(String topic, T payload);
 
 	/**
 	 * Send a message to Pub/Sub.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
@@ -42,58 +42,11 @@ public interface PubSubOperations {
 	/**
 	 * Send a message to Pub/Sub.
 	 * @param topic the name of an existing topic
-	 * @param payload the message String payload
-	 * @param headers map of String to String headers
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, String payload, Map<String, String> headers);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload the message String payload
-	 * @param headers map of String to String headers
-	 * @param charset charset to decode the payload
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, String payload, Map<String, String> headers,
-			Charset charset);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload the message payload in bytes
-	 * @param headers map of String to String headers
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, byte[] payload, Map<String, String> headers);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload the message payload on the {@link PubsubMessage} payload format
-	 * @param headers map of String to String headers
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, ByteString payload, Map<String, String> headers);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
 	 * @param payload an object that will be serialized and sent
 	 * @return the listenable future of the call
 	 */
 	<T> ListenableFuture<String> publish(String topic, T payload,
 			Map<String, String> headers) throws IOException;
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload the message String payload
-	 * @param charset charset to decode the payload
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, String payload, Charset charset);
 
 	/**
 	 * Send a message to Pub/Sub.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gcp.pubsub.core;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
@@ -17,13 +17,11 @@
 package org.springframework.cloud.gcp.pubsub.core;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 
 import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
@@ -81,11 +81,51 @@ public interface PubSubOperations {
 	 * Send a message to Pub/Sub.
 	 * @param topic the name of an existing topic
 	 * @param payload an object that will be serialized and sent
-	 * @param headers map of String to String headers
 	 * @return the listenable future of the call
 	 */
 	<T> ListenableFuture<String> publish(String topic, T payload,
 			Map<String, String> headers) throws IOException;
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param topic the name of an existing topic
+	 * @param payload the message String payload
+	 * @return the listenable future of the call
+	 */
+	ListenableFuture<String> publish(String topic, String payload);
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param topic the name of an existing topic
+	 * @param payload the message String payload
+	 * @param charset charset to decode the payload
+	 * @return the listenable future of the call
+	 */
+	ListenableFuture<String> publish(String topic, String payload, Charset charset);
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param topic the name of an existing topic
+	 * @param payload the message payload in bytes
+	 * @return the listenable future of the call
+	 */
+	ListenableFuture<String> publish(String topic, byte[] payload);
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param topic the name of an existing topic
+	 * @param payload the message payload on the {@link PubsubMessage} payload format
+	 * @return the listenable future of the call
+	 */
+	ListenableFuture<String> publish(String topic, ByteString payload);
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param topic the name of an existing topic
+	 * @param payload an object that will be serialized and sent
+	 * @return the listenable future of the call
+	 */
+	<T> ListenableFuture<String> publish(String topic, T payload) throws IOException;
 
 	/**
 	 * Send a message to Pub/Sub.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
@@ -90,34 +90,10 @@ public interface PubSubOperations {
 	 * Send a message to Pub/Sub.
 	 * @param topic the name of an existing topic
 	 * @param payload the message String payload
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, String payload);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload the message String payload
 	 * @param charset charset to decode the payload
 	 * @return the listenable future of the call
 	 */
 	ListenableFuture<String> publish(String topic, String payload, Charset charset);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload the message payload in bytes
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, byte[] payload);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload the message payload on the {@link PubsubMessage} payload format
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, ByteString payload);
 
 	/**
 	 * Send a message to Pub/Sub.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -100,7 +100,7 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 	}
 
 	public Charset getCharset() {
-		return charset;
+		return this.charset;
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -134,28 +134,28 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 	}
 
 	@Override
-	public ListenableFuture<String> publish(String topic, String payload) {
-		return publish(topic, payload, (Map<String, String>) null);
-	}
-
-	@Override
 	public ListenableFuture<String> publish(String topic, String payload, Charset charset) {
-		return publish(topic, payload, charset);
-	}
-
-	@Override
-	public ListenableFuture<String> publish(String topic, byte[] payload) {
-		return publish(topic, payload, null);
-	}
-
-	@Override
-	public ListenableFuture<String> publish(String topic, ByteString payload) {
-		return publish(topic, payload, null);
+		return publish(topic, payload, null, charset);
 	}
 
 	@Override
 	public <T> ListenableFuture<String> publish(String topic, T payload) throws IOException {
-		return publish(topic, payload, null);
+		ListenableFuture<String> result;
+
+		if (payload instanceof String) {
+			result = publish(topic, payload, null);
+		}
+		else if (payload instanceof byte[]) {
+			result = publish(topic, payload, null);
+		}
+		else if (payload instanceof ByteString) {
+			result = publish(topic, payload, null);
+		}
+		else {
+			result = publish(topic, payload, null);
+		}
+
+		return result;
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -138,7 +138,7 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 						ByteString.copyFrom(this.messageConverter.toPayload(payload)));
 			}
 			catch (IOException ioe) {
-				throw new UncheckedIOException("Error serializing payload into JSON. ", ioe);
+				throw new UncheckedIOException("Error serializing payload. ", ioe);
 			}
 		}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -134,6 +134,31 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 	}
 
 	@Override
+	public ListenableFuture<String> publish(String topic, String payload) {
+		return publish(topic, payload, (Map<String, String>) null);
+	}
+
+	@Override
+	public ListenableFuture<String> publish(String topic, String payload, Charset charset) {
+		return publish(topic, payload, charset);
+	}
+
+	@Override
+	public ListenableFuture<String> publish(String topic, byte[] payload) {
+		return publish(topic, payload, null);
+	}
+
+	@Override
+	public ListenableFuture<String> publish(String topic, ByteString payload) {
+		return publish(topic, payload, null);
+	}
+
+	@Override
+	public <T> ListenableFuture<String> publish(String topic, T payload) throws IOException {
+		return publish(topic, payload, null);
+	}
+
+	@Override
 	public ListenableFuture<String> publish(final String topic, PubsubMessage pubsubMessage) {
 		ApiFuture<String> publishFuture =
 				this.publisherFactory.createPublisher(topic).publish(pubsubMessage);

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -71,6 +71,8 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 
 	private final PubSubAcknowledger acknowledger;
 
+	private Charset charset = Charset.defaultCharset();
+
 	/**
 	 * Default {@link PubSubTemplate} constructor that uses a {@link JacksonPubSubMessageConverter}
 	 * to serialize and deserialize payloads.
@@ -97,65 +99,49 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 		return this;
 	}
 
-	@Override
-	public ListenableFuture<String> publish(final String topic, String payload,
-			Map<String, String> headers) {
-		return publish(topic, payload, headers, Charset.defaultCharset());
+	public Charset getCharset() {
+		return charset;
+	}
+
+	/**
+	 * Set the charset to decode the string in {@link #publish(String, Object, Map)}.
+	 * {@code Charset.defaultCharset()} is used by default.
+	 * @param charset character set to decode the string in a byte array
+	 */
+	public void setCharset(Charset charset) {
+		this.charset = charset;
 	}
 
 	@Override
-	public ListenableFuture<String> publish(final String topic, String payload,
-			Map<String, String> headers, Charset charset) {
-		return publish(topic, payload.getBytes(charset), headers);
-	}
-
-	@Override
-	public ListenableFuture<String> publish(final String topic, byte[] payload,
-			Map<String, String> headers) {
-		return publish(topic, ByteString.copyFrom(payload), headers);
-	}
-
-	@Override
-	public ListenableFuture<String> publish(final String topic, ByteString payload,
-			Map<String, String> headers) {
-		PubsubMessage.Builder pubsubMessageBuilder = PubsubMessage.newBuilder().setData(payload);
+	public <T> ListenableFuture<String> publish(String topic, T payload,
+			Map<String, String> headers) throws IOException {
+		PubsubMessage.Builder pubsubMessageBuilder = PubsubMessage.newBuilder();
 
 		if (headers != null) {
 			pubsubMessageBuilder.putAllAttributes(headers);
+		}
+
+		if (payload instanceof String) {
+			pubsubMessageBuilder.setData(
+					ByteString.copyFrom(((String) payload).getBytes(this.charset)));
+		}
+		else if (payload instanceof ByteString) {
+			pubsubMessageBuilder.setData((ByteString) payload);
+		}
+		else if (payload instanceof byte[]) {
+			pubsubMessageBuilder.setData(ByteString.copyFrom((byte[]) payload));
+		}
+		else {
+			pubsubMessageBuilder.setData(
+					ByteString.copyFrom(this.messageConverter.toPayload(payload)));
 		}
 
 		return publish(topic, pubsubMessageBuilder.build());
 	}
 
 	@Override
-	public <T> ListenableFuture<String> publish(String topic, T payload,
-			Map<String, String> headers) throws IOException {
-		return publish(topic, this.messageConverter.toPayload(payload), headers);
-	}
-
-	@Override
-	public ListenableFuture<String> publish(String topic, String payload, Charset charset) {
-		return publish(topic, payload, null, charset);
-	}
-
-	@Override
 	public <T> ListenableFuture<String> publish(String topic, T payload) throws IOException {
-		ListenableFuture<String> result;
-
-		if (payload instanceof String) {
-			result = publish(topic, payload, null);
-		}
-		else if (payload instanceof byte[]) {
-			result = publish(topic, payload, null);
-		}
-		else if (payload instanceof ByteString) {
-			result = publish(topic, payload, null);
-		}
-		else {
-			result = publish(topic, payload, null);
-		}
-
-		return result;
+		return publish(topic, payload, null);
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
@@ -17,6 +17,8 @@
 package org.springframework.cloud.gcp.pubsub.core;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import com.google.api.core.ApiService;
@@ -42,6 +44,7 @@ import org.springframework.util.concurrent.ListenableFuture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
@@ -109,16 +112,16 @@ public class PubSubTemplateTests {
 	}
 
 	@Test
-	public void testPublish_String() {
-		this.pubSubTemplate.publish("testTopic", "testPayload", null);
+	public void testPublish_String() throws IOException {
+		this.pubSubTemplate.publish("testTopic", "testPayload");
 
 		verify(this.mockPublisher, times(1))
 				.publish(isA(PubsubMessage.class));
 	}
 
 	@Test
-	public void testPublish_Bytes() {
-		this.pubSubTemplate.publish("testTopic", "testPayload".getBytes(), null);
+	public void testPublish_Bytes() throws IOException {
+		this.pubSubTemplate.publish("testTopic", "testPayload".getBytes());
 
 		verify(this.mockPublisher, times(1))
 				.publish(isA(PubsubMessage.class));
@@ -174,6 +177,19 @@ public class PubSubTemplateTests {
 		pubSubTemplate.publish("test",
 				pubSubTemplate.getMessageConverter().toMessage(disallowedPayload, null));
 		verify(pubSubTemplate, times(1)).publish(eq("test"), any());
+	}
+
+	@Test
+	public void testPublish_withHeaders() {
+		Map<String, String> headers = new HashMap<>();
+		headers.put("emperor of sand", "sultan's curse");
+		headers.put("remission", "elephant man");
+
+		this.pubSubTemplate.publish("testTopic", "jaguar god", headers);
+
+		verify(this.mockPublisher).publish(argThat(message ->
+				message.getAttributesMap().get("emperor of sand").equals("sultan's curse") &&
+				message.getAttributesMap().get("remission").equals("elephant man")));
 	}
 
 	@Test(expected = PubSubException.class)

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
@@ -180,7 +180,7 @@ public class PubSubTemplateTests {
 	}
 
 	@Test
-	public void testPublish_withHeaders() {
+	public void testPublish_withHeaders() throws IOException {
 		Map<String, String> headers = new HashMap<>();
 		headers.put("emperor of sand", "sultan's curse");
 		headers.put("remission", "elephant man");

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
@@ -112,7 +112,7 @@ public class PubSubTemplateTests {
 	}
 
 	@Test
-	public void testPublish_String() throws IOException {
+	public void testPublish_String() {
 		this.pubSubTemplate.publish("testTopic", "testPayload");
 
 		verify(this.mockPublisher, times(1))
@@ -120,7 +120,7 @@ public class PubSubTemplateTests {
 	}
 
 	@Test
-	public void testPublish_Bytes() throws IOException {
+	public void testPublish_Bytes() {
 		this.pubSubTemplate.publish("testTopic", "testPayload".getBytes());
 
 		verify(this.mockPublisher, times(1))
@@ -180,7 +180,7 @@ public class PubSubTemplateTests {
 	}
 
 	@Test
-	public void testPublish_withHeaders() throws IOException {
+	public void testPublish_withHeaders() {
 		Map<String, String> headers = new HashMap<>();
 		headers.put("emperor of sand", "sultan's curse");
 		headers.put("remission", "elephant man");

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gcp.pubsub.integration.outbound;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Map;
 
@@ -56,7 +57,7 @@ public class PubSubMessageHandlerTests {
 	private Message<?> message;
 
 	@Before
-	public void setUp() {
+	public void setUp() throws IOException {
 		this.message = new GenericMessage<>("testPayload",
 				ImmutableMap.of("key1", "value1", "key2", "value2"));
 		SettableListenableFuture<String> future = new SettableListenableFuture<>();
@@ -70,7 +71,7 @@ public class PubSubMessageHandlerTests {
 	}
 
 	@Test
-	public void testPublish() {
+	public void testPublish() throws IOException {
 		this.adapter.handleMessage(this.message);
 		verify(this.pubSubTemplate, times(1))
 				.publish(eq("testTopic"),
@@ -79,7 +80,7 @@ public class PubSubMessageHandlerTests {
 	}
 
 	@Test
-	public void testPublishDynamicTopic() {
+	public void testPublishDynamicTopic() throws IOException {
 		Message<?> dynamicMessage = new GenericMessage<>("testPayload",
 						ImmutableMap.of("key1", "value1", "key2", "value2", GcpPubSubHeaders.TOPIC, "dynamicTopic"));
 		this.adapter.handleMessage(dynamicMessage);

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -57,7 +57,7 @@ public class PubSubMessageHandlerTests {
 	private Message<?> message;
 
 	@Before
-	public void setUp() throws IOException {
+	public void setUp() {
 		this.message = new GenericMessage<>("testPayload",
 				ImmutableMap.of("key1", "value1", "key2", "value2"));
 		SettableListenableFuture<String> future = new SettableListenableFuture<>();
@@ -71,7 +71,7 @@ public class PubSubMessageHandlerTests {
 	}
 
 	@Test
-	public void testPublish() throws IOException {
+	public void testPublish() {
 		this.adapter.handleMessage(this.message);
 		verify(this.pubSubTemplate, times(1))
 				.publish(eq("testTopic"),
@@ -80,7 +80,7 @@ public class PubSubMessageHandlerTests {
 	}
 
 	@Test
-	public void testPublishDynamicTopic() throws IOException {
+	public void testPublishDynamicTopic() {
 		Message<?> dynamicMessage = new GenericMessage<>("testPayload",
 						ImmutableMap.of("key1", "value1", "key2", "value2", GcpPubSubHeaders.TOPIC, "dynamicTopic"));
 		this.adapter.handleMessage(dynamicMessage);

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gcp.pubsub.integration.outbound;
 
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Map;
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
@@ -16,6 +16,8 @@
 
 package com.example;
 
+import java.io.IOException;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -58,8 +60,8 @@ public class WebController {
 
 	@GetMapping("/postMessage")
 	public RedirectView publish(@RequestParam("message") String message,
-			@RequestParam("topicName") String topicName) {
-		this.pubSubTemplate.publish(topicName, message, null);
+			@RequestParam("topicName") String topicName) throws IOException {
+		this.pubSubTemplate.publish(topicName, message);
 
 		return new RedirectView("/");
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
@@ -16,8 +16,6 @@
 
 package com.example;
 
-import java.io.IOException;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -60,7 +58,7 @@ public class WebController {
 
 	@GetMapping("/postMessage")
 	public RedirectView publish(@RequestParam("message") String message,
-			@RequestParam("topicName") String topicName) throws IOException {
+			@RequestParam("topicName") String topicName) {
 		this.pubSubTemplate.publish(topicName, message);
 
 		return new RedirectView("/");


### PR DESCRIPTION
Users wanting to publish without headers would have had to call
publish(topic, payload, null), which isn't very idiomatic.

Fixes #686