### PR TITLE
Spanner client lib API changes

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -27,7 +27,6 @@ import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
-import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -103,7 +102,6 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 				(BiFunction<ValueBinder, boolean[], ?>) ValueBinder::toBoolArray);
 		builder.put(long[].class,
 				(BiFunction<ValueBinder, long[], ?>) ValueBinder::toInt64Array);
-		builder.put(Value.class, (BiFunction<ValueBinder, Value, ?>) ValueBinder::to);
 
 		singleItemType2ToMethodMap = builder.build();
 	}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -27,6 +27,7 @@ import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -87,26 +88,22 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 	static {
 		ImmutableMap.Builder<Class<?>, BiFunction<ValueBinder, ?, ?>> builder = new ImmutableMap.Builder<>();
 
-		builder.put(Date.class,
-				((BiFunction<ValueBinder, Date, ?>) ValueBinder::to));
-		builder.put(Boolean.class,
-				((BiFunction<ValueBinder, Boolean, ?>) ValueBinder::to));
-		builder.put(Long.class,
-				((BiFunction<ValueBinder, Long, ?>) ValueBinder::to));
-		builder.put(String.class,
-				((BiFunction<ValueBinder, String, ?>) ValueBinder::to));
-		builder.put(Double.class,
-				((BiFunction<ValueBinder, Double, ?>) ValueBinder::to));
+		builder.put(Date.class, (BiFunction<ValueBinder, Date, ?>) ValueBinder::to);
+		builder.put(Boolean.class, (BiFunction<ValueBinder, Boolean, ?>) ValueBinder::to);
+		builder.put(Long.class, (BiFunction<ValueBinder, Long, ?>) ValueBinder::to);
+		builder.put(String.class, (BiFunction<ValueBinder, String, ?>) ValueBinder::to);
+		builder.put(Double.class, (BiFunction<ValueBinder, Double, ?>) ValueBinder::to);
 		builder.put(Timestamp.class,
-				((BiFunction<ValueBinder, Timestamp, ?>) ValueBinder::to));
+				(BiFunction<ValueBinder, Timestamp, ?>) ValueBinder::to);
 		builder.put(ByteArray.class,
-				((BiFunction<ValueBinder, ByteArray, ?>) ValueBinder::to));
+				(BiFunction<ValueBinder, ByteArray, ?>) ValueBinder::to);
 		builder.put(double[].class,
-				((BiFunction<ValueBinder, double[], ?>) ValueBinder::toFloat64Array));
+				(BiFunction<ValueBinder, double[], ?>) ValueBinder::toFloat64Array);
 		builder.put(boolean[].class,
-				((BiFunction<ValueBinder, boolean[], ?>) ValueBinder::toBoolArray));
+				(BiFunction<ValueBinder, boolean[], ?>) ValueBinder::toBoolArray);
 		builder.put(long[].class,
-				((BiFunction<ValueBinder, long[], ?>) ValueBinder::toInt64Array));
+				(BiFunction<ValueBinder, long[], ?>) ValueBinder::toInt64Array);
+		builder.put(Value.class, (BiFunction<ValueBinder, Value, ?>) ValueBinder::to);
 
 		singleItemType2ToMethodMap = builder.build();
 	}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructAccessor.java
