### PR TITLE
Split PubSubTemplate into Publisher and Subscriber [WIP]

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -38,6 +38,8 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
 import org.threeten.bp.Duration;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -122,12 +124,23 @@ public class GcpPubSubAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public PubSubTemplate pubSubTemplate(PublisherFactory publisherFactory,
-			SubscriberFactory subscriberFactory,
-			ObjectProvider<PubSubMessageConverter> pubSubMessageConverter) {
-		PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
-		pubSubMessageConverter.ifUnique(pubSubTemplate::setMessageConverter);
-		return pubSubTemplate;
+	public PubSubPublisherTemplate pubSubPublisherTemplate(PublisherFactory publisherFactory, ObjectProvider<PubSubMessageConverter> pubSubMessageConverter) {
+		PubSubPublisherTemplate pubSubPublisherTemplate =  new PubSubPublisherTemplate(publisherFactory);
+		pubSubMessageConverter.ifUnique(pubSubPublisherTemplate::setMessageConverter);
+		return pubSubPublisherTemplate;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PubSubSubscriberTemplate pubSubSubscriberTemplate(SubscriberFactory subscriberFactory) {
+		return new PubSubSubscriberTemplate(subscriberFactory);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PubSubTemplate pubSubTemplate(PubSubPublisherTemplate pubSubPublisherTemplate,
+			PubSubSubscriberTemplate pubSubSubscriberTemplate) {
+		return new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
 	}
 
 	@Bean

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubOperations.java
@@ -16,87 +16,18 @@
 
 package org.springframework.cloud.gcp.pubsub.core;
 
-import java.util.List;
-import java.util.Map;
-
-import com.google.cloud.pubsub.v1.MessageReceiver;
-import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.pubsub.v1.PubsubMessage;
-
-import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;
-import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherOperations;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberOperations;
 
 /**
- * An abstraction for Google Cloud Pub/Sub.
+ * An abstraction for Google Cloud Pub/Sub that combines publisher and subscriber
+ * operations.
  *
  * @author Vinicius Carvalho
  * @author João André Martins
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  */
-public interface PubSubOperations {
+public interface PubSubOperations extends PubSubPublisherOperations, PubSubSubscriberOperations {
 
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload an object that will be serialized and sent
-	 * @return the listenable future of the call
-	 */
-	<T> ListenableFuture<String> publish(String topic, T payload,
-			Map<String, String> headers);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param payload an object that will be serialized and sent
-	 * @return the listenable future of the call
-	 */
-	<T> ListenableFuture<String> publish(String topic, T payload);
-
-	/**
-	 * Send a message to Pub/Sub.
-	 * @param topic the name of an existing topic
-	 * @param pubsubMessage a Google Cloud Pub/Sub API message
-	 * @return the listenable future of the call
-	 */
-	ListenableFuture<String> publish(String topic, PubsubMessage pubsubMessage);
-
-	/**
-	 * Add a callback method to an existing subscription.
-	 *
-	 * <p>The created {@link Subscriber} is returned so it can be stopped.
-	 * @param subscription the name of an existing subscription
-	 * @param messageHandler the callback method triggered when new messages arrive
-	 * @return subscriber listening to new messages
-	 */
-	Subscriber subscribe(String subscription, MessageReceiver messageHandler);
-
-	/**
-	 * Pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
-	 * @param subscription the subscription name
-	 * @param maxMessages the maximum number of pulled messages
-	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
-	 * messages to satisfy {@code maxMessages}
-	 * @return the list of received messages
-	 */
-	List<PubsubMessage> pullAndAck(String subscription, Integer maxMessages,
-			Boolean returnImmediately);
-
-	/**
-	 * Pull a number of messages from a Google Cloud Pub/Sub subscription.
-	 * @param subscription the subscription name
-	 * @param maxMessages the maximum number of pulled messages
-	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
-	 * messages to satisfy {@code maxMessages}
-	 * @return the list of received acknowledgeable messages
-	 */
-	List<AcknowledgeablePubsubMessage> pull(String subscription, Integer maxMessages,
-			Boolean returnImmediately);
-
-	/**
-	 * Pull and auto-acknowledge a message from a Google Cloud Pub/Sub subscription.
-	 * @param subscription the subscription name
-	 * @return a received message, or {@code null} if none exists in the subscription
-	 */
-	PubsubMessage pullNext(String subscription);
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherOperations.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package org.springframework.cloud.gcp.pubsub.core;
+package org.springframework.cloud.gcp.pubsub.core.publisher;
 
 import java.util.Map;
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherOperations.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.pubsub.core;
+
+import java.util.Map;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import org.springframework.util.concurrent.ListenableFuture;
+
+/**
+ * An abstraction for Google Cloud Pub/Sub that specifies publisher-only operations.
+ *
+ * @author Mike Eltsufin
+ * @since 1.1.0
+ */
+public interface PubSubPublisherOperations {
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param topic the name of an existing topic
+	 * @param payload an object that will be serialized and sent
+	 * @return the listenable future of the call
+	 */
+	<T> ListenableFuture<String> publish(String topic, T payload,
+			Map<String, String> headers);
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param topic the name of an existing topic
+	 * @param payload an object that will be serialized and sent
+	 * @return the listenable future of the call
+	 */
+	<T> ListenableFuture<String> publish(String topic, T payload);
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param topic the name of an existing topic
+	 * @param pubsubMessage a Google Cloud Pub/Sub API message
+	 * @return the listenable future of the call
+	 */
+	ListenableFuture<String> publish(String topic, PubsubMessage pubsubMessage);
+
+}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
@@ -14,29 +14,18 @@
  *  limitations under the License.
  */
 
-package org.springframework.cloud.gcp.pubsub.core;
+package org.springframework.cloud.gcp.pubsub.core.publisher;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
-import com.google.cloud.pubsub.v1.MessageReceiver;
-import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.cloud.pubsub.v1.stub.SubscriberStub;
 import com.google.pubsub.v1.PubsubMessage;
-import com.google.pubsub.v1.PullRequest;
-import com.google.pubsub.v1.PullResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;
-import org.springframework.cloud.gcp.pubsub.support.PubSubAcknowledger;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
-import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.cloud.gcp.pubsub.support.converter.PubSubMessageConverter;
 import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
 import org.springframework.util.Assert;
@@ -44,17 +33,19 @@ import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
- * Default implementation of {@link PubSubOperations}.
+ * Default implementation of {@link PubSubPublisherOperations}.
  *
- * <p>The main Google Cloud Pub/Sub integration component for publishing to topics and consuming
- * messages from subscriptions asynchronously or by pulling.
+ * <p>
+ * The main Google Cloud Pub/Sub integration component for publishing messages to topics.
  *
  * @author Vinicius Carvalho
  * @author João André Martins
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
+ *
+ * @since 1.1.0
  */
-public class PubSubPublisherTemplate implements PubSubOperations, InitializingBean {
+public class PubSubPublisherTemplate implements PubSubPublisherOperations {
 
 	private static final Log LOGGER = LogFactory.getLog(PubSubPublisherTemplate.class);
 
@@ -62,26 +53,14 @@ public class PubSubPublisherTemplate implements PubSubOperations, InitializingBe
 
 	private final PublisherFactory publisherFactory;
 
-	private final SubscriberFactory subscriberFactory;
-
-	private final SubscriberStub subscriberStub;
-
-	private final PubSubAcknowledger acknowledger;
-
 	/**
-	 * Default {@link PubSubPublisherTemplate} constructor that uses {@link SimplePubSubMessageConverter}
-	 * to serialize and deserialize payloads.
+	 * Default {@link PubSubPublisherTemplate} constructor that uses
+	 * {@link SimplePubSubMessageConverter} to serialize and deserialize payloads.
 	 * @param publisherFactory the {@link com.google.cloud.pubsub.v1.Publisher} factory to
 	 * publish to topics
-	 * @param subscriberFactory the {@link Subscriber} factory
-	 * to subscribe to subscriptions
 	 */
-	public PubSubPublisherTemplate(PublisherFactory publisherFactory,
-			SubscriberFactory subscriberFactory) {
+	public PubSubPublisherTemplate(PublisherFactory publisherFactory) {
 		this.publisherFactory = publisherFactory;
-		this.subscriberFactory = subscriberFactory;
-		this.subscriberStub = this.subscriberFactory.createSubscriberStub();
-		this.acknowledger = this.subscriberFactory.createAcknowledger();
 	}
 
 	public PubSubMessageConverter getMessageConverter() {
@@ -111,8 +90,7 @@ public class PubSubPublisherTemplate implements PubSubOperations, InitializingBe
 
 	@Override
 	public ListenableFuture<String> publish(final String topic, PubsubMessage pubsubMessage) {
-		ApiFuture<String> publishFuture =
-				this.publisherFactory.createPublisher(topic).publish(pubsubMessage);
+		ApiFuture<String> publishFuture = this.publisherFactory.createPublisher(topic).publish(pubsubMessage);
 
 		final SettableListenableFuture<String> settableFuture = new SettableListenableFuture<>();
 		ApiFutures.addCallback(publishFuture, new ApiFutureCallback<String>() {
@@ -137,80 +115,8 @@ public class PubSubPublisherTemplate implements PubSubOperations, InitializingBe
 		return settableFuture;
 	}
 
-	@Override
-	public Subscriber subscribe(String subscription, MessageReceiver messageHandler) {
-		Subscriber subscriber =
-				this.subscriberFactory.createSubscriber(subscription, messageHandler);
-		subscriber.startAsync();
-		return subscriber;
-	}
-
-	/**
-	 * Pulls messages synchronously, on demand, using the pull request in argument.
-	 * @param pullRequest pull request containing the subscription name
-	 * @return the list of {@link AcknowledgeablePubsubMessage} containing the ack ID, subscription
-	 * and acknowledger
-	 */
-	private List<AcknowledgeablePubsubMessage> pull(PullRequest pullRequest) {
-		Assert.notNull(pullRequest, "The pull request cannot be null.");
-
-		PullResponse pullResponse =	this.subscriberStub.pullCallable().call(pullRequest);
-		List<AcknowledgeablePubsubMessage> receivedMessages =
-				pullResponse.getReceivedMessagesList().stream()
-						.map(message -> {
-							return new AcknowledgeablePubsubMessage(message.getMessage(),
-									message.getAckId(),
-									pullRequest.getSubscription(),
-									this.acknowledger);
-						})
-						.collect(Collectors.toList());
-
-		return receivedMessages;
-	}
-
-	@Override
-	public List<AcknowledgeablePubsubMessage> pull(String subscription, Integer maxMessages,
-			Boolean returnImmediately) {
-		return pull(this.subscriberFactory.createPullRequest(subscription, maxMessages,
-				returnImmediately));
-	}
-
-	@Override
-	public List<PubsubMessage> pullAndAck(String subscription, Integer maxMessages,
-			Boolean returnImmediately) {
-		PullRequest pullRequest = this.subscriberFactory.createPullRequest(
-				subscription, maxMessages, returnImmediately);
-
-		List<AcknowledgeablePubsubMessage> ackableMessages = pull(pullRequest);
-
-		this.acknowledger.ack(ackableMessages.stream()
-				.map(AcknowledgeablePubsubMessage::getAckId)
-				.collect(Collectors.toList()), pullRequest.getSubscription());
-
-		return ackableMessages.stream().map(AcknowledgeablePubsubMessage::getMessage)
-				.collect(Collectors.toList());
-	}
-
-	@Override
-	public PubsubMessage pullNext(String subscription) {
-		List<PubsubMessage> receivedMessageList = pullAndAck(subscription, 1, true);
-
-		return receivedMessageList.size() > 0 ?	receivedMessageList.get(0) : null;
-	}
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-	}
-
 	public PublisherFactory getPublisherFactory() {
 		return this.publisherFactory;
 	}
 
-	public SubscriberFactory getSubscriberFactory() {
-		return this.subscriberFactory;
-	}
-
-	public PubSubAcknowledger getAcknowledger() {
-		return this.acknowledger;
-	}
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
@@ -1,0 +1,216 @@
+/*
+ *  Copyright 2017-2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.pubsub.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;
+import org.springframework.cloud.gcp.pubsub.support.PubSubAcknowledger;
+import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.converter.PubSubMessageConverter;
+import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
+import org.springframework.util.Assert;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.SettableListenableFuture;
+
+/**
+ * Default implementation of {@link PubSubOperations}.
+ *
+ * <p>The main Google Cloud Pub/Sub integration component for publishing to topics and consuming
+ * messages from subscriptions asynchronously or by pulling.
+ *
+ * @author Vinicius Carvalho
+ * @author João André Martins
+ * @author Mike Eltsufin
+ * @author Chengyuan Zhao
+ */
+public class PubSubPublisherTemplate implements PubSubOperations, InitializingBean {
+
+	private static final Log LOGGER = LogFactory.getLog(PubSubPublisherTemplate.class);
+
+	private PubSubMessageConverter messageConverter = new SimplePubSubMessageConverter();
+
+	private final PublisherFactory publisherFactory;
+
+	private final SubscriberFactory subscriberFactory;
+
+	private final SubscriberStub subscriberStub;
+
+	private final PubSubAcknowledger acknowledger;
+
+	/**
+	 * Default {@link PubSubPublisherTemplate} constructor that uses {@link SimplePubSubMessageConverter}
+	 * to serialize and deserialize payloads.
+	 * @param publisherFactory the {@link com.google.cloud.pubsub.v1.Publisher} factory to
+	 * publish to topics
+	 * @param subscriberFactory the {@link Subscriber} factory
+	 * to subscribe to subscriptions
+	 */
+	public PubSubPublisherTemplate(PublisherFactory publisherFactory,
+			SubscriberFactory subscriberFactory) {
+		this.publisherFactory = publisherFactory;
+		this.subscriberFactory = subscriberFactory;
+		this.subscriberStub = this.subscriberFactory.createSubscriberStub();
+		this.acknowledger = this.subscriberFactory.createAcknowledger();
+	}
+
+	public PubSubMessageConverter getMessageConverter() {
+		return this.messageConverter;
+	}
+
+	public PubSubPublisherTemplate setMessageConverter(PubSubMessageConverter messageConverter) {
+		Assert.notNull(messageConverter, "A valid Pub/Sub message converter is required.");
+		this.messageConverter = messageConverter;
+		return this;
+	}
+
+	/**
+	 * Uses the configured message converter to first convert the payload and headers to a
+	 * {@code PubsubMessage} and then publish it.
+	 */
+	@Override
+	public <T> ListenableFuture<String> publish(String topic, T payload,
+			Map<String, String> headers) {
+		return publish(topic, this.messageConverter.toPubSubMessage(payload, headers));
+	}
+
+	@Override
+	public <T> ListenableFuture<String> publish(String topic, T payload) {
+		return publish(topic, payload, null);
+	}
+
+	@Override
+	public ListenableFuture<String> publish(final String topic, PubsubMessage pubsubMessage) {
+		ApiFuture<String> publishFuture =
+				this.publisherFactory.createPublisher(topic).publish(pubsubMessage);
+
+		final SettableListenableFuture<String> settableFuture = new SettableListenableFuture<>();
+		ApiFutures.addCallback(publishFuture, new ApiFutureCallback<String>() {
+
+			@Override
+			public void onFailure(Throwable throwable) {
+				LOGGER.warn("Publishing to " + topic + " topic failed.", throwable);
+				settableFuture.setException(throwable);
+			}
+
+			@Override
+			public void onSuccess(String result) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(
+							"Publishing to " + topic + " was successful. Message ID: " + result);
+				}
+				settableFuture.set(result);
+			}
+
+		});
+
+		return settableFuture;
+	}
+
+	@Override
+	public Subscriber subscribe(String subscription, MessageReceiver messageHandler) {
+		Subscriber subscriber =
+				this.subscriberFactory.createSubscriber(subscription, messageHandler);
+		subscriber.startAsync();
+		return subscriber;
+	}
+
+	/**
+	 * Pulls messages synchronously, on demand, using the pull request in argument.
+	 * @param pullRequest pull request containing the subscription name
+	 * @return the list of {@link AcknowledgeablePubsubMessage} containing the ack ID, subscription
+	 * and acknowledger
+	 */
+	private List<AcknowledgeablePubsubMessage> pull(PullRequest pullRequest) {
+		Assert.notNull(pullRequest, "The pull request cannot be null.");
+
+		PullResponse pullResponse =	this.subscriberStub.pullCallable().call(pullRequest);
+		List<AcknowledgeablePubsubMessage> receivedMessages =
+				pullResponse.getReceivedMessagesList().stream()
+						.map(message -> {
+							return new AcknowledgeablePubsubMessage(message.getMessage(),
+									message.getAckId(),
+									pullRequest.getSubscription(),
+									this.acknowledger);
+						})
+						.collect(Collectors.toList());
+
+		return receivedMessages;
+	}
+
+	@Override
+	public List<AcknowledgeablePubsubMessage> pull(String subscription, Integer maxMessages,
+			Boolean returnImmediately) {
+		return pull(this.subscriberFactory.createPullRequest(subscription, maxMessages,
+				returnImmediately));
+	}
+
+	@Override
+	public List<PubsubMessage> pullAndAck(String subscription, Integer maxMessages,
+			Boolean returnImmediately) {
+		PullRequest pullRequest = this.subscriberFactory.createPullRequest(
+				subscription, maxMessages, returnImmediately);
+
+		List<AcknowledgeablePubsubMessage> ackableMessages = pull(pullRequest);
+
+		this.acknowledger.ack(ackableMessages.stream()
+				.map(AcknowledgeablePubsubMessage::getAckId)
+				.collect(Collectors.toList()), pullRequest.getSubscription());
+
+		return ackableMessages.stream().map(AcknowledgeablePubsubMessage::getMessage)
+				.collect(Collectors.toList());
+	}
+
+	@Override
+	public PubsubMessage pullNext(String subscription) {
+		List<PubsubMessage> receivedMessageList = pullAndAck(subscription, 1, true);
+
+		return receivedMessageList.size() > 0 ?	receivedMessageList.get(0) : null;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+	}
+
+	public PublisherFactory getPublisherFactory() {
+		return this.publisherFactory;
+	}
+
+	public SubscriberFactory getSubscriberFactory() {
+		return this.subscriberFactory;
+	}
+
+	public PubSubAcknowledger getAcknowledger() {
+		return this.acknowledger;
+	}
+}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.pubsub.core;
+
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.PubsubMessage;
+import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;
+
+import java.util.List;
+
+/**
+ * An abstraction for Google Cloud Pub/Sub that specifies subscriber-only operations.
+ *
+ * @author Mike Eltsufin
+ * @since 1.1.0
+ */
+public interface PubSubSubscriberOperations {
+	/**
+	 * Add a callback method to an existing subscription.
+	 *
+	 * <p>The created {@link Subscriber} is returned so it can be stopped.
+	 * @param subscription the name of an existing subscription
+	 * @param messageHandler the callback method triggered when new messages arrive
+	 * @return subscriber listening to new messages
+	 */
+	Subscriber subscribe(String subscription, MessageReceiver messageHandler);
+
+	/**
+	 * Pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
+	 * @param subscription the subscription name
+	 * @param maxMessages the maximum number of pulled messages
+	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
+	 * messages to satisfy {@code maxMessages}
+	 * @return the list of received messages
+	 */
+	List<PubsubMessage> pullAndAck(String subscription, Integer maxMessages,
+			Boolean returnImmediately);
+
+	/**
+	 * Pull a number of messages from a Google Cloud Pub/Sub subscription.
+	 * @param subscription the subscription name
+	 * @param maxMessages the maximum number of pulled messages
+	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
+	 * messages to satisfy {@code maxMessages}
+	 * @return the list of received acknowledgeable messages
+	 */
+	List<AcknowledgeablePubsubMessage> pull(String subscription, Integer maxMessages,
+			Boolean returnImmediately);
+
+	/**
+	 * Pull and auto-acknowledge a message from a Google Cloud Pub/Sub subscription.
+	 * @param subscription the subscription name
+	 * @return a received message, or {@code null} if none exists in the subscription
+	 */
+	PubsubMessage pullNext(String subscription);
+}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -14,14 +14,15 @@
  *  limitations under the License.
  */
 
-package org.springframework.cloud.gcp.pubsub.core;
+package org.springframework.cloud.gcp.pubsub.core.subscriber;
+
+import java.util.List;
 
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.pubsub.v1.PubsubMessage;
-import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;
 
-import java.util.List;
+import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;
 
 /**
  * An abstraction for Google Cloud Pub/Sub that specifies subscriber-only operations.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
@@ -1,0 +1,216 @@
+/*
+ *  Copyright 2017-2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.pubsub.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;
+import org.springframework.cloud.gcp.pubsub.support.PubSubAcknowledger;
+import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
+import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
+import org.springframework.cloud.gcp.pubsub.support.converter.PubSubMessageConverter;
+import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
+import org.springframework.util.Assert;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.SettableListenableFuture;
+
+/**
+ * Default implementation of {@link PubSubOperations}.
+ *
+ * <p>The main Google Cloud Pub/Sub integration component for publishing to topics and consuming
+ * messages from subscriptions asynchronously or by pulling.
+ *
+ * @author Vinicius Carvalho
+ * @author João André Martins
+ * @author Mike Eltsufin
+ * @author Chengyuan Zhao
+ */
+public class PubSubSubscriberTemplate implements PubSubOperations, InitializingBean {
+
+	private static final Log LOGGER = LogFactory.getLog(PubSubSubscriberTemplate.class);
+
+	private PubSubMessageConverter messageConverter = new SimplePubSubMessageConverter();
+
+	private final PublisherFactory publisherFactory;
+
+	private final SubscriberFactory subscriberFactory;
+
+	private final SubscriberStub subscriberStub;
+
+	private final PubSubAcknowledger acknowledger;
+
+	/**
+	 * Default {@link PubSubSubscriberTemplate} constructor that uses {@link SimplePubSubMessageConverter}
+	 * to serialize and deserialize payloads.
+	 * @param publisherFactory the {@link com.google.cloud.pubsub.v1.Publisher} factory to
+	 * publish to topics
+	 * @param subscriberFactory the {@link Subscriber} factory
+	 * to subscribe to subscriptions
+	 */
+	public PubSubSubscriberTemplate(PublisherFactory publisherFactory,
+			SubscriberFactory subscriberFactory) {
+		this.publisherFactory = publisherFactory;
+		this.subscriberFactory = subscriberFactory;
+		this.subscriberStub = this.subscriberFactory.createSubscriberStub();
+		this.acknowledger = this.subscriberFactory.createAcknowledger();
+	}
+
+	public PubSubMessageConverter getMessageConverter() {
+		return this.messageConverter;
+	}
+
+	public PubSubSubscriberTemplate setMessageConverter(PubSubMessageConverter messageConverter) {
+		Assert.notNull(messageConverter, "A valid Pub/Sub message converter is required.");
+		this.messageConverter = messageConverter;
+		return this;
+	}
+
+	/**
+	 * Uses the configured message converter to first convert the payload and headers to a
+	 * {@code PubsubMessage} and then publish it.
+	 */
+	@Override
+	public <T> ListenableFuture<String> publish(String topic, T payload,
+			Map<String, String> headers) {
+		return publish(topic, this.messageConverter.toPubSubMessage(payload, headers));
+	}
+
+	@Override
+	public <T> ListenableFuture<String> publish(String topic, T payload) {
+		return publish(topic, payload, null);
+	}
+
+	@Override
+	public ListenableFuture<String> publish(final String topic, PubsubMessage pubsubMessage) {
+		ApiFuture<String> publishFuture =
+				this.publisherFactory.createPublisher(topic).publish(pubsubMessage);
+
+		final SettableListenableFuture<String> settableFuture = new SettableListenableFuture<>();
+		ApiFutures.addCallback(publishFuture, new ApiFutureCallback<String>() {
+
+			@Override
+			public void onFailure(Throwable throwable) {
+				LOGGER.warn("Publishing to " + topic + " topic failed.", throwable);
+				settableFuture.setException(throwable);
+			}
+
+			@Override
+			public void onSuccess(String result) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(
+							"Publishing to " + topic + " was successful. Message ID: " + result);
+				}
+				settableFuture.set(result);
+			}
+
+		});
+
+		return settableFuture;
+	}
+
+	@Override
+	public Subscriber subscribe(String subscription, MessageReceiver messageHandler) {
+		Subscriber subscriber =
+				this.subscriberFactory.createSubscriber(subscription, messageHandler);
+		subscriber.startAsync();
+		return subscriber;
+	}
+
+	/**
+	 * Pulls messages synchronously, on demand, using the pull request in argument.
+	 * @param pullRequest pull request containing the subscription name
+	 * @return the list of {@link AcknowledgeablePubsubMessage} containing the ack ID, subscription
+	 * and acknowledger
+	 */
+	private List<AcknowledgeablePubsubMessage> pull(PullRequest pullRequest) {
+		Assert.notNull(pullRequest, "The pull request cannot be null.");
+
+		PullResponse pullResponse =	this.subscriberStub.pullCallable().call(pullRequest);
+		List<AcknowledgeablePubsubMessage> receivedMessages =
+				pullResponse.getReceivedMessagesList().stream()
+						.map(message -> {
+							return new AcknowledgeablePubsubMessage(message.getMessage(),
+									message.getAckId(),
+									pullRequest.getSubscription(),
+									this.acknowledger);
+						})
+						.collect(Collectors.toList());
+
+		return receivedMessages;
+	}
+
+	@Override
+	public List<AcknowledgeablePubsubMessage> pull(String subscription, Integer maxMessages,
+			Boolean returnImmediately) {
+		return pull(this.subscriberFactory.createPullRequest(subscription, maxMessages,
+				returnImmediately));
+	}
+
+	@Override
+	public List<PubsubMessage> pullAndAck(String subscription, Integer maxMessages,
+			Boolean returnImmediately) {
+		PullRequest pullRequest = this.subscriberFactory.createPullRequest(
+				subscription, maxMessages, returnImmediately);
+
+		List<AcknowledgeablePubsubMessage> ackableMessages = pull(pullRequest);
+
+		this.acknowledger.ack(ackableMessages.stream()
+				.map(AcknowledgeablePubsubMessage::getAckId)
+				.collect(Collectors.toList()), pullRequest.getSubscription());
+
+		return ackableMessages.stream().map(AcknowledgeablePubsubMessage::getMessage)
+				.collect(Collectors.toList());
+	}
+
+	@Override
+	public PubsubMessage pullNext(String subscription) {
+		List<PubsubMessage> receivedMessageList = pullAndAck(subscription, 1, true);
+
+		return receivedMessageList.size() > 0 ?	receivedMessageList.get(0) : null;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+	}
+
+	public PublisherFactory getPublisherFactory() {
+		return this.publisherFactory;
+	}
+
+	public SubscriberFactory getSubscriberFactory() {
+		return this.subscriberFactory;
+	}
+
+	public PubSubAcknowledger getAcknowledger() {
+		return this.acknowledger;
+	}
+}


### PR DESCRIPTION
Changes PubSubTemplate to contain instances of PubSubPublisherTemplate
and PubSubSubscriberTemplate and delegates all method calls to them.

Fixes #816.