### PR TITLE
Remove hard dependency on WebMVC from Logging

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverJsonLayout.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverJsonLayout.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.contrib.json.classic.JsonLayout;
-import com.google.cloud.logging.TraceLoggingEnhancer;
 import com.google.gson.Gson;
 
 import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
@@ -205,11 +204,11 @@ public class StackdriverJsonLayout extends JsonLayout {
 		String traceId =
 				event.getMDCPropertyMap().get(StackdriverTraceConstants.MDC_FIELD_TRACE_ID);
 		if (traceId == null) {
-			traceId = TraceLoggingEnhancer.getCurrentTraceId();
+			traceId = TraceIdLoggingEnhancer.getCurrentTraceId();
 		}
 		if (!StringUtils.isEmpty(traceId)
-			&& !StringUtils.isEmpty(this.projectId)
-			&& !this.projectId.endsWith("_IS_UNDEFINED")) {
+				&& !StringUtils.isEmpty(this.projectId)
+				&& !this.projectId.endsWith("_IS_UNDEFINED")) {
 			traceId = StackdriverTraceConstants.composeFullTraceName(
 					this.projectId, formatTraceId(traceId));
 		}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.gcp.autoconfigure.logging;
 
-import com.google.cloud.logging.TraceLoggingEnhancer;
+import com.google.cloud.logging.logback.LoggingAppender;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -33,13 +33,18 @@ import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 /**
+ * This class configures a Web MVC interceptor to capture trace IDs for log correlation.
+ * This configuration is turned on only if Sleuth is not used, and both Web MVC and the
+ * GCP Logback appender are used.
+ *
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  */
 @Configuration
-@ConditionalOnClass(TraceLoggingEnhancer.class)
+@ConditionalOnClass({ LoggingAppender.class, HandlerInterceptorAdapter.class })
 @ConditionalOnMissingBean(SleuthProperties.class)
 @AutoConfigureAfter(StackdriverTraceAutoConfiguration.class)
 @EnableConfigurationProperties({ StackdriverLoggingProperties.class })

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.gcp.autoconfigure.logging;
 
-import com.google.cloud.logging.logback.LoggingAppender;
-
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -37,14 +35,14 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 /**
  * This class configures a Web MVC interceptor to capture trace IDs for log correlation.
- * This configuration is turned on only if Sleuth is not used, and both Web MVC and the
- * GCP Logback appender are used.
+ * This configuration is turned on only if Sleuth is not used and Web MVC is used.
+ * Otherwise, the MDC context will be used by the Logback appenders.
  *
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  */
 @Configuration
-@ConditionalOnClass({ LoggingAppender.class, HandlerInterceptorAdapter.class })
+@ConditionalOnClass(HandlerInterceptorAdapter.class)
 @ConditionalOnMissingBean(SleuthProperties.class)
 @AutoConfigureAfter(StackdriverTraceAutoConfiguration.class)
 @EnableConfigurationProperties({ StackdriverLoggingProperties.class })

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverJsonLayoutLoggerTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverJsonLayoutLoggerTests.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @author Andreas Berger
+ * @author Mike Eltsufin
  */
 public class StackdriverJsonLayoutLoggerTests {
 
@@ -97,6 +98,31 @@ public class StackdriverJsonLayoutLoggerTests {
 			mdc.clear();
 		}
 	}
+
+	@Test
+	public void testEnhancerNoMdc() {
+		PrintStream oldOut = System.out;
+
+		try {
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			System.setOut(new java.io.PrintStream(out));
+
+			String traceId = "1234567890123456";
+			TraceIdLoggingEnhancer.setCurrentTraceId(traceId);
+
+			LOGGER.warn("test");
+
+			Map data = new Gson().fromJson(new String(out.toByteArray()), Map.class);
+
+			checkData(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
+					"projects/test-project/traces/0000000000000000" + traceId, data);
+		}
+		finally {
+			System.setOut(oldOut);
+			TraceIdLoggingEnhancer.setCurrentTraceId(null);
+		}
+	}
+
 
 	private void checkData(String attribute, Object value, Map data) {
 		Object actual = data.get(attribute);

--- a/spring-cloud-gcp-docs/src/main/asciidoc/logging.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/logging.adoc
@@ -31,7 +31,9 @@ NOTE: Due to the way logging is set up, the GCP project ID and credentials defin
 Instead, you should set the `GOOGLE_CLOUD_PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS` environment variables to the project ID and credentials private key location, respectively.
 You can do this easily if you're using the http://cloud.google.com/sdk[Google Cloud SDK], using the `gcloud config set project [YOUR_PROJECT_ID]` and `gcloud auth application-default login` commands, respectively.
 
-`TraceIdLoggingWebMvcInterceptor` extracts the request trace ID from an HTTP request using a `TraceIdExtractor` and stores it in a thread-local, which can then be used in a logging appender to add the trace ID metadata to log messages.
+=== Web MVC Interceptor
+
+For use in Web MVC-based applications, `TraceIdLoggingWebMvcInterceptor` is provided that extracts the request trace ID from an HTTP request using a `TraceIdExtractor` and stores it in a thread-local, which can then be used in a logging appender to add the trace ID metadata to log messages.
 
 WARNING: If Spring Cloud GCP Trace is enabled, the logging module disables itself and delegates log correlation to Spring Cloud Sleuth.
 
@@ -48,12 +50,10 @@ There are implementations provided for `TraceIdExtractor`:
 `LoggingWebMvcConfigurer` configuration class is also provided to help register the `TraceIdLoggingWebMvcInterceptor`
 in Spring MVC applications.
 
-Currently, https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-logging#add-a-stackdriver-logging-handler-to-a-logger[Java Util Logging (JUL)]
-and https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-contrib/google-cloud-logging-logback[Logback] are supported.
-
 === Logback Support
 
-There are 2 possibilities to log to Stackdriver via this library with Logback:
+Currently, only Logback is supported and there are 2 possibilities to log to Stackdriver via this library with Logback:
+via direct API calls and through JSON-formatted console logs.
 
 ==== Log via API
 A Stackdriver appender is available using `org/springframework/cloud/gcp/autoconfigure/logging/logback-appender.xml`.

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-logging/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-logging/pom.xml
@@ -25,9 +25,5 @@
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-logging-logback</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The logging starter can now also be used without Web MVC.
In this case the Web MVC interceptor for trace id extraction will not
automatically kick in.

Fixes #713.