### PR TITLE
Improve message conversion in Pub/Sub channel adapter

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
@@ -144,7 +144,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 			try {
 				context.getBean(PubSubInboundChannelAdapter.class).setAckMode(AckMode.MANUAL);
 				context.getBean("inputChannel", MessageChannel.class).send(
-						MessageBuilder.withPayload("I am a message.").build());
+						MessageBuilder.withPayload("I am a message.".getBytes()).build());
 
 				PollableChannel channel = context.getBean("outputChannel", PollableChannel.class);
 
@@ -188,7 +188,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 						});
 				context.getBean(PubSubMessageHandler.class).setPublishCallback(callbackSpy);
 				context.getBean("inputChannel", MessageChannel.class).send(
-						MessageBuilder.withPayload("I am a message.").build());
+						MessageBuilder.withPayload("I am a message.".getBytes()).build());
 
 				Message<?> message =
 						context.getBean("outputChannel", PollableChannel.class).receive(5000);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
@@ -48,6 +48,7 @@ import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.serializer.support.DeserializingConverter;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
@@ -95,6 +96,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 				context.getBean("inputChannel", MessageChannel.class).send(
 						MessageBuilder.createMessage("I am a message.",
 								new MessageHeaders(headers)));
+				context.getBean(PubSubInboundChannelAdapter.class).setPayloadConverter(new DeserializingConverter());
 
 				Message<?> message =
 						context.getBean("outputChannel", PollableChannel.class).receive(5000);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
