### PR TITLE
pubsub factory direct settings and compound-setting beans

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -36,6 +36,7 @@ import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import org.threeten.bp.Duration;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -57,7 +58,6 @@ import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessa
 import org.springframework.cloud.gcp.pubsub.support.converter.PubSubMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.lang.Nullable;
 
 /**
  * @author João André Martins
@@ -136,10 +136,11 @@ public class GcpPubSubAutoConfiguration {
 	public SubscriberFactory defaultSubscriberFactory(
 			@Qualifier("subscriberExecutorProvider") ExecutorProvider executorProvider,
 			@Qualifier("subscriberSystemExecutorProvider")
-			@Nullable ExecutorProvider systemExecutorProvider,
-			@Qualifier("subscriberFlowControlSettings") @Nullable FlowControlSettings flowControlSettings,
-			@Qualifier("subscriberApiClock") @Nullable ApiClock apiClock,
-			@Qualifier("subscriberRetrySettings") @Nullable RetrySettings retrySettings,
+			@Autowired(required = false) ExecutorProvider systemExecutorProvider,
+			@Qualifier("subscriberFlowControlSettings") @Autowired(required = false)
+					FlowControlSettings flowControlSettings,
+			@Qualifier("subscriberApiClock") @Autowired(required = false) ApiClock apiClock,
+			@Qualifier("subscriberRetrySettings") @Autowired(required = false) RetrySettings retrySettings,
 			TransportChannelProvider transportChannelProvider) {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(this.finalProjectIdProvider);
 		factory.setExecutorProvider(executorProvider);
@@ -182,8 +183,9 @@ public class GcpPubSubAutoConfiguration {
 	@ConditionalOnMissingBean
 	public PublisherFactory defaultPublisherFactory(
 			@Qualifier("publisherExecutorProvider") ExecutorProvider executorProvider,
-			@Qualifier("publisherBatchSettings") @Nullable BatchingSettings batchingSettings,
-			@Qualifier("publisherRetrySettings") @Nullable RetrySettings retrySettings,
+			@Qualifier("publisherBatchSettings") @Autowired(required = false)
+					BatchingSettings batchingSettings,
+			@Qualifier("publisherRetrySettings") @Autowired(required = false) RetrySettings retrySettings,
 			TransportChannelProvider transportChannelProvider) {
 		DefaultPublisherFactory factory = new DefaultPublisherFactory(this.finalProjectIdProvider);
 		factory.setExecutorProvider(executorProvider);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -132,30 +132,6 @@ public class GcpPubSubAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(name = "subscriberSystemExecutorProvider")
-	public ExecutorProvider subscriberSystemExecutorProvider() {
-		return null;
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(name = "subscriberFlowControlSettings")
-	public FlowControlSettings subscriberFlowControlSettings() {
-		return null;
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(name = "subscriberApiClock")
-	public ApiClock subscriberApiClock() {
-		return null;
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(name = "subscriberRetrySettings")
-	public RetrySettings subscriberRetrySettings() {
-		return null;
-	}
-
-	@Bean
 	@ConditionalOnMissingBean
 	public SubscriberFactory defaultSubscriberFactory(
 			@Qualifier("subscriberExecutorProvider") ExecutorProvider executorProvider,
@@ -200,18 +176,6 @@ public class GcpPubSubAutoConfiguration {
 					this.gcpPubSubProperties.getSubscriber().getPullEndpoint());
 		}
 		return factory;
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(name = "publisherRetrySettings")
-	public RetrySettings publisherRetrySettings() {
-		return null;
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(name = "publisherBatchSettings")
-	public BatchingSettings publisherBatchSettings() {
-		return null;
 	}
 
 	@Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -87,7 +87,8 @@ public class GcpPubSubAutoConfiguration {
 				? gcpPubSubProperties::getProjectId
 				: gcpProjectIdProvider;
 
-		if (gcpPubSubProperties.getEmulatorHost() == null || "false".equals(gcpPubSubProperties.getEmulatorHost())) {
+		if (gcpPubSubProperties.getEmulatorHost() == null
+				|| "false".equals(gcpPubSubProperties.getEmulatorHost())) {
 			this.finalCredentialsProvider = gcpPubSubProperties.getCredentials().hasKey()
 					? new DefaultCredentialsProvider(gcpPubSubProperties)
 					: credentialsProvider;
@@ -104,14 +105,14 @@ public class GcpPubSubAutoConfiguration {
 	@ConditionalOnMissingBean(name = "publisherExecutorProvider")
 	public ExecutorProvider publisherExecutorProvider() {
 		return FixedExecutorProvider.create(Executors.newScheduledThreadPool(
-				this.gcpPubSubProperties.getPublisherExecutorThreads()));
+				this.gcpPubSubProperties.getPublisher().getExecutorThreads()));
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(name = "subscriberExecutorProvider")
 	public ExecutorProvider subscriberExecutorProvider() {
 		return FixedExecutorProvider.create(Executors.newScheduledThreadPool(
-				this.gcpPubSubProperties.getSubscriberExecutorThreads()));
+				this.gcpPubSubProperties.getSubscriber().getExecutorThreads()));
 	}
 
 	@Bean
@@ -158,7 +159,8 @@ public class GcpPubSubAutoConfiguration {
 	@ConditionalOnMissingBean
 	public SubscriberFactory defaultSubscriberFactory(
 			@Qualifier("subscriberExecutorProvider") ExecutorProvider executorProvider,
-			@Qualifier("subscriberSystemExecutorProvider") @Nullable ExecutorProvider systemExecutorProvider,
+			@Qualifier("subscriberSystemExecutorProvider")
+			@Nullable ExecutorProvider systemExecutorProvider,
 			@Qualifier("subscriberFlowControlSettings") @Nullable FlowControlSettings flowControlSettings,
 			@Qualifier("subscriberApiClock") @Nullable ApiClock apiClock,
 			@Qualifier("subscriberRetrySettings") @Nullable RetrySettings retrySettings,
@@ -180,16 +182,22 @@ public class GcpPubSubAutoConfiguration {
 		if (retrySettings != null) {
 			factory.setSubscriberStubRetrySettings(retrySettings);
 		}
-		if (this.gcpPubSubProperties.getSubscriberMaxAckDurationSeconds().isPresent()) {
+		if (this.gcpPubSubProperties.getSubscriber().getMaxAckDurationSeconds()
+				.isPresent()) {
 			factory.setMaxAckDurationPeriod(Duration.ofSeconds(
-					this.gcpPubSubProperties.getSubscriberMaxAckDurationSeconds().get()));
+					this.gcpPubSubProperties.getSubscriber()
+							.getMaxAckDurationSeconds().get()));
 		}
-		if (this.gcpPubSubProperties.getSubscriberParallelPullCount().isPresent()) {
+		if (this.gcpPubSubProperties.getSubscriber().getParallelPullCount()
+				.isPresent()) {
 			factory.setParallelPullCount(
-					this.gcpPubSubProperties.getSubscriberParallelPullCount().get());
+					this.gcpPubSubProperties.getSubscriber()
+							.getParallelPullCount().get());
 		}
-		if (this.gcpPubSubProperties.getSubscriberPullEndpoint() != null) {
-			factory.setPullEndpoint(this.gcpPubSubProperties.getSubscriberPullEndpoint());
+		if (this.gcpPubSubProperties.getSubscriber()
+				.getPullEndpoint() != null) {
+			factory.setPullEndpoint(
+					this.gcpPubSubProperties.getSubscriber().getPullEndpoint());
 		}
 		return factory;
 	}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubProperties.java
@@ -31,11 +31,18 @@ import org.springframework.cloud.gcp.core.GcpScope;
  */
 @ConfigurationProperties("spring.cloud.gcp.pubsub")
 public class GcpPubSubProperties implements CredentialsSupplier {
-	/** Number of threads used by every {@link com.google.cloud.pubsub.v1.Subscriber}. */
-	private int subscriberExecutorThreads = 4;
 
-	/** Number of threads used by every {@link com.google.cloud.pubsub.v1.Publisher}. */
-	private int publisherExecutorThreads = 4;
+	private final Subscriber subscriber = new Subscriber();
+
+	private final Publisher publisher = new Publisher();
+
+	public Subscriber getSubscriber() {
+		return this.subscriber;
+	}
+
+	public Publisher getPublisher() {
+		return this.publisher;
+	}
 
 	/** Overrides the GCP project ID specified in the Core module. */
 	private String projectId;
@@ -52,66 +59,9 @@ public class GcpPubSubProperties implements CredentialsSupplier {
 	 */
 	private String[] trustedPackages;
 
-	/**
-	 * The optional pull endpoint setting for the subscriber factory.
-	 */
-	private String subscriberPullEndpoint;
-
-	/**
-	 * The optional max ack duration in seconds for the subscriber factory.
-	 */
-	private Optional<Long> subscriberMaxAckDurationSeconds = Optional.empty();
-
-	/**
-	 * The optional parallel pull count setting for the subscriber factory.
-	 */
-	private Optional<Integer> subscriberParallelPullCount = Optional.empty();
-
-	public String getSubscriberPullEndpoint() {
-		return this.subscriberPullEndpoint;
-	}
-
-	public void setSubscriberPullEndpoint(String subscriberPullEndpoint) {
-		this.subscriberPullEndpoint = subscriberPullEndpoint;
-	}
-
-	public Optional<Long> getSubscriberMaxAckDurationSeconds() {
-		return this.subscriberMaxAckDurationSeconds;
-	}
-
-	public void setSubscriberMaxAckDurationSeconds(
-			Optional<Long> subscriberMaxAckDurationSeconds) {
-		this.subscriberMaxAckDurationSeconds = subscriberMaxAckDurationSeconds;
-	}
-
-	public Optional<Integer> getSubscriberParallelPullCount() {
-		return this.subscriberParallelPullCount;
-	}
-
-	public void setSubscriberParallelPullCount(
-			Optional<Integer> subscriberParallelPullCount) {
-		this.subscriberParallelPullCount = subscriberParallelPullCount;
-	}
-
 	/** Overrides the GCP OAuth2 credentials specified in the Core module. */
 	@NestedConfigurationProperty
 	private final Credentials credentials = new Credentials(GcpScope.PUBSUB.getUrl());
-
-	public int getSubscriberExecutorThreads() {
-		return this.subscriberExecutorThreads;
-	}
-
-	public void setSubscriberExecutorThreads(int subscriberExecutorThreads) {
-		this.subscriberExecutorThreads = subscriberExecutorThreads;
-	}
-
-	public int getPublisherExecutorThreads() {
-		return this.publisherExecutorThreads;
-	}
-
-	public void setPublisherExecutorThreads(int publisherExecutorThreads) {
-		this.publisherExecutorThreads = publisherExecutorThreads;
-	}
 
 	public String getProjectId() {
 		return this.projectId;
@@ -139,5 +89,76 @@ public class GcpPubSubProperties implements CredentialsSupplier {
 
 	public void setTrustedPackages(String[] trustedPackages) {
 		this.trustedPackages = trustedPackages;
+	}
+
+	public static class Publisher {
+
+		/**
+		 * Number of threads used by every {@link com.google.cloud.pubsub.v1.Publisher}.
+		 */
+		private int executorThreads = 4;
+
+		public int getExecutorThreads() {
+			return this.executorThreads;
+		}
+
+		public void setExecutorThreads(int executorThreads) {
+			this.executorThreads = executorThreads;
+		}
+	}
+
+	public static class Subscriber {
+
+		/**
+		 * Number of threads used by every {@link com.google.cloud.pubsub.v1.Subscriber}.
+		 */
+		private int executorThreads = 4;
+
+		/**
+		 * The optional pull endpoint setting for the subscriber factory.
+		 */
+		private String pullEndpoint;
+
+		/**
+		 * The optional max ack duration in seconds for the subscriber factory.
+		 */
+		private Optional<Long> maxAckDurationSeconds = Optional.empty();
+
+		/**
+		 * The optional parallel pull count setting for the subscriber factory.
+		 */
+		private Optional<Integer> parallelPullCount = Optional.empty();
+
+		public String getPullEndpoint() {
+			return this.pullEndpoint;
+		}
+
+		public void setPullEndpoint(String pullEndpoint) {
+			this.pullEndpoint = pullEndpoint;
+		}
+
+		public Optional<Long> getMaxAckDurationSeconds() {
+			return this.maxAckDurationSeconds;
+		}
+
+		public void setMaxAckDurationSeconds(Optional<Long> maxAckDurationSeconds) {
+			this.maxAckDurationSeconds = maxAckDurationSeconds;
+		}
+
+		public Optional<Integer> getParallelPullCount() {
+			return this.parallelPullCount;
+		}
+
+		public void setParallelPullCount(Optional<Integer> parallelPullCount) {
+			this.parallelPullCount = parallelPullCount;
+		}
+
+		public int getExecutorThreads() {
+			return this.executorThreads;
+		}
+
+		public void setExecutorThreads(int executorThreads) {
+			this.executorThreads = executorThreads;
+		}
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.autoconfigure.pubsub;
 
+import java.util.Optional;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.cloud.gcp.core.Credentials;
@@ -49,6 +51,47 @@ public class GcpPubSubProperties implements CredentialsSupplier {
 	 * message payloads.
 	 */
 	private String[] trustedPackages;
+
+	/**
+	 * The optional pull endpoint setting for the subscriber factory.
+	 */
+	private String subscriberPullEndpoint;
+
+	/**
+	 * The optional max ack duration in seconds for the subscriber factory.
+	 */
+	private Optional<Long> subscriberMaxAckDurationSeconds = Optional.empty();
+
+	/**
+	 * The optional parallel pull count setting for the subscriber factory.
+	 */
+	private Optional<Integer> subscriberParallelPullCount = Optional.empty();
+
+	public String getSubscriberPullEndpoint() {
+		return this.subscriberPullEndpoint;
+	}
+
+	public void setSubscriberPullEndpoint(String subscriberPullEndpoint) {
+		this.subscriberPullEndpoint = subscriberPullEndpoint;
+	}
+
+	public Optional<Long> getSubscriberMaxAckDurationSeconds() {
+		return this.subscriberMaxAckDurationSeconds;
+	}
+
+	public void setSubscriberMaxAckDurationSeconds(
+			Optional<Long> subscriberMaxAckDurationSeconds) {
+		this.subscriberMaxAckDurationSeconds = subscriberMaxAckDurationSeconds;
+	}
+
+	public Optional<Integer> getSubscriberParallelPullCount() {
+		return this.subscriberParallelPullCount;
+	}
+
+	public void setSubscriberParallelPullCount(
+			Optional<Integer> subscriberParallelPullCount) {
+		this.subscriberParallelPullCount = subscriberParallelPullCount;
+	}
 
 	/** Overrides the GCP OAuth2 credentials specified in the Core module. */
 	@NestedConfigurationProperty

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfigurationTests.java
@@ -40,8 +40,8 @@ public class GcpPubSubEmulatorConfigurationTests {
 					"spring.cloud.gcp.projectId=test-project",
 					"spring.cloud.gcp.pubsub.trusted-packages[0]=a",
 					"spring.cloud.gcp.pubsub.trusted-packages[1]=b",
-					"spring.cloud.gcp.pubsub.subscriber-pull-endpoint=fake-endpoint",
-					"spring.cloud.gcp.pubsub.subscriber-parallel-pull-count=333")
+					"spring.cloud.gcp.pubsub.subscriber.pull-endpoint=fake-endpoint",
+					"spring.cloud.gcp.pubsub.subscriber.parallel-pull-count=333")
 			.withConfiguration(AutoConfigurations.of(GcpPubSubEmulatorConfiguration.class,
 					GcpContextAutoConfiguration.class,
 					GcpPubSubAutoConfiguration.class));
@@ -81,11 +81,11 @@ public class GcpPubSubEmulatorConfigurationTests {
 			GcpPubSubProperties gcpPubSubProperties = context
 					.getBean(GcpPubSubProperties.class);
 			Assert.assertEquals("fake-endpoint",
-					gcpPubSubProperties.getSubscriberPullEndpoint());
+					gcpPubSubProperties.getSubscriber().getPullEndpoint());
 			Assert.assertEquals(333,
-					(int) gcpPubSubProperties.getSubscriberParallelPullCount().get());
+					(int) gcpPubSubProperties.getSubscriber().getParallelPullCount().get());
 			Assert.assertFalse(
-					gcpPubSubProperties.getSubscriberMaxAckDurationSeconds().isPresent());
+					gcpPubSubProperties.getSubscriber().getMaxAckDurationSeconds().isPresent());
 		});
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorConfigurationTests.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfigurat
 /**
  * @author Andreas Berger
  * @author João André Martins
+ * @author Chengyuan Zhao
  */
 public class GcpPubSubEmulatorConfigurationTests {
 
@@ -38,7 +39,9 @@ public class GcpPubSubEmulatorConfigurationTests {
 			.withPropertyValues("spring.cloud.gcp.pubsub.emulator-host=localhost:8085",
 					"spring.cloud.gcp.projectId=test-project",
 					"spring.cloud.gcp.pubsub.trusted-packages[0]=a",
-					"spring.cloud.gcp.pubsub.trusted-packages[1]=b")
+					"spring.cloud.gcp.pubsub.trusted-packages[1]=b",
+					"spring.cloud.gcp.pubsub.subscriber-pull-endpoint=fake-endpoint",
+					"spring.cloud.gcp.pubsub.subscriber-parallel-pull-count=333")
 			.withConfiguration(AutoConfigurations.of(GcpPubSubEmulatorConfiguration.class,
 					GcpContextAutoConfiguration.class,
 					GcpPubSubAutoConfiguration.class));
@@ -69,6 +72,20 @@ public class GcpPubSubEmulatorConfigurationTests {
 			Assert.assertEquals(2, trustedPackages.length);
 			Assert.assertEquals("a", trustedPackages[0]);
 			Assert.assertEquals("b", trustedPackages[1]);
+		});
+	}
+
+	@Test
+	public void testSubscriberPullConfig() {
+		this.contextRunner.run(context -> {
+			GcpPubSubProperties gcpPubSubProperties = context
+					.getBean(GcpPubSubProperties.class);
+			Assert.assertEquals("fake-endpoint",
+					gcpPubSubProperties.getSubscriberPullEndpoint());
+			Assert.assertEquals(333,
+					(int) gcpPubSubProperties.getSubscriberParallelPullCount().get());
+			Assert.assertFalse(
+					gcpPubSubProperties.getSubscriberMaxAckDurationSeconds().isPresent());
 		});
 	}
 }

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -261,7 +261,7 @@ The Spring Boot starter for Google Cloud Pub/Sub provides the following configur
 | `spring.cloud.gcp.pubsub.enabled` | Enables or disables Pub/Sub auto-configuration | No | `true`
 | `spring.cloud.gcp.pubsub.subscriber-executor-threads` | Number of threads used by `Subscriber`
 instances created by `SubscriberFactory` | No | 4
