### PR TITLE
Spanner LIKE and CONTAINS queries

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/SpannerStatementQueryExecutor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/SpannerStatementQueryExecutor.java
@@ -188,7 +188,18 @@ public class SpannerStatementQueryExecutor {
 
 					switch (part.getType()) {
 					case LIKE:
-						andString += " LIKE %" + insertedTag;
+						andString += " LIKE " + insertedTag;
+						break;
+					case NOT_LIKE:
+						andString += " NOT LIKE " + insertedTag;
+						break;
+					case CONTAINING:
+						andString = " REGEXP_CONTAINS(" + andString + "," + insertedTag
+								+ ") =TRUE";
+						break;
+					case NOT_CONTAINING:
+						andString = " REGEXP_CONTAINS(" + andString + "," + insertedTag
+								+ ") =FALSE";
 						break;
 					case SIMPLE_PROPERTY:
 						andString += "=" + insertedTag;

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -130,6 +130,14 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		assertEquals(2, customSortedTrades.size());
 		assertTrue(customSortedTrades.get(0).getId()
 				.compareTo(customSortedTrades.get(1).getId()) < 0);
+
+		this.tradeRepository.findBySymbolLike("%BCD")
+				.forEach(x -> assertEquals("ABCD", x.getSymbol()));
+		assertTrue(this.tradeRepository.findBySymbolNotLike("%BCD").isEmpty());
+
+		this.tradeRepository.findBySymbolContains("BCD")
+				.forEach(x -> assertEquals("ABCD", x.getSymbol()));
+		assertTrue(this.tradeRepository.findBySymbolNotContains("BCD").isEmpty());
 	}
 
 	protected List<Trade> insertTrades(String traderId1, String action, int numTrades) {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -69,7 +69,7 @@ public class SpannerStatementQueryTests {
 	}
 
 	private PartTreeSpannerQuery<Trade> createQuery() {
-		return new PartTreeSpannerQuery<Trade>(Trade.class, this.queryMethod,
+		return new PartTreeSpannerQuery<>(Trade.class, this.queryMethod,
 				this.spannerTemplate, this.spannerMappingContext);
 	}
 
@@ -92,7 +92,7 @@ public class SpannerStatementQueryTests {
 							"SELECT DISTINCT * FROM trades WHERE ( LOWER(action)=LOWER(@tag0) "
 									+ "AND ticker=@tag1 ) OR "
 									+ "( trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id<>NULL AND "
-									+ "trader_id=NULL AND trader_id LIKE %@tag7 AND price=TRUE AND price=FALSE AND "
+									+ "trader_id=NULL AND trader_id LIKE @tag7 AND price=TRUE AND price=FALSE AND "
 									+ "price>@tag10 AND price<=@tag11 ) ORDER BY id DESC LIMIT 3;",
 							statement.getSql());
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/TradeRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/TradeRepository.java
@@ -42,4 +42,12 @@ public interface TradeRepository extends SpannerRepository<Trade, Key> {
 	@Query("SELECT * FROM :org.springframework.cloud.gcp.data.spanner.test.domain.Trade:"
 			+ " ORDER BY LOWER(action) DESC")
 	List<Trade> sortedTrades(Pageable pageable);
+
+	List<Trade> findBySymbolLike(String symbolFragment);
+
+	List<Trade> findBySymbolContains(String symbolFragment);
+
+	List<Trade> findBySymbolNotLike(String symbolFragment);
+
+	List<Trade> findBySymbolNotContains(String symbolFragment);
 }

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spanner.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spanner.adoc
@@ -869,6 +869,20 @@ a non-case-sensitive matching. The `IgnoreCase` phrase may only be appended to f
 to columns of type STRING or BYTES.
 The Spring Data "AllIgnoreCase" phrase appended at the end of the method name is not supported.
 
+The `Like` or `NotLike` naming conventions:
+[source, java]
+----
+List<Trade> findBySymbolLike(String symbolFragment);
+----
+The param `symbolFragment` can contain https://cloud.google.com/spanner/docs/functions-and-operators#comparison-operators[wildcard characters]
+for string matching such as `_` and `%`.
+
+The `Contains` and `NotContains` naming conventions:
+[source, java]
+----
+List<Trade> findBySymbolContains(String symbolFragment);
+----
+The param `symbolFragment` is a https://cloud.google.com/spanner/docs/functions-and-operators#regexp_contains[regular expression] that is checked for occurrences.
 
 ==== Custom SQL query methods
 


### PR DESCRIPTION
fixes #809
fixes #810 

For LIKE and NOT LIKE queries the user needs to provide the `_` or `%` matching characters in the param.
https://cloud.google.com/spanner/docs/functions-and-operators#operators

For CONTAINS and NOT  CONTAINS queries, the string the user provides is a regex. 
https://cloud.google.com/spanner/docs/functions-and-operators#regexp_contains