### PR TITLE
Logging module queries MDC

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/LoggingWebMvcConfigurer.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/LoggingWebMvcConfigurer.java
@@ -53,8 +53,7 @@ public class LoggingWebMvcConfigurer implements WebMvcConfigurer {
 		else {
 			this.interceptor = new TraceIdLoggingWebMvcInterceptor(
 					new CompositeTraceIdExtractor(
-							new XCloudTraceIdExtractor(), new ZipkinTraceIdExtractor()),
-					projectIdProvider);
+							new XCloudTraceIdExtractor(), new ZipkinTraceIdExtractor()));
 		}
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverJsonLayout.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverJsonLayout.java
@@ -41,50 +41,10 @@ import org.springframework.util.StringUtils;
  */
 public class StackdriverJsonLayout extends JsonLayout {
 
-	/**
-	 * The JSON field name for the log level (severity)
-	 */
-	public static final String SEVERITY_ATTRIBUTE = "severity";
-
-	/**
-	 * The JSON field name for the seconds of the timestamp
-	 */
-	public static final String TIMESTAMP_SECONDS_ATTRIBUTE = "timestampSeconds";
-
-	/**
-	 * The JSON field name for the nanos of the timestamp
-	 */
-	public static final String TIMESTAMP_NANOS_ATTRIBUTE = "timestampNanos";
-
-	/**
-	 * The JSON field name for the span-id
-	 */
-	public static final String SPAN_ID_ATTRIBUTE = "logging.googleapis.com/spanId";
-
-	/**
-	 * The JSON field name for the trace-id
-	 */
-	public static final String TRACE_ID_ATTRIBUTE = "logging.googleapis.com/trace";
-
-	/**
-	 * The name of the MDC parameter, Spring Sleuth is storing the trace id at
-	 */
-	public static final String MDC_FIELD_TRACE_ID = "X-B3-TraceId";
-
-	/**
-	 * The name of the MDC parameter, Spring Sleuth is storing the span id at
-	 */
-	public static final String MDC_FIELD_SPAN_ID = "X-B3-SpanId";
-
-	/**
-	 * The name of the MDC parameter, Spring Sleuth is storing the span export information at
-	 */
-	public static final String MDC_FIELD_SPAN_EXPORT = "X-Span-Export";
-
 	private static final Set<String> FILTERED_MDC_FIELDS = new HashSet<>(Arrays.asList(
-			MDC_FIELD_TRACE_ID,
-			MDC_FIELD_SPAN_ID,
-			MDC_FIELD_SPAN_EXPORT));
+			StackdriverTraceConstants.MDC_FIELD_TRACE_ID,
+			StackdriverTraceConstants.MDC_FIELD_SPAN_ID,
+			StackdriverTraceConstants.MDC_FIELD_SPAN_EXPORT));
 
 	private String projectId;
 
@@ -194,11 +154,14 @@ public class StackdriverJsonLayout extends JsonLayout {
 			});
 		}
 		if (this.includeTimestamp) {
-			map.put(TIMESTAMP_SECONDS_ATTRIBUTE, TimeUnit.MILLISECONDS.toSeconds(event.getTimeStamp()));
-			map.put(TIMESTAMP_NANOS_ATTRIBUTE, TimeUnit.MILLISECONDS.toNanos(event.getTimeStamp() % 1_000));
+			map.put(StackdriverTraceConstants.TIMESTAMP_SECONDS_ATTRIBUTE,
+					TimeUnit.MILLISECONDS.toSeconds(event.getTimeStamp()));
+			map.put(StackdriverTraceConstants.TIMESTAMP_NANOS_ATTRIBUTE,
+					TimeUnit.MILLISECONDS.toNanos(event.getTimeStamp() % 1_000));
 		}
 
-		add(SEVERITY_ATTRIBUTE, this.includeLevel, String.valueOf(event.getLevel()), map);
+		add(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, this.includeLevel,
+				String.valueOf(event.getLevel()), map);
 		add(JsonLayout.THREAD_ATTR_NAME, this.includeThreadName, event.getThreadName(), map);
 		add(JsonLayout.LOGGER_ATTR_NAME, this.includeLoggerName, event.getLoggerName(), map);
 