@@ -48,7 +48,6 @@ import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.serializer.support.DeserializingConverter;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
@@ -94,9 +93,8 @@ public class PubSubChannelAdaptersIntegrationTests {
 				headers.put("sleep", "lift your skinny fists");
 
 				context.getBean("inputChannel", MessageChannel.class).send(
-						MessageBuilder.createMessage("I am a message.",
+						MessageBuilder.createMessage("I am a message.".getBytes(),
 								new MessageHeaders(headers)));
-				context.getBean(PubSubInboundChannelAdapter.class).setPayloadConverter(new DeserializingConverter());
 
 				Message<?> message =
 						context.getBean("outputChannel", PollableChannel.class).receive(5000);
@@ -123,7 +121,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 		this.contextRunner.run(context -> {
 			try {
 				context.getBean("inputChannel", MessageChannel.class).send(
-						MessageBuilder.withPayload("I am a message.").build());
+						MessageBuilder.withPayload("I am a message.".getBytes()).build());
 
 				Message<?> message =
 						context.getBean("outputChannel", PollableChannel.class).receive(5000);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
@@ -55,7 +55,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.messaging.converter.StringMessageConverter;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 
@@ -93,9 +92,6 @@ public class PubSubChannelAdaptersIntegrationTests {
 				headers.put("static", "lift your skinny fists");
 				headers.put("sleep", "lift your skinny fists");
 
-				context.getBean(PubSubInboundChannelAdapter.class).setMessageConverter(
-						new StringMessageConverter());
-
 				context.getBean("inputChannel", MessageChannel.class).send(
 						MessageBuilder.createMessage("I am a message.",
 								new MessageHeaders(headers)));
@@ -104,10 +100,10 @@ public class PubSubChannelAdaptersIntegrationTests {
 						context.getBean("outputChannel", PollableChannel.class).receive(5000);
 				assertThat(message).isNotNull();
 				assertThat(message.getPayload()).isInstanceOf(byte[].class);
-				String payload = (String) message.getPayload().toString();
+				String payload = new String((byte[]) message.getPayload());
 				assertThat(payload).isEqualTo("I am a message.");
 
-				assertThat(message.getHeaders().size()).isEqualTo(6);
+				assertThat(message.getHeaders().size()).isEqualTo(5);
 				assertThat(message.getHeaders().get("storm")).isEqualTo("lift your skinny fists");
 				assertThat(message.getHeaders().get("static")).isEqualTo("lift your skinny fists");
 				assertThat(message.getHeaders().get("sleep")).isEqualTo("lift your skinny fists");

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -41,6 +41,11 @@ It converts new messages to an internal Spring
 https://docs.spring.io/spring-integration/reference/html/messaging-construction-chapter.html#message[`Message`]
 and then sends it to the bound output channel.
 
+Google Pub/Sub treats message payloads as byte arrays. So, by default, the inbound channel adapter
+will construct the Spring `Message` with `byte[]` as the payload. However, you can also specify
+a `MessageConverter` that would then be used to convert the `byte[]` payload coming from
+Pub/Sub to a Spring `Message`.
+
 To use the inbound channel adapter, a `PubSubInboundChannelAdapter` must be provided and configured
 on the user application side.
 
@@ -101,8 +106,13 @@ public MessageHandler messageReceiver() {
 
 `PubSubMessageHandler` is the outbound channel adapter for GCP Pub/Sub that listens for new messages
 on a Spring `MessageChannel`.
-It uses `PubSubTemplate` to convert new `Message` instances to the GCP Pub/Sub format and post them
-to a GCP Pub/Sub topic.
+It uses `PubSubTemplate` to post them to a GCP Pub/Sub topic.
+
+To construct a Pub/Sub representation of the message, the outbound channel adapter needs to
+convert the Spring `Message` payload to a `byte[]` representation expected by Pub/Sub. If the
+`Message` payload is already of type `PubsubMessage`, `byte[]`, or `ByteString`, then a message
+converter doesn't need to be specified. Otherwise, you can specify a `MessageConverter` that
+should convert the `Object` payload of the Spring `Message` to a `byte[]` representation.
 
 To use the outbound channel adapter, a `PubSubMessageHandler` bean must be provided and configured
 on the user application side.

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -89,7 +89,7 @@ users can extract using the `GcpPubSubHeaders.ACKNOWLEDGEMENT` key and use to (n
 @ServiceActivator(inputChannel = "pubsubInputChannel")
 public MessageHandler messageReceiver() {
     return message -> {
-        LOGGER.info("Message arrived! Payload: " + message.getPayload());
+        LOGGER.info("Message arrived! Payload: " + new String((byte[]) message.getPayload()));
         AckReplyConsumer consumer =
               message.getHeaders().get(GcpPubSubHeaders.ACKNOWLEDGEMENT, AckReplyConsumer.class);
         consumer.ack();

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -41,10 +41,9 @@ It converts new messages to an internal Spring
 https://docs.spring.io/spring-integration/reference/html/messaging-construction-chapter.html#message[`Message`]
 and then sends it to the bound output channel.
 
-Google Pub/Sub treats message payloads as byte arrays. So, by default, the inbound channel adapter
-will construct the Spring `Message` with `byte[]` as the payload. However, you can also specify
-a `MessageConverter` that would then be used to convert the `byte[]` payload coming from
-Pub/Sub to a Spring `Message`.
+Google Pub/Sub treats message payloads as byte arrays.
+So, by default, the inbound channel adapter will construct the Spring `Message` with `byte[]` as the payload.
+However, you can also specify a `MessageConverter` that would then be used to convert the `byte[]` payload coming from Pub/Sub to a Spring `Message`.
 
 To use the inbound channel adapter, a `PubSubInboundChannelAdapter` must be provided and configured
 on the user application side.
@@ -108,11 +107,9 @@ public MessageHandler messageReceiver() {
 on a Spring `MessageChannel`.
 It uses `PubSubTemplate` to post them to a GCP Pub/Sub topic.
 
-To construct a Pub/Sub representation of the message, the outbound channel adapter needs to
-convert the Spring `Message` payload to a `byte[]` representation expected by Pub/Sub. If the
-`Message` payload is already of type `PubsubMessage`, `byte[]`, or `ByteString`, then a message
-converter doesn't need to be specified. Otherwise, you can specify a `MessageConverter` that
-should convert the `Object` payload of the Spring `Message` to a `byte[]` representation.
+To construct a Pub/Sub representation of the message, the outbound channel adapter needs to convert the Spring `Message` payload to a `byte[]` representation expected by Pub/Sub.
+If the `Message` payload is already of type `PubsubMessage`, `byte[]`, or `ByteString`, then a message converter doesn't need to be specified.
+Otherwise, you can specify a `MessageConverter` that should convert the `Object` payload of the Spring `Message` to a `byte[]` representation.
 
 To use the outbound channel adapter, a `PubSubMessageHandler` bean must be provided and configured
 on the user application side.

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -35,6 +35,7 @@ import org.springframework.messaging.MessageHandler;
 
 /**
  * @author João André Martins
+ * @author Mike Eltsufin
  */
 public class PubSubMessageChannelBinder
 		extends AbstractMessageChannelBinder<ExtendedConsumerProperties<PubSubConsumerProperties>,
@@ -66,8 +67,6 @@ public class PubSubMessageChannelBinder
 			ExtendedConsumerProperties<PubSubConsumerProperties> properties) {
 		PubSubInboundChannelAdapter inboundAdapter =
 				new PubSubInboundChannelAdapter(this.pubSubTemplate, destination.getName());
-		// Lets Stream do the message payload conversion.
-		inboundAdapter.setMessageConverter(null);
 
 		return inboundAdapter;
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -81,7 +81,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 			Message<?> internalMessage = null;
 
 			if (this.messageConverter != null) {
-				this.messageConverter.toMessage(
+				internalMessage = this.messageConverter.toMessage(
 						pubsubMessage.getData().toByteArray(),
 						new MessageHeaders(messageHeaders));
 			}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.Assert;
@@ -77,16 +78,16 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		}
 
 		try {
+			Message message;
 			if (this.messageConverter != null) {
-				sendMessage(this.messageConverter.toMessage(pubsubMessage.getData().toByteArray(),
-						new MessageHeaders(messageHeaders)));
+				message = this.messageConverter.toMessage(pubsubMessage.getData().toByteArray(),
+						new MessageHeaders(messageHeaders));
 			}
 			else {
-				sendMessage(MessageBuilder.withPayload(pubsubMessage.getData().toByteArray())
-						.copyHeaders(messageHeaders).build());
+				message = MessageBuilder.withPayload(pubsubMessage.getData().toByteArray())
+						.copyHeaders(messageHeaders).build();
 			}
-
-
+			sendMessage(message);
 		}
 		catch (RuntimeException re) {
 			if (this.ackMode == AckMode.AUTO) {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -72,7 +72,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 	private HeaderMapper<Map<String, String>> headerMapper = new PubSubHeaderMapper();
 
-	private PubSubMessageHandler(PubSubOperations pubSubTemplate, String topic) {
+	public PubSubMessageHandler(PubSubOperations pubSubTemplate, String topic) {
 		Assert.notNull(pubSubTemplate, "Pub/Sub template cannot be null.");
 		Assert.notNull(topic, "Pub/Sub topic cannot be null.");
 		this.pubSubTemplate = pubSubTemplate;

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -23,11 +23,10 @@ import java.util.concurrent.TimeUnit;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 
+import org.springframework.cloud.gcp.pubsub.core.PubSubException;
 import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
 import org.springframework.cloud.gcp.pubsub.integration.PubSubHeaderMapper;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.core.serializer.support.SerializingConverter;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
@@ -36,6 +35,7 @@ import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
@@ -45,9 +45,9 @@ import org.springframework.util.concurrent.ListenableFutureCallback;
  *
  * <p>It delegates Google Cloud Pub/Sub interaction to {@link PubSubOperations}. It also converts
  * the {@link Message} payload into a {@link PubsubMessage} accepted by the Google Cloud Pub/Sub
- * Client Library. It supports synchronous and asynchronous sending. If a payload {@link Converter}
- * is not specified, an instance of {@link SerializingConverter} will be used when provided
- * payloads are not of type {@link PubsubMessage}, {@code byte[]} or {@link com.google.cloud.ByteArray}.
+ * Client Library. It supports synchronous and asynchronous sending. If a {@link MessageConverter}
+ * to {@code byte[]} is not specified, the message payload should be either {@link PubsubMessage},
+ * {@code byte[]}, or {@link com.google.cloud.ByteArray}.
  *
  * @author João André Martins
  * @author Mike Eltsufin
@@ -58,7 +58,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 	private final PubSubOperations pubSubTemplate;
 
-	private Converter<Object, byte[]> payloadConverter;
+	private MessageConverter messageConverter;
 
 	private Expression topicExpression;
 
@@ -77,7 +77,6 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 		Assert.notNull(topic, "Pub/Sub topic cannot be null.");
 		this.pubSubTemplate = pubSubTemplate;
 		this.topicExpression = new LiteralExpression(topic);
-		this.payloadConverter = new SerializingConverter();
 	}
 
 	@Override
@@ -89,21 +88,26 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 		ListenableFuture<String> pubsubFuture;
 
-
 		if (payload instanceof PubsubMessage) {
 			pubsubFuture = this.pubSubTemplate.publish(topic, (PubsubMessage) payload);
 		}
 		else {
 			ByteString pubsubPayload;
 
-			if (payload instanceof byte[]) {
+			if (this.messageConverter != null) {
+				pubsubPayload = ByteString.copyFrom(
+						(byte[]) this.messageConverter.fromMessage(message, byte[].class));
+			}
+			else if (payload instanceof byte[]) {
 				pubsubPayload = ByteString.copyFrom((byte[]) payload);
 			}
 			else if (payload instanceof ByteString) {
 				pubsubPayload = (ByteString) payload;
 			}
 			else {
-				pubsubPayload = ByteString.copyFrom(this.payloadConverter.convert(payload));
+				throw new PubSubException("Unable to convert payload of type "
+						+ payload.getClass().getName() + " to byte[] for sending to Pub/Sub."
+						+ " Try specifying a message converter.");
 			}
 
 			Map<String, String> headers = new HashMap<>();
@@ -128,21 +132,19 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 		}
 	}
 
-	public Converter<Object, byte[]> getPayloadConverter() {
-		return this.payloadConverter;
+	public MessageConverter getMessageConverter() {
+		return this.messageConverter;
 	}
 
 	/**
-	 * Set the {@link Converter} to convert an outgoing message payload to a {@code byte[]}
+	 * Set the {@link MessageConverter} to convert an outgoing message payload to a {@code byte[]}
 	 * payload for sending to Pub/Sub. If the payload is already of type {@link PubsubMessage},
-	 * {@code byte[]} or {@link ByteString}, the converter is ignored.
-	 * @param payloadConverter converts {@link Message} to a payload of the outgoing message
-	 * to Pub/Sub. Cannot be set to null.
+	 * {@code byte[]} or {@link ByteString}, the converter doesn't have to be set.
+	 * @param messageConverter converts {@link Message} to a payload of the outgoing message
+	 * to Pub/Sub.
 	 */
-	public void setPayloadConverter(Converter<Object, byte[]> payloadConverter) {
-		Assert.notNull(payloadConverter,
-				"The specified message payload converter can't be null.");
-		this.payloadConverter = payloadConverter;
+	public void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
 	}
 
 	public boolean isSync() {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -72,15 +72,12 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 	private HeaderMapper<Map<String, String>> headerMapper = new PubSubHeaderMapper();
 
-	public PubSubMessageHandler(PubSubOperations pubSubTemplate, String topic) {
-		this(pubSubTemplate, topic, new SerializingConverter());
-	}
-
-	public PubSubMessageHandler(PubSubOperations pubSubTemplate, String topic,
-			Converter<Object, byte[]> payloadConverter) {
+	private PubSubMessageHandler(PubSubOperations pubSubTemplate, String topic) {
+		Assert.notNull(pubSubTemplate, "Pub/Sub template cannot be null.");
+		Assert.notNull(topic, "Pub/Sub topic cannot be null.");
 		this.pubSubTemplate = pubSubTemplate;
 		this.topicExpression = new LiteralExpression(topic);
-		this.payloadConverter = payloadConverter;
+		this.payloadConverter = new SerializingConverter();
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 
-import org.springframework.cloud.gcp.pubsub.core.PubSubException;
 import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
 import org.springframework.cloud.gcp.pubsub.integration.PubSubHeaderMapper;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
@@ -35,6 +34,7 @@ import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
@@ -105,7 +105,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 				pubsubPayload = (ByteString) payload;
 			}
 			else {
-				throw new PubSubException("Unable to convert payload of type "
+				throw new MessageConversionException("Unable to convert payload of type "
 						+ payload.getClass().getName() + " to byte[] for sending to Pub/Sub."
 						+ " Try specifying a message converter.");
 			}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -99,7 +99,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 			pubsubPayload = (ByteString) payload;
 		}
 		else {
-			pubsubPayload = ByteString.copyFrom(message.toString().getBytes());
+			pubsubPayload = ByteString.copyFrom(message.getPayload().toString().getBytes());
 		}
 
 		Map<String, String> headers = new HashMap<>();
@@ -131,7 +131,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 	/**
 	 * Set the {@link MessageConverter} to convert an outgoing message to a {@code byte[]}
 	 * payload for sending to Pub/Sub. If {@code messageConverter} is null and payload is not
-	 * already of type {@code byte[]} or {@code {@link ByteString}}, the
+	 * already of type {@code byte[]} or {@link ByteString}, the
 	 * {@code toString().getBytes()} will be called on the payload to convert it to a
 	 * {@code byte[]} form.
 	 * @param messageConverter converts {@link Message} to a payload of the outgoing message

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -57,7 +57,7 @@ public class PubSubMessageHandlerTests {
 
 	@Before
 	public void setUp() {
-		this.message = new GenericMessage<>("testPayload",
+		this.message = new GenericMessage<byte[]>("testPayload".getBytes(),
 				ImmutableMap.of("key1", "value1", "key2", "value2"));
 		SettableListenableFuture<String> future = new SettableListenableFuture<>();
 		future.set("benfica");
@@ -80,7 +80,7 @@ public class PubSubMessageHandlerTests {
 
 	@Test
 	public void testPublishDynamicTopic() {
-		Message<?> dynamicMessage = new GenericMessage<>("testPayload",
+		Message<?> dynamicMessage = new GenericMessage<byte[]>("testPayload".getBytes(),
 						ImmutableMap.of("key1", "value1", "key2", "value2", GcpPubSubHeaders.TOPIC, "dynamicTopic"));
 		this.adapter.handleMessage(dynamicMessage);
 		verify(this.pubSubTemplate, times(1))


### PR DESCRIPTION
Replaces `Message` -> `String` -> `byte[]` message converter requirement with the direct `Message` -> `byte[]` converter, thus avoiding the UTF-8 encoding issue.

Fixes #161.