### PR TITLE
Postgres sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/README.adoc
@@ -23,7 +23,8 @@ https://console.cloud.google.com/sql/instances[Google Cloud Console Cloud SQL pa
 step 1.
 +
 If you set a root password, add the `spring.datasource.password` property with the root password as the value.
-
++
+If you would like to use a different user, set the `spring.datasource.username` property appropriately.
 
 5. https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If
 you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring
@@ -34,6 +35,23 @@ from the Google Cloud Console] and download its private key.
 Then, uncomment the `spring.cloud.gcp.sql.credentials.location` property in the
 link:src/main/resources/application.properties file and fill its value with the path to your service
 account private key on your local file system, prepended with `file:`.
+
+6. If you created a postgres instance, you will need to replace the mysql starter dependency in the `pom.xml` file
+
+[source,xml]
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-sql-mysql</artifactId>
+</dependency>
+
+with a postgres one
+[source,xml]
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-sql-postgresql</artifactId>
+</dependency>
+
+
 
 == Running the application
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/main/resources/data.sql
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/main/resources/data.sql
@@ -1,4 +1,4 @@
 INSERT INTO users VALUES
-  ("luisao@example.com", "Anderson", "Silva"),
-  ("jonas@example.com", "Jonas", "Gonçalves"),
-  ("fejsa@example.com", "Ljubomir", "Fejsa");
+  ('luisao@example.com', 'Anderson', 'Silva'),
+  ('jonas@example.com', 'Jonas', 'Gonçalves'),
+  ('fejsa@example.com', 'Ljubomir', 'Fejsa');


### PR DESCRIPTION
postgres does not support double quotes for string literals 
Fixes #480 