### PR TITLE
Fix logging autoconfig conditional

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.autoconfigure.logging;
 
+import com.google.cloud.logging.logback.LoggingAppender;
+
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -42,7 +44,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  * @author Chengyuan Zhao
  */
 @Configuration
-@ConditionalOnClass(HandlerInterceptorAdapter.class)
+@ConditionalOnClass({HandlerInterceptorAdapter.class, LoggingAppender.class})
 @ConditionalOnMissingBean(SleuthProperties.class)
 @AutoConfigureAfter(StackdriverTraceAutoConfiguration.class)
 @EnableConfigurationProperties({ StackdriverLoggingProperties.class })


### PR DESCRIPTION
Currently, logging is automatically enabled for anyone running a
Spring Web MVC app, using any of our autoconfiguration that isn't
logging.

One remotely possible issue is when a user wants to use the Json
appender, doesn't use the logging starter but rather the autoconfigure
dependency with the google-cloud-logging-logback. In which case, they'll
have a ClassNotFoundException and should promptly add the missing
dependency.
We don't recommend using the logging bit without our starter, so this
is unlikely to begin with, and the solution is fairly straightforward,
so we don't think this is an issue.