-| `spring.cloud.gcp.pubsub.publisher-executor-threads` | Number of threads used by `Publisher`
+| `spring.cloud.gcp.pubsub.publisher.executor-threads` | Number of threads used by `Publisher`
 instances created by `PublisherFactory` | No | 4
 | `spring.cloud.gcp.pubsub.project-id` | GCP project ID where the Google Cloud Pub/Sub API
 is hosted, if different from the one in the <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>>
@@ -274,7 +274,7 @@ https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for 
 Pub/Sub credentials | No | https://www.googleapis.com/auth/pubsub
 | `spring.cloud.gcp.pubsub.trustedPackages[n]` |
 Package names that contain the types that are whitelisted for deserializing message payloads | No | When using `JacksonMessageConverter` the default trusted packages listed in `org.springframework.integration.support.json.JacksonJsonUtils` are always trusted.
-| `spring.cloud.gcp.pubsub.subscriber-parallel-pull-count` | The number of pull workers | No | The available number of processors
-| `spring.cloud.gcp.pubsub.subscriber-max-ack-duration-seconds` | The maximum period a message ack deadline will be extended in seconds | No | 3600
-| `spring.cloud.gcp.pubsub.subscriber-pull-endpoint` | The endpoint for synchronous pulling messages | No | pubsub.googleapis.com:443
+| `spring.cloud.gcp.pubsub.subscriber.parallel-pull-count` | The number of pull workers | No | The available number of processors
+| `spring.cloud.gcp.pubsub.subscriber.max-ack-duration-seconds` | The maximum period a message ack deadline will be extended in seconds | No | 3600
+| `spring.cloud.gcp.pubsub.subscriber.pull-endpoint` | The endpoint for synchronous pulling messages | No | pubsub.googleapis.com:443
 |===

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -274,4 +274,7 @@ https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for 
 Pub/Sub credentials | No | https://www.googleapis.com/auth/pubsub
 | `spring.cloud.gcp.pubsub.trustedPackages[n]` |
 Package names that contain the types that are whitelisted for deserializing message payloads | No | When using `JacksonMessageConverter` the default trusted packages listed in `org.springframework.integration.support.json.JacksonJsonUtils` are always trusted.