@@ -219,7 +182,8 @@ public class StackdriverJsonLayout extends JsonLayout {
 		add(JsonLayout.CONTEXT_ATTR_NAME, this.includeContextName, event.getLoggerContextVO().getName(), map);
 		addThrowableInfo(JsonLayout.EXCEPTION_ATTR_NAME, this.includeException, event, map);
 		addTraceId(event, map);
-		add(SPAN_ID_ATTRIBUTE, this.includeSpanId, event.getMDCPropertyMap().get(MDC_FIELD_SPAN_ID), map);
+		add(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, this.includeSpanId,
+				event.getMDCPropertyMap().get(StackdriverTraceConstants.MDC_FIELD_SPAN_ID), map);
 		addCustomDataToJsonMap(map, event);
 		return map;
 	}
@@ -240,7 +204,7 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 		String traceId = TraceLoggingEnhancer.getCurrentTraceId();
 		if (traceId == null) {
-			traceId = event.getMDCPropertyMap().get(MDC_FIELD_TRACE_ID);
+			traceId = event.getMDCPropertyMap().get(StackdriverTraceConstants.MDC_FIELD_TRACE_ID);
 		}
 		if (!StringUtils.isEmpty(traceId)
 			&& !StringUtils.isEmpty(this.projectId)
@@ -248,6 +212,6 @@ public class StackdriverJsonLayout extends JsonLayout {
 			traceId = "projects/" + this.projectId + "/traces/" + formatTraceId(traceId);
 		}
 
-		add(TRACE_ID_ATTRIBUTE, this.includeTraceId, traceId, map);
+		add(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, this.includeTraceId, traceId, map);
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.cloud.gcp.autoconfigure.logging.extractors.TraceIdExt
 import org.springframework.cloud.gcp.autoconfigure.logging.extractors.TraceIdExtractorType;
 import org.springframework.cloud.gcp.autoconfigure.logging.extractors.XCloudTraceIdExtractor;
 import org.springframework.cloud.gcp.autoconfigure.logging.extractors.ZipkinTraceIdExtractor;
-import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -46,9 +45,8 @@ public class StackdriverLoggingAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public TraceIdLoggingWebMvcInterceptor loggingWebMvcInterceptor(
-			TraceIdExtractor extractor,
-			GcpProjectIdProvider projectIdProvider) {
-		return new TraceIdLoggingWebMvcInterceptor(extractor, projectIdProvider);
+			TraceIdExtractor extractor) {
+		return new TraceIdLoggingWebMvcInterceptor(extractor);
 	}
 
 	@Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverTraceConstants.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverTraceConstants.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.logging;
+
+/**
+ * @author João André Martins
+ */
+public final class StackdriverTraceConstants {
+
+	private StackdriverTraceConstants() { }
+
+	/**
+	 * The JSON field name for the log level (severity)
+	 */
+	public static final String SEVERITY_ATTRIBUTE = "severity";
+
+	/**
+	 * The JSON field name for the seconds of the timestamp
+	 */
+	public static final String TIMESTAMP_SECONDS_ATTRIBUTE = "timestampSeconds";
+
+	/**
+	 * The JSON field name for the nanos of the timestamp
+	 */
+	public static final String TIMESTAMP_NANOS_ATTRIBUTE = "timestampNanos";
+
+	/**
+	 * The JSON field name for the span-id
+	 */
+	public static final String SPAN_ID_ATTRIBUTE = "logging.googleapis.com/spanId";
+
+	/**
+	 * The JSON field name for the trace-id
+	 */
+	public static final String TRACE_ID_ATTRIBUTE = "logging.googleapis.com/trace";
+
+	/**
+	 * The name of the MDC parameter, Spring Sleuth is storing the trace id at
+	 */
+	public static final String MDC_FIELD_TRACE_ID = "X-B3-TraceId";
+
+	/**
+	 * The name of the MDC parameter, Spring Sleuth is storing the span id at
+	 */
+	public static final String MDC_FIELD_SPAN_ID = "X-B3-SpanId";
+
+	/**
+	 * The name of the MDC parameter, Spring Sleuth is storing the span export information at
+	 */
+	public static final String MDC_FIELD_SPAN_EXPORT = "X-Span-Export";
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/TraceIdLoggingEnhancer.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/TraceIdLoggingEnhancer.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.gcp.autoconfigure.logging;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.LoggingEnhancer;
 
+import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
+import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
+
 /**
  * Adds the trace ID to the logging entry, in its correct format to be displayed in the Logs viewer.
  *
@@ -28,28 +31,46 @@ public class TraceIdLoggingEnhancer implements LoggingEnhancer {
 
 	private static final ThreadLocal<String> traceId = new ThreadLocal<>();
 
-	public static void setCurrentTraceId(String projectId, String id) {
+	private GcpProjectIdProvider projectIdProvider = new DefaultGcpProjectIdProvider();
+
+	public static void setCurrentTraceId(String id) {
 		if (id == null) {
 			traceId.remove();
 		}
 		else {
-			traceId.set("projects/" + projectId + "/traces/" + id);
+			traceId.set(id);
 		}
 	}
 
 	/**
-	 * Returns the trace ID in the "projects/[MY_PROJECT_ID]/traces/[MY_TRACE_ID]".
-	 * @return the trace ID in the "projects/[MY_PROJECT_ID]/traces/[MY_TRACE_ID]"
+	 * @return the trace ID stored through {@link #setCurrentTraceId(String)}
 	 */
 	public static String getCurrentTraceId() {
 		return traceId.get();
 	}
 
+	/**
+	 * Set the trace field of the log entry to the current trace ID.
+	 * <p>The current trace ID is either the trace ID stored in the Mapped Diagnostic Context (MDC)
+	 * under the "X-B3-TraceId" key or, if none set, the current trace ID set by
+	 * {@link #setCurrentTraceId(String)}.
+	 * <p>The trace ID is set in the log entry in the "projects/[GCP_PROJECT_ID]/traces/[TRACE_ID]"
+	 * format, in order to be associated to traces by the Google Cloud Console.
+	 * @param builder
+	 */
 	@Override
 	public void enhanceLogEntry(LogEntry.Builder builder) {
-		String traceId = getCurrentTraceId();
+		// In order not to duplicate the whole google-cloud-logging-logback LoggingAppender to add
+		// the trace ID from the MDC there, we're doing it here.
+		// This requires a call to the org.slf4j package.
+		String traceId = org.slf4j.MDC.get(StackdriverTraceConstants.MDC_FIELD_TRACE_ID);
+		if (traceId == null) {
+			traceId = getCurrentTraceId();
+		}
+
 		if (traceId != null) {
-			builder.setTrace(traceId);
+			builder.setTrace("projects/" + this.projectIdProvider.getProjectId() + "/traces/"
+					+ traceId);
 		}
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/TraceIdLoggingWebMvcInterceptor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/TraceIdLoggingWebMvcInterceptor.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.cloud.gcp.autoconfigure.logging.extractors.TraceIdExtractor;
-import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.util.Assert;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
@@ -40,14 +39,9 @@ public class TraceIdLoggingWebMvcInterceptor extends HandlerInterceptorAdapter {
 
 	private final TraceIdExtractor traceIdExtractor;
 
-	private final GcpProjectIdProvider projectIdProvider;
-
-	public TraceIdLoggingWebMvcInterceptor(TraceIdExtractor extractor,
-			GcpProjectIdProvider projectIdProvider) {
+	public TraceIdLoggingWebMvcInterceptor(TraceIdExtractor extractor) {
 		Assert.notNull(extractor, "A valid trace id extractor is required.");
-		Assert.notNull(projectIdProvider, "A valid project ID provider is required.");
 		this.traceIdExtractor = extractor;
-		this.projectIdProvider = projectIdProvider;
 	}
 
 	public TraceIdExtractor getTraceIdExtractor() {
@@ -59,8 +53,7 @@ public class TraceIdLoggingWebMvcInterceptor extends HandlerInterceptorAdapter {
 			HttpServletResponse resp, Object handler) throws Exception {
 		String traceId = this.traceIdExtractor.extractTraceIdFromRequest(req);
 		if (traceId != null) {
-			TraceIdLoggingEnhancer.setCurrentTraceId(
-					this.projectIdProvider.getProjectId(), traceId);
+			TraceIdLoggingEnhancer.setCurrentTraceId(traceId);
 		}
 		return true;
 	}
@@ -70,6 +63,6 @@ public class TraceIdLoggingWebMvcInterceptor extends HandlerInterceptorAdapter {
 			HttpServletResponse httpServletResponse, Object handler, Exception e) throws Exception {
 		// Note: the thread-local is currently not fully cleared, but just set to null
 		// See: https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2746
-		TraceIdLoggingEnhancer.setCurrentTraceId(this.projectIdProvider.getProjectId(), null);
+		TraceIdLoggingEnhancer.setCurrentTraceId(null);
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverJsonLayoutLoggerTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverJsonLayoutLoggerTests.java
@@ -46,9 +46,9 @@ public class StackdriverJsonLayoutLoggerTests {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			System.setOut(new java.io.PrintStream(out));
 
-			mdc.put(StackdriverJsonLayout.MDC_FIELD_TRACE_ID, "12345678901234561234567890123456");
-			mdc.put(StackdriverJsonLayout.MDC_FIELD_SPAN_ID, "span123");
-			mdc.put(StackdriverJsonLayout.MDC_FIELD_SPAN_EXPORT, "true");
+			mdc.put(StackdriverTraceConstants.MDC_FIELD_TRACE_ID, "12345678901234561234567890123456");
+			mdc.put(StackdriverTraceConstants.MDC_FIELD_SPAN_ID, "span123");
+			mdc.put(StackdriverTraceConstants.MDC_FIELD_SPAN_EXPORT, "true");
 			mdc.put("foo", "bar");
 
 			LOGGER.warn("test");
@@ -56,18 +56,18 @@ public class StackdriverJsonLayoutLoggerTests {
 			Map data = new Gson().fromJson(new String(out.toByteArray()), Map.class);
 
 			checkData(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, "test", data);
-			checkData(StackdriverJsonLayout.SEVERITY_ATTRIBUTE, "WARN", data);
+			checkData(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, "WARN", data);
 			checkData(StackdriverJsonLayout.LOGGER_ATTR_NAME, "StackdriverJsonLayoutLoggerTests", data);
-			checkData(StackdriverJsonLayout.TRACE_ID_ATTRIBUTE,
+			checkData(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
 					"projects/test-project/traces/12345678901234561234567890123456", data);
-			checkData(StackdriverJsonLayout.SPAN_ID_ATTRIBUTE, "span123", data);
+			checkData(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, "span123", data);
 			checkData("foo", "bar", data);
-			assertFalse(data.containsKey(StackdriverJsonLayout.MDC_FIELD_TRACE_ID));
-			assertFalse(data.containsKey(StackdriverJsonLayout.MDC_FIELD_SPAN_ID));
-			assertFalse(data.containsKey(StackdriverJsonLayout.MDC_FIELD_SPAN_EXPORT));
+			assertFalse(data.containsKey(StackdriverTraceConstants.MDC_FIELD_TRACE_ID));
+			assertFalse(data.containsKey(StackdriverTraceConstants.MDC_FIELD_SPAN_ID));
+			assertFalse(data.containsKey(StackdriverTraceConstants.MDC_FIELD_SPAN_EXPORT));
 			assertFalse(data.containsKey(JsonLayout.TIMESTAMP_ATTR_NAME));
-			assertTrue(data.containsKey(StackdriverJsonLayout.TIMESTAMP_SECONDS_ATTRIBUTE));
-			assertTrue(data.containsKey(StackdriverJsonLayout.TIMESTAMP_NANOS_ATTRIBUTE));
+			assertTrue(data.containsKey(StackdriverTraceConstants.TIMESTAMP_SECONDS_ATTRIBUTE));
+			assertTrue(data.containsKey(StackdriverTraceConstants.TIMESTAMP_NANOS_ATTRIBUTE));
 		}
 		finally {
 			System.setOut(oldOut);
@@ -83,13 +83,13 @@ public class StackdriverJsonLayoutLoggerTests {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			System.setOut(new java.io.PrintStream(out));
 
-			mdc.put(StackdriverJsonLayout.MDC_FIELD_TRACE_ID, "1234567890123456");
+			mdc.put(StackdriverTraceConstants.MDC_FIELD_TRACE_ID, "1234567890123456");
 
 			LOGGER.warn("test");
 
 			Map data = new Gson().fromJson(new String(out.toByteArray()), Map.class);
 
-			checkData(StackdriverJsonLayout.TRACE_ID_ATTRIBUTE,
+			checkData(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
 					"projects/test-project/traces/00000000000000001234567890123456", data);
 		}
 		finally {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/TraceIdLoggingWebMvcInterceptorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/TraceIdLoggingWebMvcInterceptorTests.java
@@ -38,24 +38,23 @@ public class TraceIdLoggingWebMvcInterceptorTests {
 	private static final String TRACE_ID_HEADER = "X-CLOUD-TRACE-CONTEXT";
 
 	private TraceIdLoggingWebMvcInterceptor interceptor =
-			new TraceIdLoggingWebMvcInterceptor(new XCloudTraceIdExtractor(), () -> "remission");
+			new TraceIdLoggingWebMvcInterceptor(new XCloudTraceIdExtractor());
 
 	@Test
 	public void testPreHandle() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader(TRACE_ID_HEADER, TEST_TRACE_ID_WITH_SPAN);
 
-		TraceIdLoggingEnhancer.setCurrentTraceId("remission", null);
+		TraceIdLoggingEnhancer.setCurrentTraceId(null);
 
 		this.interceptor.preHandle(request, null, null);
 
-		assertThat(TraceIdLoggingEnhancer.getCurrentTraceId(),
-				is("projects/remission/traces/" + TEST_TRACE_ID));
+		assertThat(TraceIdLoggingEnhancer.getCurrentTraceId(), is(TEST_TRACE_ID));
 	}
 
 	@Test
 	public void testAfterCompletion() throws Exception {
-		TraceIdLoggingEnhancer.setCurrentTraceId("remission", TEST_TRACE_ID);
+		TraceIdLoggingEnhancer.setCurrentTraceId(TEST_TRACE_ID);
 
 		this.interceptor.afterCompletion(null, null, null, null);
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/it/StackdriverLoggingIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/it/StackdriverLoggingIntegrationTests.java
@@ -50,7 +50,10 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 /**
  * @author João André Martins
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = {"spring.main.banner-mode=off"}
+)
 @RunWith(SpringRunner.class)
 public class StackdriverLoggingIntegrationTests {
 
@@ -99,8 +102,8 @@ public class StackdriverLoggingIntegrationTests {
 		} while (pageSize == 0 && counter++ < 20);
 		assertThat(pageSize).isEqualTo(1);
 		assertThat(page.getValues().iterator().next().getTrace())
-				.isEqualTo("projects/" + this.projectIdProvider.getProjectId()
-						+ "/traces/everything-zen");
+				.matches("projects/" + this.projectIdProvider.getProjectId()
+						+ "/traces/([a-z0-9]){32}");
 	}
 
 	@RestController

--- a/spring-cloud-gcp-docs/src/main/asciidoc/logging.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/logging.adoc
@@ -23,16 +23,15 @@ https://cloud.google.com/logging/[Stackdriver Logging] is the managed logging se
 Platform.
 
 This module provides support for associating a web request trace ID with the corresponding log entries.
-This allows grouping of log messages by request.
+It does so by retrieving the `X-B3-TraceId` value from the https://logback.qos.ch/manual/mdc.html[Mapped Diagnostic Context (MDC)], which is set by Spring Cloud Sleuth.
+If Spring Cloud Sleuth isn't used, the configured `TraceIdExtractor` extracts the desired header value and sets it as the log entry's trace ID.
+This allows grouping of log messages by request, for example, in the https://console.cloud.google.com/logs/viewer[Google Cloud Console Logs viewer].
 
-NOTE: Due to the way logging is set up, the GCP project ID and credentials defined in
-`application.properties` are ignored.
-Instead, you should set the `GOOGLE_CLOUD_PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS` environment
-variables to the project ID and credentials private key location, respectively.
+NOTE: Due to the way logging is set up, the GCP project ID and credentials defined in `application.properties` are ignored.
+Instead, you should set the `GOOGLE_CLOUD_PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS` environment variables to the project ID and credentials private key location, respectively.
+You can do this easily if you're using the http://cloud.google.com/sdk[Google Cloud SDK], using the `gcloud config set project [YOUR_PROJECT_ID]` and `gcloud auth application-default login` commands, respectively.
 
-`TraceIdLoggingWebMvcInterceptor` extracts the request trace ID from an HTTP request using a
-`TraceIdExtractor` and stores it in a thread-local of the https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-logging/src/main/java/com/google/cloud/logging/TraceLoggingEnhancer.java[`TraceLoggingEnhancer`]
-which can then be used in a logging appender to add the trace ID metadata to log messages.
+`TraceIdLoggingWebMvcInterceptor` extracts the request trace ID from an HTTP request using a `TraceIdExtractor` and stores it in a thread-local, which can then be used in a logging appender to add the trace ID metadata to log messages.
 
 There are implementations provided for `TraceIdExtractor`:
 
@@ -55,9 +54,14 @@ and https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-
 There are 2 possibilities to log to Stackdriver via this library with Logback:
 
 ==== Log via API
+A Stackdriver appender is available using `org/springframework/cloud/gcp/autoconfigure/logging/logback-appender.xml`.
+This appender builds a Stackdriver Logging log entry from a JUL or Logback log entry, adds a trace ID to it and sends it to Stackdriver Logging.
 
-For Logback, a `org/springframework/cloud/gcp/autoconfigure/logging/logback-json-appender.xml` file is
-made available for import to make it easier to configure the JSON Logback appender.
+`STACKDRIVER_LOG_NAME` and `STACKDRIVER_LOG_FLUSH_LEVEL` environment variables can be used to customize the `STACKDRIVER` appender.
+
+==== Log via Console
+
+For Logback, a `org/springframework/cloud/gcp/autoconfigure/logging/logback-json-appender.xml` file is made available for import to make it easier to configure the JSON Logback appender.
 
 Your configuration may then look something like this:
 [source, xml]
@@ -66,35 +70,14 @@ Your configuration may then look something like this:
   <include resource="org/springframework/cloud/gcp/autoconfigure/logging/logback-json-appender.xml" />
 
   <root level="INFO">
-    <appender-ref ref="STACKDRIVER" />
+    <appender-ref ref="CONSOLE_JSON" />
   </root>
 </configuration>
 ----
 
-A Stackdriver appender is also available using `org/springframework/cloud/gcp/autoconfigure/logging/logback-appender.xml`.
-
-`STACKDRIVER_LOG_NAME` and `STACKDRIVER_LOG_FLUSH_LEVEL` environment variables can be used to customize the
-`STACKDRIVER` appender.
-
-Also see the link:../spring-cloud-gcp-starters/spring-cloud-gcp-starter-logging[spring-cloud-gcp-starter-logging] module.
-
-==== Log via Console
-
-If you run your Spring Boot application in a Kubernetes cluster in the Google Cloud (GKE) or on App Engine flexible
-environment, you can log JSON directly from the console by including
-`org/springframework/cloud/gcp/autoconfigure/logging/logback-json-appender.xml`. The traceId will be set
-correctly.
-
-You need the additional dependency:
-
-[source, xml]
-----
-<dependency>
-  <groupId>ch.qos.logback.contrib</groupId>
-  <artifactId>logback-json-classic</artifactId>
-  <version>0.1.5</version>
-</dependency>
-----
+If your application is running on Google Container Engine, Google Compute Engine or Google App Engine Flexible, your console logging is automatically saved to Google Stackdriver Logging.
+Therefore, you can just include `org/springframework/cloud/gcp/autoconfigure/logging/logback-json-appender.xml` in your logging configuration, which logs JSON entries to the console.
+The trace id will be set correctly.
 
 Your Logback configuration may then look something like this:
 


### PR DESCRIPTION
If MDC doesn't have any saved trace ID (read: Sleuth isn't used), then
logging resorts to the trace ID manually extracted from the request, in
order to group log entries by trace ID.

Fixes #637