### PR TITLE
Reuse PubSubTemplate conversion

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -45,7 +45,9 @@ and then sends it to the bound output channel.
 
 Google Pub/Sub treats message payloads as byte arrays.
 So, by default, the inbound channel adapter will construct the Spring `Message` with `byte[]` as the payload.
-However, you can also specify a `MessageConverter` that would then be used to convert the `byte[]` payload coming from Pub/Sub to a Spring `Message`.
+However, you can change the desired payload type by setting the `payloadType` property of the `PubSubInboundChannelAdapter`.
+The `PubSubInboundChannelAdapter` delegates to conversion to the desired payload type to the `PubSubMessageConverter` configured in the `PubSubTemplate`.
+
 
 To use the inbound channel adapter, a `PubSubInboundChannelAdapter` must be provided and configured
 on the user application side.
@@ -109,9 +111,9 @@ public MessageHandler messageReceiver() {
 on a Spring `MessageChannel`.
 It uses `PubSubTemplate` to post them to a GCP Pub/Sub topic.
 
-To construct a Pub/Sub representation of the message, the outbound channel adapter needs to convert the Spring `Message` payload to a `byte[]` representation expected by Pub/Sub.
-If the `Message` payload is already of type `PubsubMessage`, `byte[]`, or `ByteString`, then a message converter doesn't need to be specified.
-Otherwise, you can specify a `MessageConverter` that should convert the `Object` payload of the Spring `Message` to a `byte[]` representation.
+To construct a Pub/Sub representation of the message, the outbound channel adapter needs to convert the Spring `Message` payload to a byte array representation expected by Pub/Sub.
+It delegates this conversion to the `PubSubTemplate`.
+To customize the conversion, you can specify a `PubSubMessageConverter` in the `PubSubTemplate` that should convert the `Object` payload and headers of the Spring `Message` to a `PubsubMessage`.
 
 To use the outbound channel adapter, a `PubSubMessageHandler` bean must be provided and configured
 on the user application side.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -101,7 +101,7 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 	@Override
 	public <T> ListenableFuture<String> publish(String topic, T payload,
 			Map<String, String> headers) {
-		return publish(topic, this.messageConverter.toMessage(payload, headers));
+		return publish(topic, this.messageConverter.toPubSubMessage(payload, headers));
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -29,9 +29,6 @@ import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.Assert;
 
 /**
@@ -50,8 +47,6 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 	private Subscriber subscriber;
 
 	private AckMode ackMode = AckMode.AUTO;
-
-	private MessageConverter messageConverter;
 
 	private HeaderMapper<Map<String, String>> headerMapper = new PubSubHeaderMapper();
 
@@ -78,16 +73,9 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		}
 
 		try {
-			Message message;
-			if (this.messageConverter != null) {
-				message = this.messageConverter.toMessage(pubsubMessage.getData().toByteArray(),
-						new MessageHeaders(messageHeaders));
-			}
-			else {
-				message = MessageBuilder.withPayload(pubsubMessage.getData().toByteArray())
-						.copyHeaders(messageHeaders).build();
-			}
-			sendMessage(message);
+			sendMessage(
+					MessageBuilder.withPayload(pubsubMessage.getData().toByteArray())
+							.copyHeaders(messageHeaders).build());
 		}
 		catch (RuntimeException re) {
 			if (this.ackMode == AckMode.AUTO) {
@@ -117,20 +105,6 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 	public void setAckMode(AckMode ackMode) {
 		Assert.notNull(ackMode, "The acknowledgement mode can't be null.");
 		this.ackMode = ackMode;
-	}
-
-	public MessageConverter getMessageConverter() {
-		return this.messageConverter;
-	}
-
-	/**
-	 * Set the {@link MessageConverter} to convert an incoming Pub/Sub message payload to an
-	 * {@code Object}. If the converter is null, the payload is unchanged.
-	 * @param messageConverter converts a {@link PubsubMessage} payload to a
-	 * {@link org.springframework.messaging.Message} payload. Can be set to null.
-	 */
-	public void setMessageConverter(MessageConverter messageConverter) {
-		this.messageConverter = messageConverter;
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -22,6 +22,7 @@ import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.pubsub.v1.PubsubMessage;
 
+import org.springframework.cloud.gcp.pubsub.core.PubSubException;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.integration.AckMode;
 import org.springframework.cloud.gcp.pubsub.integration.PubSubHeaderMapper;
@@ -80,11 +81,11 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 					.copyHeaders(messageHeaders)
 					.build());
 		}
-		catch (Exception re) {
+		catch (RuntimeException re) {
 			if (this.ackMode == AckMode.AUTO) {
 				consumer.nack();
 			}
-			throw new RuntimeException(re);
+			throw new PubSubException("Spring Message construction from Pub/Sub message failed.", re);
 		}
 
 		if (this.ackMode == AckMode.AUTO) {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -85,7 +85,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 			if (this.ackMode == AckMode.AUTO) {
 				consumer.nack();
 			}
-			throw new PubSubException("Spring Message construction from Pub/Sub message failed.", re);
+			throw new PubSubException("Sending Spring message failed.", re);
 		}
 
 		if (this.ackMode == AckMode.AUTO) {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -189,7 +189,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 	/**
 	 * Set the header mapper to map headers from {@link Message} into outbound
-	 * {@link PubsubMessage}.
+	 * {@link com.google.pubsub.v1.PubsubMessage}.
 	 * @param headerMapper the header mapper
 	 */
 	public void setHeaderMapper(HeaderMapper<Map<String, String>> headerMapper) {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -20,9 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import com.google.protobuf.ByteString;
-import com.google.pubsub.v1.PubsubMessage;
-
 import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
 import org.springframework.cloud.gcp.pubsub.integration.PubSubHeaderMapper;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
@@ -34,8 +31,6 @@ import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.converter.MessageConversionException;
-import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
@@ -43,11 +38,8 @@ import org.springframework.util.concurrent.ListenableFutureCallback;
 /**
  * Outbound channel adapter to publish messages to Google Cloud Pub/Sub.
  *
- * <p>It delegates Google Cloud Pub/Sub interaction to {@link PubSubOperations}. It also converts
- * the {@link Message} payload into a {@link PubsubMessage} accepted by the Google Cloud Pub/Sub
- * Client Library. It supports synchronous and asynchronous sending. If a {@link MessageConverter}
- * to {@code byte[]} is not specified, the message payload should be either {@link PubsubMessage},
- * {@code byte[]}, or {@link com.google.cloud.ByteArray}.
+ * <p>It delegates Google Cloud Pub/Sub interaction to
+ * {@link org.springframework.cloud.gcp.pubsub.core.PubSubTemplate}.
  *
  * @author João André Martins
  * @author Mike Eltsufin
@@ -57,8 +49,6 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 	private static final long DEFAULT_PUBLISH_TIMEOUT = 10000;
 
 	private final PubSubOperations pubSubTemplate;
-
-	private MessageConverter messageConverter;
 
 	private Expression topicExpression;
 
@@ -88,33 +78,10 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 		ListenableFuture<String> pubsubFuture;
 
-		if (payload instanceof PubsubMessage) {
-			pubsubFuture = this.pubSubTemplate.publish(topic, (PubsubMessage) payload);
-		}
-		else {
-			ByteString pubsubPayload;
+		Map<String, String> headers = new HashMap<>();
+		this.headerMapper.fromHeaders(message.getHeaders(), headers);
 
-			if (this.messageConverter != null) {
-				pubsubPayload = ByteString.copyFrom(
-						(byte[]) this.messageConverter.fromMessage(message, byte[].class));
-			}
-			else if (payload instanceof byte[]) {
-				pubsubPayload = ByteString.copyFrom((byte[]) payload);
-			}
-			else if (payload instanceof ByteString) {
-				pubsubPayload = (ByteString) payload;
-			}
-			else {
-				throw new MessageConversionException("Unable to convert payload of type "
-						+ payload.getClass().getName() + " to byte[] for sending to Pub/Sub."
-						+ " Try specifying a message converter.");
-			}
-
-			Map<String, String> headers = new HashMap<>();
-			this.headerMapper.fromHeaders(message.getHeaders(), headers);
-
-			pubsubFuture = this.pubSubTemplate.publish(topic, pubsubPayload, headers);
-		}
+		pubsubFuture = this.pubSubTemplate.publish(topic, payload, headers);
 
 		if (this.publishCallback != null) {
 			pubsubFuture.addCallback(this.publishCallback);
@@ -130,21 +97,6 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 				pubsubFuture.get(timeout, TimeUnit.MILLISECONDS);
 			}
 		}
-	}
-
-	public MessageConverter getMessageConverter() {
-		return this.messageConverter;
-	}
-
-	/**
-	 * Set the {@link MessageConverter} to convert an outgoing message payload to a {@code byte[]}
-	 * payload for sending to Pub/Sub. If the payload is already of type {@link PubsubMessage},
-	 * {@code byte[]} or {@link ByteString}, the converter doesn't have to be set.
-	 * @param messageConverter converts {@link Message} to a payload of the outgoing message
-	 * to Pub/Sub.
-	 */
-	public void setMessageConverter(MessageConverter messageConverter) {
-		this.messageConverter = messageConverter;
 	}
 
 	public boolean isSync() {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/JacksonPubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/JacksonPubSubMessageConverter.java
@@ -65,7 +65,7 @@ public class JacksonPubSubMessageConverter implements PubSubMessageConverter {
 	}
 
 	@Override
-	public <T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType) {
+	public Object fromPubSubMessage(PubsubMessage message, Class<?> payloadType) {
 		try {
 			return this.objectMapper.readerFor(payloadType).readValue(message.getData().toByteArray());
 		}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/JacksonPubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/JacksonPubSubMessageConverter.java
@@ -46,7 +46,7 @@ public class JacksonPubSubMessageConverter implements PubSubMessageConverter {
 	}
 
 	@Override
-	public PubsubMessage toMessage(Object payload, Map<String, String> headers) {
+	public PubsubMessage toPubSubMessage(Object payload, Map<String, String> headers) {
 		try {
 			PubsubMessage.Builder pubsubMessageBuilder = PubsubMessage.newBuilder()
 					.setData(ByteString.copyFrom(this.objectMapper.writeValueAsBytes(payload)));
@@ -65,7 +65,7 @@ public class JacksonPubSubMessageConverter implements PubSubMessageConverter {
 	}
 
 	@Override
-	public <T> T fromMessage(PubsubMessage message, Class<T> payloadType) {
+	public <T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType) {
 		try {
 			return this.objectMapper.readerFor(payloadType).readValue(message.getData().toByteArray());
 		}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/PubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/PubSubMessageConverter.java
@@ -34,7 +34,7 @@ public interface PubSubMessageConverter {
 	 * @param headers the headers of the message
 	 * @return the PubsubMessage ready to be sent
 	 */
-	PubsubMessage toMessage(Object payload, Map<String, String> headers);
+	PubsubMessage toPubSubMessage(Object payload, Map<String, String> headers);
 
 	/**
 	 * Convert the payload of a given {@code PubsubMessage} to a desired Java type.
@@ -42,5 +42,5 @@ public interface PubSubMessageConverter {
 	 * @param payloadType the desired type of the object
 	 * @return the object converted from the message's payload
 	 */
-	<T> T fromMessage(PubsubMessage message, Class<T> payloadType);
+	<T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType);
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/PubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/PubSubMessageConverter.java
@@ -42,5 +42,5 @@ public interface PubSubMessageConverter {
 	 * @param payloadType the desired type of the object
 	 * @return the object converted from the message's payload
 	 */
-	<T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType);
+	Object fromPubSubMessage(PubsubMessage message, Class<?> payloadType);
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverter.java
@@ -75,21 +75,21 @@ public class SimplePubSubMessageConverter implements PubSubMessageConverter {
 	}
 
 	@Override
-	public <T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType) {
-		T result;
+	public Object fromPubSubMessage(PubsubMessage message, Class<?> payloadType) {
+		Object result;
 		byte[] payload = message.getData().toByteArray();
 
 		if (payloadType == ByteString.class) {
-			result = (T) message.getData();
+			result = message.getData();
 		}
 		else if (payloadType == String.class) {
-			result = (T) new String(payload, this.charset);
+			result = new String(payload, this.charset);
 		}
 		else if (payloadType == ByteBuffer.class) {
-			result = (T) ByteBuffer.wrap(payload);
+			result = ByteBuffer.wrap(payload);
 		}
 		else if (payloadType == byte[].class) {
-			result = (T) payload;
+			result = payload;
 		}
 		else {
 			throw new PubSubMessageConversionException("Unable to convert Pub/Sub message to payload of type " +

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverter.java
@@ -42,7 +42,7 @@ public class SimplePubSubMessageConverter implements PubSubMessageConverter {
 	}
 
 	@Override
-	public PubsubMessage toMessage(Object payload, Map<String, String> headers) {
+	public PubsubMessage toPubSubMessage(Object payload, Map<String, String> headers) {
 
 		ByteString convertedPayload;
 
@@ -75,7 +75,7 @@ public class SimplePubSubMessageConverter implements PubSubMessageConverter {
 	}
 
 	@Override
-	public <T> T fromMessage(PubsubMessage message, Class<T> payloadType) {
+	public <T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType) {
 		T result;
 		byte[] payload = message.getData().toByteArray();
 

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 
 /**
  * {@link PubSubInboundChannelAdapter} unit tests.
@@ -32,7 +32,7 @@ import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
 public class PubSubInboundChannelAdapterTests {
 
 	@Mock
-	private PubSubOperations pubSubTemplate;
+	private PubSubTemplate pubSubTemplate;
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testNonNullAckMode() {

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -16,11 +16,9 @@
 
 package org.springframework.cloud.gcp.pubsub.integration.outbound;
 
-import java.nio.charset.Charset;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.ByteString;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,8 +60,7 @@ public class PubSubMessageHandlerTests {
 		SettableListenableFuture<String> future = new SettableListenableFuture<>();
 		future.set("benfica");
 		when(this.pubSubTemplate.publish(eq("testTopic"),
-				eq(ByteString.copyFrom("testPayload", Charset.defaultCharset())),
-				isA(Map.class)))
+				eq("testPayload".getBytes()), isA(Map.class)))
 				.thenReturn(future);
 		this.adapter = new PubSubMessageHandler(this.pubSubTemplate, "testTopic");
 
@@ -73,20 +70,17 @@ public class PubSubMessageHandlerTests {
 	public void testPublish() {
 		this.adapter.handleMessage(this.message);
 		verify(this.pubSubTemplate, times(1))
-				.publish(eq("testTopic"),
-						eq(ByteString.copyFrom("testPayload", Charset.defaultCharset())),
-						isA(Map.class));
+				.publish(eq("testTopic"), eq("testPayload".getBytes()), isA(Map.class));
 	}
 
 	@Test
 	public void testPublishDynamicTopic() {
 		Message<?> dynamicMessage = new GenericMessage<byte[]>("testPayload".getBytes(),
-						ImmutableMap.of("key1", "value1", "key2", "value2", GcpPubSubHeaders.TOPIC, "dynamicTopic"));
+						ImmutableMap.of("key1", "value1", "key2", "value2",
+								GcpPubSubHeaders.TOPIC, "dynamicTopic"));
 		this.adapter.handleMessage(dynamicMessage);
 		verify(this.pubSubTemplate, times(1))
-			.publish(eq("dynamicTopic"),
-						eq(ByteString.copyFrom("testPayload", Charset.defaultCharset())),
-						isA(Map.class));
+			.publish(eq("dynamicTopic"),	eq("testPayload".getBytes()), isA(Map.class));
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverterTests.java
@@ -106,7 +106,7 @@ public class SimplePubSubMessageConverterTests {
 		SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
 
 		// test extraction from PubsubMessage to T
-		assertEquals(TEST_STRING, toString.convert(converter.fromPubSubMessage(PubsubMessage.newBuilder()
+		assertEquals(TEST_STRING, toString.convert((T) converter.fromPubSubMessage(PubsubMessage.newBuilder()
 				.setData(ByteString.copyFrom(TEST_STRING.getBytes())).putAllAttributes(TEST_HEADERS).build(), type)));
 	}
 

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverterTests.java
@@ -96,7 +96,7 @@ public class SimplePubSubMessageConverterTests {
 	@Test
 	public void testNullHeaders() {
 		SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
-		PubsubMessage pubsubMessage = converter.toMessage(TEST_STRING, null);
+		PubsubMessage pubsubMessage = converter.toPubSubMessage(TEST_STRING, null);
 
 		assertEquals(TEST_STRING, pubsubMessage.getData().toString(Charset.defaultCharset()));
 		assertEquals(new HashMap<>(), pubsubMessage.getAttributesMap());
@@ -106,7 +106,7 @@ public class SimplePubSubMessageConverterTests {
 		SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
 
 		// test extraction from PubsubMessage to T
-		assertEquals(TEST_STRING, toString.convert(converter.fromMessage(PubsubMessage.newBuilder()
+		assertEquals(TEST_STRING, toString.convert(converter.fromPubSubMessage(PubsubMessage.newBuilder()
 				.setData(ByteString.copyFrom(TEST_STRING.getBytes())).putAllAttributes(TEST_HEADERS).build(), type)));
 	}
 
@@ -114,7 +114,7 @@ public class SimplePubSubMessageConverterTests {
 		SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
 
 		// test conversion of T to PubsubMessage
-		PubsubMessage convertedPubSubMessage = converter.toMessage(value, TEST_HEADERS);
+		PubsubMessage convertedPubSubMessage = converter.toPubSubMessage(value, TEST_HEADERS);
 		assertEquals(TEST_STRING, new String(convertedPubSubMessage.getData().toByteArray()));
 		assertEquals(TEST_HEADERS, convertedPubSubMessage.getAttributesMap());
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/main/java/com/example/ReceiverApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/main/java/com/example/ReceiverApplication.java
@@ -25,7 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.integration.AckMode;
 import org.springframework.cloud.gcp.pubsub.integration.inbound.PubSubInboundChannelAdapter;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
@@ -52,7 +52,7 @@ public class ReceiverApplication {
 	@Bean
 	public PubSubInboundChannelAdapter messageChannelAdapter(
 			@Qualifier("pubsubInputChannel") MessageChannel inputChannel,
-			PubSubOperations pubSubTemplate) {
+			PubSubTemplate pubSubTemplate) {
 		PubSubInboundChannelAdapter adapter =
 				new PubSubInboundChannelAdapter(pubSubTemplate, "exampleSubscription");
 		adapter.setOutputChannel(inputChannel);


### PR DESCRIPTION
PubSubTemplate already offers type conversion to/from JSON.
On top of that, we found that the current MessageConverters are not
only very expressive, but they don't provide the kind of conversion we
need (arguably, the don't provide any conversion, but rather message
building/mapping).