@@ -70,6 +70,9 @@ class StructAccessor {
 					.put(double[].class, AbstractStructReader::getDoubleArray)
 					.put(long[].class, AbstractStructReader::getLongArray)
 					.put(boolean[].class, AbstractStructReader::getBooleanArray)
+					// Note that Struct.class appears in this map. While we support
+					// converting structs into POJO fields of POJOs, the value in this map is for
+					// the case where the field within the POJO is Struct.
 					.put(Struct.class, Struct::getStruct).build();
 
 	private final SpannerTypeMapper spannerTypeMapper;

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructAccessor.java
@@ -69,7 +69,8 @@ class StructAccessor {
 					.put(ByteArray.class, AbstractStructReader::getBytes)
 					.put(double[].class, AbstractStructReader::getDoubleArray)
 					.put(long[].class, AbstractStructReader::getLongArray)
-					.put(boolean[].class, AbstractStructReader::getBooleanArray).build();
+					.put(boolean[].class, AbstractStructReader::getBooleanArray)
+					.put(Struct.class, Struct::getStruct).build();
 
 	private final SpannerTypeMapper spannerTypeMapper;
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
@@ -64,14 +64,14 @@ public class SpannerDatabaseAdminTemplateTests {
 	public void getParentChildTablesMapTest() {
 		ReadContext readContext = mock(ReadContext.class);
 
-		Struct s1 = Struct.newBuilder().add("table_name", Value.string("grandpa"))
-				.add("parent_table_name", Value.string(null)).build();
-		Struct s2 = Struct.newBuilder().add("table_name", Value.string("parent_a"))
-				.add("parent_table_name", Value.string("grandpa")).build();
-		Struct s3 = Struct.newBuilder().add("table_name", Value.string("parent_b"))
-				.add("parent_table_name", Value.string("grandpa")).build();
-		Struct s4 = Struct.newBuilder().add("table_name", Value.string("child"))
-				.add("parent_table_name", Value.string("parent_a")).build();
+		Struct s1 = Struct.newBuilder().set("table_name").to(Value.string("grandpa"))
+				.set("parent_table_name").to(Value.string(null)).build();
+		Struct s2 = Struct.newBuilder().set("table_name").to(Value.string("parent_a"))
+				.set("parent_table_name").to(Value.string("grandpa")).build();
+		Struct s3 = Struct.newBuilder().set("table_name").to(Value.string("parent_b"))
+				.set("parent_table_name").to(Value.string("grandpa")).build();
+		Struct s4 = Struct.newBuilder().set("table_name").to(Value.string("child"))
+				.set("parent_table_name").to(Value.string("parent_a")).build();
 
 		MockResults mockResults = new MockResults();
 		mockResults.structs = Arrays.asList(s1, s2, s3, s4);

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
@@ -128,43 +128,41 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 		timestamps.add(ts2);
 		timestamps.add(ts3);
 
-		Struct struct1 = Struct.newBuilder().add("id", Value.string("key1"))
-				.add("custom_col", Value.string("string1"))
-				.add("booleanField", Value.bool(true))
-				.add("intField", Value.int64(123L))
-				.add("longField", Value.int64(3L))
-				.add("doubleField", Value.float64(3.33))
-				.add("doubleArray", Value.float64Array(new double[] { 3.33, 3.33, 3.33 }))
-				.add("doubleList", Value.float64Array(doubleList))
-				.add("stringList", Value.stringArray(stringList))
-				.add("booleanList", Value.boolArray(new boolean[] {}))
-				.add("longList", Value.int64Array(new long[] {}))
-				.add("timestampList", Value.timestampArray(new ArrayList<>()))
-				.add("dateList", Value.dateArray(new ArrayList<>()))
-				.add("bytesList", Value.bytesArray(new ArrayList<>()))
-				.add("dateField", Value.date(Date.fromYearMonthDay(2018, 11, 22)))
-				.add("timestampField", Value.timestamp(Timestamp.ofTimeMicroseconds(333)))
-				.add("bytes", Value.bytes(ByteArray.copyFrom("string1")))
-				.add("momentsInTime", Value.timestampArray(timestamps)).build();
+		Struct struct1 = Struct.newBuilder().set("id").to(Value.string("key1"))
+				.set("custom_col").to(Value.string("string1")).set("booleanField")
+				.to(Value.bool(true)).set("intField").to(Value.int64(123L))
+				.set("longField").to(Value.int64(3L)).set("doubleField")
+				.to(Value.float64(3.33)).set("doubleArray")
+				.to(Value.float64Array(new double[] { 3.33, 3.33, 3.33 }))
+				.set("doubleList").to(Value.float64Array(doubleList)).set("stringList")
+				.to(Value.stringArray(stringList)).set("booleanList")
+				.to(Value.boolArray(new boolean[] {})).set("longList")
+				.to(Value.int64Array(new long[] {})).set("timestampList")
+				.to(Value.timestampArray(new ArrayList<>())).set("dateList")
+				.to(Value.dateArray(new ArrayList<>())).set("bytesList")
+				.to(Value.bytesArray(new ArrayList<>())).set("dateField")
+				.to(Value.date(Date.fromYearMonthDay(2018, 11, 22))).set("timestampField")
+				.to(Value.timestamp(Timestamp.ofTimeMicroseconds(333))).set("bytes")
+				.to(Value.bytes(ByteArray.copyFrom("string1"))).set("momentsInTime")
+				.to(Value.timestampArray(timestamps)).build();
 
-		Struct struct2 = Struct.newBuilder().add("id", Value.string("key2"))
-				.add("custom_col", Value.string("string2"))
-				.add("booleanField", Value.bool(true))
-				.add("intField", Value.int64(222L))
-				.add("longField", Value.int64(5L))
-				.add("doubleField", Value.float64(5.55))
-				.add("doubleArray", Value.float64Array(new double[] { 5.55, 5.55 }))
-				.add("doubleList", Value.float64Array(doubleList))
-				.add("stringList", Value.stringArray(stringList))
-				.add("booleanList", Value.boolArray(new boolean[] {}))
-				.add("longList", Value.int64Array(new long[] {}))
-				.add("timestampList", Value.timestampArray(new ArrayList<>()))
-				.add("dateList", Value.dateArray(new ArrayList<>()))
-				.add("bytesList", Value.bytesArray(new ArrayList<>()))
-				.add("dateField", Value.date(Date.fromYearMonthDay(2019, 11, 22)))
-				.add("timestampField", Value.timestamp(Timestamp.ofTimeMicroseconds(555)))
-				.add("momentsInTime", Value.timestampArray(timestamps))
-				.add("bytes", Value.bytes(ByteArray.copyFrom("string2"))).build();
+		Struct struct2 = Struct.newBuilder().set("id").to(Value.string("key2"))
+				.set("custom_col").to(Value.string("string2")).set("booleanField")
+				.to(Value.bool(true)).set("intField").to(Value.int64(222L))
+				.set("longField").to(Value.int64(5L)).set("doubleField")
+				.to(Value.float64(5.55)).set("doubleArray")
+				.to(Value.float64Array(new double[] { 5.55, 5.55 })).set("doubleList")
+				.to(Value.float64Array(doubleList)).set("stringList")
+				.to(Value.stringArray(stringList)).set("booleanList")
+				.to(Value.boolArray(new boolean[] {})).set("longList")
+				.to(Value.int64Array(new long[] {})).set("timestampList")
+				.to(Value.timestampArray(new ArrayList<>())).set("dateList")
+				.to(Value.dateArray(new ArrayList<>())).set("bytesList")
+				.to(Value.bytesArray(new ArrayList<>())).set("dateField")
+				.to(Value.date(Date.fromYearMonthDay(2019, 11, 22))).set("timestampField")
+				.to(Value.timestamp(Timestamp.ofTimeMicroseconds(555)))
+				.set("momentsInTime").to(Value.timestampArray(timestamps)).set("bytes")
+				.to(Value.bytes(ByteArray.copyFrom("string2"))).build();
 
 		MockResults mockResults = new MockResults();
 		mockResults.structs = Arrays.asList(struct1, struct2);
@@ -217,15 +215,15 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 		List<String> stringList = new ArrayList<>();
 		stringList.add("string");
 
-		Struct struct1 = Struct.newBuilder().add("id", Value.string("key1"))
-				.add("custom_col", Value.string("string1"))
-				.add("doubleList", Value.float64Array(doubleList))
-				.add("stringList", Value.stringArray(stringList)).build();
+		Struct struct1 = Struct.newBuilder().set("id").to(Value.string("key1"))
+				.set("custom_col").to(Value.string("string1")).set("doubleList")
+				.to(Value.float64Array(doubleList)).set("stringList")
+				.to(Value.stringArray(stringList)).build();
 
-		Struct struct2 = Struct.newBuilder().add("id", Value.string("key2"))
-				.add("custom_col", Value.string("string2"))
-				.add("doubleList", Value.float64Array(doubleList))
-				.add("stringList", Value.stringArray(stringList)).build();
+		Struct struct2 = Struct.newBuilder().set("id").to(Value.string("key2"))
+				.set("custom_col").to(Value.string("string2")).set("doubleList")
+				.to(Value.float64Array(doubleList)).set("stringList")
+				.to(Value.stringArray(stringList)).build();
 
 		MockResults mockResults = new MockResults();
 		mockResults.structs = Arrays.asList(struct1, struct2);

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.Value;
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
@@ -68,11 +69,10 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	@Test
 	public void readNestedStructTest() {
 		Struct innerStruct = Struct.newBuilder()
-				.add("value", Value.string("value")).build();
+				.set("value").to(Value.string("value")).build();
 		Struct outerStruct = Struct.newBuilder()
-				.add("id", Value.string("key1"))
-				.add("innerTestEntities",
-						ImmutableList.of(Type.StructField.of("value", Type.string())),
+				.set("id").to(Value.string("key1")).set("innerTestEntities")
+				.toStructArray(Type.struct(StructField.of("value", Type.string())),
 						ImmutableList.of(innerStruct))
 				.build();
 
@@ -85,18 +85,18 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 
 	@Test(expected = SpannerDataException.class)
 	public void readArraySingularMismatchTest() {
-		Struct rowStruct = Struct.newBuilder().add("id", Value.string("key1"))
-				.add("innerTestEntities", Value.int64(3)).build();
+		Struct rowStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
+				.set("innerTestEntities").to(Value.int64(3)).build();
 		this.spannerEntityReader.read(OuterTestEntity.class, rowStruct);
 	}
 
 	@Test(expected = SpannerDataException.class)
 	public void readSingularArrayMismatchTest() {
-		Struct colStruct = Struct.newBuilder().add("string_col", Value.string("value"))
+		Struct colStruct = Struct.newBuilder().set("string_col").to(Value.string("value"))
 				.build();
-		Struct rowStruct = Struct.newBuilder().add("id", Value.string("key1"))
-				.add("innerLengths",
-						ImmutableList.of(Type.StructField.of("string_col", Type.string())),
+		Struct rowStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
+				.set("innerLengths")
+				.toStructArray(Type.struct(StructField.of("string_col", Type.string())),
 						ImmutableList.of(colStruct))
 				.build();
 
@@ -113,12 +113,11 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 
 	@Test
 	public void readConvertedNestedStructTest() {
-		Struct colStruct = Struct.newBuilder().add("string_col", Value.string("value"))
+		Struct colStruct = Struct.newBuilder().set("string_col").to(Value.string("value"))
 				.build();
-		Struct rowStruct = Struct.newBuilder().add("id", Value.string("key1"))
-				.add("innerLengths",
-						ImmutableList
-								.of(Type.StructField.of("string_col", Type.string())),
+		Struct rowStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
+				.set("innerLengths")
+				.toStructArray(Type.struct(StructField.of("string_col", Type.string())),
 						ImmutableList.of(colStruct))
 				.build();
 
@@ -139,13 +138,14 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	@Test(expected = SpannerDataException.class)
 	public void readNotFoundColumnTest() {
 		Struct struct = Struct.newBuilder()
-				.add("id", Value.string("key1"))
-				.add("custom_col", Value.string("string1"))
-				.add("booleanField", Value.bool(true)).add("longField", Value.int64(3L))
-				.add("doubleArray", Value.float64Array(new double[] { 3.33, 3.33, 3.33 }))
-				.add("dateField", Value.date(Date.fromYearMonthDay(2018, 11, 22)))
-				.add("timestampField", Value.timestamp(Timestamp.ofTimeMicroseconds(333)))
-				.add("bytes", Value.bytes(ByteArray.copyFrom("string1"))).build();
+				.set("id").to(Value.string("key1")).set("custom_col")
+				.to(Value.string("string1")).set("booleanField").to(Value.bool(true))
+				.set("longField").to(Value.int64(3L)).set("doubleArray")
+				.to(Value.float64Array(new double[] { 3.33, 3.33, 3.33 }))
+				.set("dateField").to(Value.date(Date.fromYearMonthDay(2018, 11, 22)))
+				.set("timestampField")
+				.to(Value.timestamp(Timestamp.ofTimeMicroseconds(333))).set("bytes")
+				.to(Value.bytes(ByteArray.copyFrom("string1"))).build();
 
 		this.spannerEntityReader.read(TestEntity.class, struct);
 	}
@@ -153,14 +153,15 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	@Test(expected = ConversionFailedException.class)
 	public void readUnconvertableValueTest() {
 		Struct struct = Struct.newBuilder()
-				.add("id", Value.string("key1"))
-				.add("custom_col", Value.string("string1"))
-				.add("booleanField", Value.bool(true)).add("longField", Value.int64(3L))
-				.add("doubleField", Value.string("UNCONVERTABLE VALUE"))
-				.add("doubleArray", Value.float64Array(new double[] { 3.33, 3.33, 3.33 }))
-				.add("dateField", Value.date(Date.fromYearMonthDay(2018, 11, 22)))
-				.add("timestampField", Value.timestamp(Timestamp.ofTimeMicroseconds(333)))
-				.add("bytes", Value.bytes(ByteArray.copyFrom("string1"))).build();
+				.set("id").to(Value.string("key1")).set("custom_col")
+				.to(Value.string("string1")).set("booleanField").to(Value.bool(true))
+				.set("longField").to(Value.int64(3L)).set("doubleField")
+				.to(Value.string("UNCONVERTABLE VALUE")).set("doubleArray")
+				.to(Value.float64Array(new double[] { 3.33, 3.33, 3.33 }))
+				.set("dateField").to(Value.date(Date.fromYearMonthDay(2018, 11, 22)))
+				.set("timestampField")
+				.to(Value.timestamp(Timestamp.ofTimeMicroseconds(333))).set("bytes")
+				.to(Value.bytes(ByteArray.copyFrom("string1"))).build();
 
 		this.spannerEntityReader.read(TestEntity.class, struct);
 	}
@@ -168,14 +169,14 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	@Test(expected = SpannerDataException.class)
 	public void readUnmatachableTypesTest() {
 		Struct struct = Struct.newBuilder()
-				.add("fieldWithUnsupportedType", Value.string("key1")).build();
+				.set("fieldWithUnsupportedType").to(Value.string("key1")).build();
 		this.spannerEntityReader.read(FaultyTestEntity.class, struct);
 	}
 
 	@Test
 	public void shouldReadEntityWithNoDefaultConstructor() {
 		Struct row = Struct.newBuilder()
-				.add("id", Value.string("1234")).build();
+				.set("id").to(Value.string("1234")).build();
 		TestEntities.SimpleConstructorTester result = this.spannerEntityReader
 				.read(TestEntities.SimpleConstructorTester.class, row);
 
@@ -184,10 +185,11 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 
 	@Test
 	public void readNestedStructWithConstructor() {
-		Struct innerStruct = Struct.newBuilder().add("value", Value.string("value")).build();
-		Struct outerStruct = Struct.newBuilder().add("id", Value.string("key1"))
-				.add("innerTestEntities",
-						ImmutableList.of(Type.StructField.of("value", Type.string())),
+		Struct innerStruct = Struct.newBuilder().set("value").to(Value.string("value"))
+				.build();
+		Struct outerStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
+				.set("innerTestEntities")
+				.toStructArray(Type.struct(StructField.of("value", Type.string())),
 						ImmutableList.of(innerStruct))
 				.build();
 
@@ -201,11 +203,10 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	@Test
 	public void testPartialConstructor() {
 		Struct struct = Struct.newBuilder()
-				.add("id", Value.string("key1"))
-				.add("custom_col", Value.string("string1"))
-				.add("booleanField", Value.bool(true))
-				.add("longField", Value.int64(3L))
-				.add("doubleField", Value.float64(3.14)).build();
+				.set("id").to(Value.string("key1")).set("custom_col")
+				.to(Value.string("string1")).set("booleanField").to(Value.bool(true))
+				.set("longField").to(Value.int64(3L)).set("doubleField")
+				.to(Value.float64(3.14)).build();
 
 		this.spannerEntityReader.read(TestEntities.PartialConstructor.class, struct);
 	}
@@ -227,10 +228,9 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	@Test(expected = SpannerDataException.class)
 	public void testPartialConstructorWithNotEnoughArgs() {
 		Struct struct = Struct.newBuilder()
-				.add("id", Value.string("key1"))
-				.add("booleanField", Value.bool(true))
-				.add("longField", Value.int64(3L))
-				.add("doubleField", Value.float64(3.14)).build();
+				.set("id").to(Value.string("key1")).set("booleanField")
+				.to(Value.bool(true)).set("longField").to(Value.int64(3L))
+				.set("doubleField").to(Value.float64(3.14)).build();
 
 		this.spannerEntityReader.read(TestEntities.PartialConstructor.class, struct);
 	}
@@ -238,7 +238,8 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	@Test(expected = SpannerDataException.class)
 	public void zeroArgsListShouldThrowError() {
 		Struct struct = Struct.newBuilder()
-				.add("zeroArgsListOfObjects", Value.stringArray(ImmutableList.of("hello", "world"))).build();
+				.set("zeroArgsListOfObjects")
+				.to(Value.stringArray(ImmutableList.of("hello", "world"))).build();
 		this.spannerEntityReader
 				.read(TestEntities.TestEntityWithListWithZeroTypeArgs.class, struct);
 	}

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTest.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.Oute
 import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.OuterTestEntityFlat;
 import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.OuterTestEntityFlatFaulty;
 import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.OuterTestHoldingStructEntity;
+import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.OuterTestHoldingStructsEntity;
 import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.TestEntity;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.SpannerDataException;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.SpannerMappingContext;
@@ -85,7 +86,7 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	}
 
 	@Test
-	public void readNestedStructAsStructTest() {
+	public void readNestedStructsAsStructsTest() {
 		Struct innerStruct = Struct.newBuilder().set("value").to(Value.string("value"))
 				.build();
 		Struct outerStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
@@ -94,11 +95,24 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 						ImmutableList.of(innerStruct))
 				.build();
 
-		OuterTestHoldingStructEntity result = this.spannerEntityReader
-				.read(OuterTestHoldingStructEntity.class, outerStruct);
+		OuterTestHoldingStructsEntity result = this.spannerEntityReader
+				.read(OuterTestHoldingStructsEntity.class, outerStruct);
 		assertEquals("key1", result.id);
 		assertEquals(1, result.innerStructs.size());
 		assertEquals("value", result.innerStructs.get(0).getString("value"));
+	}
+
+	@Test
+	public void readNestedStructAsStructTest() {
+		Struct innerStruct = Struct.newBuilder().set("value").to(Value.string("value"))
+				.build();
+		Struct outerStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
+				.set("innerStruct").to(innerStruct).build();
+
+		OuterTestHoldingStructEntity result = this.spannerEntityReader
+				.read(OuterTestHoldingStructEntity.class, outerStruct);
+		assertEquals("key1", result.id);
+		assertEquals("value", result.innerStruct.getString("value"));
 	}
 
 	@Test(expected = SpannerDataException.class)

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTest.java
@@ -33,6 +33,7 @@ import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.Faul
 import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.OuterTestEntity;
 import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.OuterTestEntityFlat;
 import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.OuterTestEntityFlatFaulty;
+import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.OuterTestHoldingStructEntity;
 import org.springframework.cloud.gcp.data.spanner.core.convert.TestEntities.TestEntity;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.SpannerDataException;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.SpannerMappingContext;
@@ -81,6 +82,23 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 		assertEquals("key1", result.id);
 		assertEquals(1, result.innerTestEntities.size());
 		assertEquals("value", result.innerTestEntities.get(0).value);
+	}
+
+	@Test
+	public void readNestedStructAsStructTest() {
+		Struct innerStruct = Struct.newBuilder().set("value").to(Value.string("value"))
+				.build();
+		Struct outerStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
+				.set("innerStructs")
+				.toStructArray(Type.struct(StructField.of("value", Type.string())),
+						ImmutableList.of(innerStruct))
+				.build();
+
+		OuterTestHoldingStructEntity result = this.spannerEntityReader
+				.read(OuterTestHoldingStructEntity.class, outerStruct);
+		assertEquals("key1", result.id);
+		assertEquals(1, result.innerStructs.size());
+		assertEquals("value", result.innerStructs.get(0).getString("value"));
 	}
 
 	@Test(expected = SpannerDataException.class)

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTest.java
@@ -71,7 +71,7 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 	@Test
 	public void readNestedStructTest() {
 		Struct innerStruct = Struct.newBuilder()
-				.set("value").to(Value.string("value")).build();
+				.set("value").to(Value.string("inner-value")).build();
 		Struct outerStruct = Struct.newBuilder()
 				.set("id").to(Value.string("key1")).set("innerTestEntities")
 				.toStructArray(Type.struct(StructField.of("value", Type.string())),
@@ -82,12 +82,12 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 				outerStruct);
 		assertEquals("key1", result.id);
 		assertEquals(1, result.innerTestEntities.size());
-		assertEquals("value", result.innerTestEntities.get(0).value);
+		assertEquals("inner-value", result.innerTestEntities.get(0).value);
 	}
 
 	@Test
 	public void readNestedStructsAsStructsTest() {
-		Struct innerStruct = Struct.newBuilder().set("value").to(Value.string("value"))
+		Struct innerStruct = Struct.newBuilder().set("value").to(Value.string("inner-value"))
 				.build();
 		Struct outerStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
 				.set("innerStructs")
@@ -99,12 +99,12 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 				.read(OuterTestHoldingStructsEntity.class, outerStruct);
 		assertEquals("key1", result.id);
 		assertEquals(1, result.innerStructs.size());
-		assertEquals("value", result.innerStructs.get(0).getString("value"));
+		assertEquals("inner-value", result.innerStructs.get(0).getString("value"));
 	}
 
 	@Test
 	public void readNestedStructAsStructTest() {
-		Struct innerStruct = Struct.newBuilder().set("value").to(Value.string("value"))
+		Struct innerStruct = Struct.newBuilder().set("value").to(Value.string("inner-value"))
 				.build();
 		Struct outerStruct = Struct.newBuilder().set("id").to(Value.string("key1"))
 				.set("innerStruct").to(innerStruct).build();
@@ -112,7 +112,7 @@ public class ConverterAwareMappingSpannerEntityReaderTest {
 		OuterTestHoldingStructEntity result = this.spannerEntityReader
 				.read(OuterTestHoldingStructEntity.class, outerStruct);
 		assertEquals("key1", result.id);
-		assertEquals("value", result.innerStruct.getString("value"));
+		assertEquals("inner-value", result.innerStruct.getString("value"));
 	}
 
 	@Test(expected = SpannerDataException.class)

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTest.java
@@ -28,7 +28,6 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
-import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
 import org.junit.Before;
 import org.junit.Test;
@@ -98,7 +97,6 @@ public class ConverterAwareMappingSpannerEntityWriterTest {
 		t.timestampList.add(t.timestampField);
 		t.bytesList = new ArrayList<>();
 		t.bytesList.add(t.bytes);
-		t.valueField = Value.string("testValue");
 
 		Instant i1 = Instant.ofEpochSecond(111);
 		Instant i2 = Instant.ofEpochSecond(222);
@@ -217,7 +215,6 @@ public class ConverterAwareMappingSpannerEntityWriterTest {
 		verify(timestampFieldBinder, times(1)).to(eq(t.timestampField));
 		verify(bytesFieldBinder, times(1)).to(eq(t.bytes));
 		verify(instantListFieldBinder, times(1)).toTimestampArray(eq(timestamps));
-		verify(valueFieldBinder, times(1)).to(eq(t.valueField));
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,6 +98,7 @@ public class ConverterAwareMappingSpannerEntityWriterTest {
 		t.timestampList.add(t.timestampField);
 		t.bytesList = new ArrayList<>();
 		t.bytesList.add(t.bytes);
+		t.valueField = Value.string("testValue");
 
 		Instant i1 = Instant.ofEpochSecond(111);
 		Instant i2 = Instant.ofEpochSecond(222);
@@ -190,6 +192,11 @@ public class ConverterAwareMappingSpannerEntityWriterTest {
 		when(bytesFieldBinder.to((ByteArray) any())).thenReturn(null);
 		when(writeBuilder.set(eq("bytes"))).thenReturn(bytesFieldBinder);
 
+		ValueBinder<WriteBuilder> valueFieldBinder = mock(ValueBinder.class);
+		when(valueFieldBinder.to((com.google.cloud.spanner.Value) any()))
+				.thenReturn(null);
+		when(writeBuilder.set(eq("valueField"))).thenReturn(valueFieldBinder);
+
 		this.spannerEntityWriter.write(t, writeBuilder);
 
 		verify(idBinder, times(1)).to(eq(t.id));
@@ -210,6 +217,7 @@ public class ConverterAwareMappingSpannerEntityWriterTest {
 		verify(timestampFieldBinder, times(1)).to(eq(t.timestampField));
 		verify(bytesFieldBinder, times(1)).to(eq(t.bytes));
 		verify(instantListFieldBinder, times(1)).toTimestampArray(eq(timestamps));
+		verify(valueFieldBinder, times(1)).to(eq(t.valueField));
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTest.java
@@ -190,11 +190,6 @@ public class ConverterAwareMappingSpannerEntityWriterTest {
 		when(bytesFieldBinder.to((ByteArray) any())).thenReturn(null);
 		when(writeBuilder.set(eq("bytes"))).thenReturn(bytesFieldBinder);
 
-		ValueBinder<WriteBuilder> valueFieldBinder = mock(ValueBinder.class);
-		when(valueFieldBinder.to((com.google.cloud.spanner.Value) any()))
-				.thenReturn(null);
-		when(writeBuilder.set(eq("valueField"))).thenReturn(valueFieldBinder);
-
 		this.spannerEntityWriter.write(t, writeBuilder);
 
 		verify(idBinder, times(1)).to(eq(t.id));

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/SpannerWriteMethodCoverageTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/SpannerWriteMethodCoverageTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 
+import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.ValueBinder;
 import org.junit.Test;
 
@@ -45,7 +46,12 @@ public class SpannerWriteMethodCoverageTest {
 			}
 
 			Class<?> paramType = ConversionUtils.boxIfNeeded(method.getParameterTypes()[0]);
-			if (ConversionUtils.isIterableNonByteArrayType(paramType)) {
+			if (paramType.equals(Struct.class)) {
+				// there is a method for binding a Struct value, but because Struct values
+				// cannot be written to table columns we will ignore it.
+				continue;
+			}
+			else if (ConversionUtils.isIterableNonByteArrayType(paramType)) {
 				Class<?> innerParamType = (Class) ((ParameterizedType) method
 						.getGenericParameterTypes()[0]).getActualTypeArguments()[0];
 				assertThat(ConverterAwareMappingSpannerEntityWriter.iterablePropertyType2ToMethodMap

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/SpannerWriteMethodCoverageTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/SpannerWriteMethodCoverageTest.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
 import org.junit.Test;
 
@@ -46,9 +47,15 @@ public class SpannerWriteMethodCoverageTest {
 			}
 
 			Class<?> paramType = ConversionUtils.boxIfNeeded(method.getParameterTypes()[0]);
-			if (paramType.equals(Struct.class)) {
-				// there is a method for binding a Struct value, but because Struct values
-				// cannot be written to table columns we will ignore it.
+			if (paramType.equals(Struct.class) || paramType.equals(Value.class)) {
+				/*
+				 * 1. there is a method for binding a Struct value, but because Struct
+				 * values cannot be written to table columns we will ignore it. 2. there
+				 * is a method for binding a Value value. However, the purpose of the
+				 * converters is to wrap java types into the Value for the user.
+				 * Furthermore, the Cloud Spanner client lib does not give a way to read a
+				 * Value back from a Struct, so we will ignore this method.
+				 */
 				continue;
 			}
 			else if (ConversionUtils.isIterableNonByteArrayType(paramType)) {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
@@ -102,11 +102,19 @@ public class TestEntities {
 	}
 
 	@Table(name = "outer_test_entity")
-	static class OuterTestHoldingStructEntity {
+	static class OuterTestHoldingStructsEntity {
 		@PrimaryKey
 		String id;
 
 		List<Struct> innerStructs;
+	}
+
+	@Table(name = "outer_test_entity")
+	static class OuterTestHoldingStructEntity {
+		@PrimaryKey
+		String id;
+
+		Struct innerStruct;
 	}
 
 	@Table(name = "outer_test_entity_flat")

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
@@ -23,6 +23,7 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
 
 import org.springframework.cloud.gcp.data.spanner.core.mapping.Column;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.PrimaryKey;
@@ -75,6 +76,8 @@ public class TestEntities {
 		Timestamp timestampField;
 
 		ByteArray bytes;
+
+		Value valueField;
 	}
 
 	@Table(name = "faulty_test_table")

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
@@ -23,7 +23,6 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Struct;
-import com.google.cloud.spanner.Value;
 
 import org.springframework.cloud.gcp.data.spanner.core.mapping.Column;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.PrimaryKey;
@@ -76,8 +75,6 @@ public class TestEntities {
 		Timestamp timestampField;
 
 		ByteArray bytes;
-
-		Value valueField;
 	}
 
 	@Table(name = "faulty_test_table")

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
@@ -22,6 +22,7 @@ import java.util.List;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Struct;
 
 import org.springframework.cloud.gcp.data.spanner.core.mapping.Column;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.PrimaryKey;
@@ -98,6 +99,14 @@ public class TestEntities {
 		String id;
 
 		List<InnerTestEntity> innerTestEntities;
+	}
+
+	@Table(name = "outer_test_entity")
+	static class OuterTestHoldingStructEntity {
+		@PrimaryKey
+		String id;
+
+		List<Struct> innerStructs;
 	}
 
 	@Table(name = "outer_test_entity_flat")

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<google-cloud-bom.version>0.51.0-alpha</google-cloud-bom.version>
+		<google-cloud-bom.version>0.53.0-alpha</google-cloud-bom.version>
 		<google-auth-library-oauth2-http.version>0.9.1</google-auth-library-oauth2-http.version>
 		<mysql-socket-factory.version>1.0.9</mysql-socket-factory.version>
 	</properties>


### PR DESCRIPTION
Moved to newer version of Spanner client lib for new functionality of structs. 

It involved some API changes for us, and also support for reading Struct columns as Structs. Added new unit tests to cover this case. 

Note that these changes were necessary when going to 0.53.0-alpha BOM for the GCP client libs, which we have already done for the 1.0.x branch. 