+| `spring.cloud.gcp.pubsub.subscriber-parallel-pull-count` | The number of pull workers | No | The available number of processors
+| `spring.cloud.gcp.pubsub.subscriber-max-ack-duration-seconds` | The maximum period a message ack deadline will be extended in seconds | No | 3600
+| `spring.cloud.gcp.pubsub.subscriber-pull-endpoint` | The endpoint for synchronous pulling messages | No | pubsub.googleapis.com:443
 |===

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -259,7 +259,7 @@ The Spring Boot starter for Google Cloud Pub/Sub provides the following configur
 |===
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.pubsub.enabled` | Enables or disables Pub/Sub auto-configuration | No | `true`
-| `spring.cloud.gcp.pubsub.subscriber-executor-threads` | Number of threads used by `Subscriber`
+| `spring.cloud.gcp.pubsub.subscriber.executor-threads` | Number of threads used by `Subscriber`
 instances created by `SubscriberFactory` | No | 4
 | `spring.cloud.gcp.pubsub.publisher.executor-threads` | Number of threads used by `Publisher`
 instances created by `PublisherFactory` | No | 4


### PR DESCRIPTION
discussed in #363

This PR adds the documentation and properties for settings that are not the compound setting objects (retry , batch, and flow control settings). Beans are added for these compound settings.

Exposing those beans as properties will come in the next PR. 