### PR TITLE
Fixes Pub/Sub SI sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/README.adoc
@@ -1,31 +1,21 @@
 = Spring Integration Channel Adapters for Google Cloud Pub/Sub Code Sample
 
 This code sample contains a couple of apps.
-One app gets a message provided by the user through a webpage and publishes it to a Google Cloud
-Pub/Sub topic.
+One app gets a message provided by the user through a webpage and publishes it to a Google Cloud Pub/Sub topic.
 The other app subscribes to that topic and logs received messages.
 
 == Setup & Configuration
 
-1. Configure your GCP project ID and credentials by following
-link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter[these instructions].
+1. Configure your GCP project ID and credentials by following link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter[these instructions].
 +
-Alternatively, if you have the
-https://cloud.google.com/sdk/[Google Cloud SDK] installed and initialized, and are logged in with
-https://developers.google.com/identity/protocols/application-default-credentials[application
-default credentials], Spring will auto-discover those parameters for you.
+Alternatively, if you have the https://cloud.google.com/sdk/[Google Cloud SDK] installed and initialized, and are logged in with https://developers.google.com/identity/protocols/application-default-credentials[application default credentials], Spring will auto-discover those parameters for you.
 
-2. Go to the https://console.cloud.google.com/cloudpubsub/topicList[Google Cloud Console Pub/Sub
-topics page] and create a topic called `exampleTopic`.
+2. Go to the https://console.cloud.google.com/cloudpubsub/topicList[Google Cloud Console Pub/Sub topics page] and create a topic called `exampleTopic`.
 
-3. Still in the same page, locate the newly created topic, click the button with the three vertical
-dots at the end of the topic's line and click "New subscription".
+3. Still in the same page, locate the newly created topic, click the button with the three vertical dots at the end of the topic's line and click "New subscription".
 Create a new subscription called `exampleSubscription` with all default parameters.
 
-3. In separate terminal windows, start the
-`spring-cloud-gcp-spring-integration-pubsub-sample-sender` and
-`spring-cloud-gcp-spring-integration-pubsub-sample-receiver` applications with the
-`$ mvn spring-boot:run` command in the same folder as the apps' `pom.xml` files.
+3. In separate terminal windows, start the `spring-cloud-gcp-spring-integration-pubsub-sample-sender` and `spring-cloud-gcp-spring-integration-pubsub-sample-receiver` applications with the `$ mvn spring-boot:run` command in the same folder as the apps' `pom.xml` files.
 
 4. Go to http://localhost:8080, write a message in the text box and hit the `Submit` button.
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/main/java/com/example/ReceiverApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/main/java/com/example/ReceiverApplication.java
@@ -62,9 +62,9 @@ public class ReceiverApplication {
 	}
 
 	@ServiceActivator(inputChannel = "pubsubInputChannel")
-	public void messageReceiver(String payload,
+	public void messageReceiver(byte[] payload,
 			@Header(GcpPubSubHeaders.ACKNOWLEDGEMENT) AckReplyConsumer ackReplyConsumer) {
-		LOGGER.info("Message arrived! Payload: " + payload);
+		LOGGER.info("Message arrived! Payload: " + new String(payload));
 		ackReplyConsumer.ack();
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/main/java/com/example/SenderApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/main/java/com/example/SenderApplication.java
@@ -66,6 +66,6 @@ public class SenderApplication {
 	@MessagingGateway(defaultRequestChannel = "pubSubOutputChannel")
 	public interface PubSubOutboundGateway {
 
-		void sendToPubSub(String text);
+		void sendToPubSub(byte[] text);
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/main/java/com/example/WebController.java
@@ -41,7 +41,7 @@ public class WebController {
 	 */
 	@PostMapping("/postMessage")
 	public RedirectView postMessage(@RequestParam("message") String message) {
-		this.messagingGateway.sendToPubSub(message);
+		this.messagingGateway.sendToPubSub(message.getBytes());
 		return new RedirectView("/");
 	}
 }


### PR DESCRIPTION
#731 caused our SI adapters to expect receiving byte arrays, as well as
producing them, leaving the actual conversion to the client.
Therefore, the sample should convert the strings to/from the byte[].

Also puts sentences from the doc in one line.

Fixes #750