### PR TITLE
Spanner IAM add scope

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
@@ -31,7 +31,8 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 
 	/** Overrides the GCP OAuth2 credentials specified in the Core module. */
 	@NestedConfigurationProperty
-	private final Credentials credentials = new Credentials(GcpScope.SPANNER.getUrl());
+	private final Credentials credentials = new Credentials(
+			GcpScope.SPANNER_DATA.getUrl(), GcpScope.SPANNER_ADMIN.getUrl());
 
 	private String projectId;
 

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
@@ -23,7 +23,8 @@ package org.springframework.cloud.gcp.core;
  */
 public enum GcpScope {
 	PUBSUB("https://www.googleapis.com/auth/pubsub"),
-	SPANNER("https://www.googleapis.com/auth/spanner.data"),
+	SPANNER_ADMIN("https://www.googleapis.com/auth/spanner.admin"),
+	SPANNER_DATA("https://www.googleapis.com/auth/spanner.data"),
 	SQLADMIN("https://www.googleapis.com/auth/sqlservice.admin"),
 	STORAGE_READ_ONLY("https://www.googleapis.com/auth/devstorage.read_only"),
 	STORAGE_READ_WRITE("https://www.googleapis.com/auth/devstorage.read_write"),


### PR DESCRIPTION
fixes #701 

The additional spanner.admin scope is needed when providing the specific credential for spanner in config.

This wasn't apparent before because providing credentials for the core module gives the "https://www.googleapis.com/auth/cloud-platform" scope, which includes every scope in it. 