### PR TITLE
removes dependency on javax.xml.bind

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironment.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironment.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 original author or authors.
+ *  Copyright 2017-2018 original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironment.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironment.java
@@ -17,11 +17,10 @@
 package org.springframework.cloud.gcp.autoconfigure.config;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * Expected response format for Google Runtime Configurator API response.
@@ -106,7 +105,7 @@ class GoogleConfigEnvironment {
 		}
 
 		private String decode(String value) {
-			byte[] decodedValue = DatatypeConverter.parseBase64Binary(value);
+			byte[] decodedValue = Base64.getDecoder().decode(value);
 			return new String(decodedValue, StandardCharsets.UTF_8);
 		}
 	}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironmentTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironmentTest.java
@@ -1,0 +1,19 @@
+package org.springframework.cloud.gcp.autoconfigure.config;
+
+import static org.junit.Assert.*;
+
+import java.util.Base64;
+import org.junit.Test;
+import org.springframework.cloud.gcp.autoconfigure.config.GoogleConfigEnvironment.Variable;
+
+public class GoogleConfigEnvironmentTest {
+
+  @Test
+  public void testSetVariabeValue() {
+    GoogleConfigEnvironment.Variable var = new Variable();
+    String value = "v a l u e";
+    String encodedString = Base64.getEncoder().encodeToString(value.getBytes());
+    var.setValue(encodedString);
+    assertEquals(value, var.getValue());
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironmentTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigEnvironmentTest.java
@@ -1,19 +1,39 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.springframework.cloud.gcp.autoconfigure.config;
 
-import static org.junit.Assert.*;
-
 import java.util.Base64;
+
+import org.junit.Assert;
 import org.junit.Test;
+
 import org.springframework.cloud.gcp.autoconfigure.config.GoogleConfigEnvironment.Variable;
 
+/**
+ * @author Dmitry Solomakha
+ */
 public class GoogleConfigEnvironmentTest {
 
-  @Test
-  public void testSetVariabeValue() {
-    GoogleConfigEnvironment.Variable var = new Variable();
-    String value = "v a l u e";
-    String encodedString = Base64.getEncoder().encodeToString(value.getBytes());
-    var.setValue(encodedString);
-    assertEquals(value, var.getValue());
-  }
+	@Test
+	public void testSetVariabeValue() {
+		GoogleConfigEnvironment.Variable var = new Variable();
+		String value = "v a l u e";
+		String encodedString = Base64.getEncoder().encodeToString(value.getBytes());
+		var.setValue(encodedString);
+		Assert.assertEquals(value, var.getValue());
+	}
 }


### PR DESCRIPTION
Fixes #400 

javax.xml.bind.DatatypeConverter was moved to a separate module in java 9 and also has been deprecated