### PR TITLE
Clean up logging sample application.properties

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/main/resources/application.properties
@@ -1,2 +1,1 @@
 spring.cloud.gcp.logging.enabled=true
-spring.cloud.gcp.logging.traceIdExtractor=xcloud_zipkin


### PR DESCRIPTION
`spring.cloud.gcp.logging.traceIdExtractor` property no longer exists