### PR TITLE
Adds google-cloud-core-grpc to Trace starter

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
@@ -36,5 +36,9 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-sleuth-zipkin</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-core-grpc</artifactId>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
We use MoreCredentials in our autoconfiguration module, which is
optionally provided by other dependencies there, but not provided when
the trace starter is used on its own.