### PR TITLE
Use bifurcated Pub/Sub template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
 branches:
   only:
     - master
+    - 1.0.x
 cache:
   directories:
     - $HOME/google-cloud-sdk
@@ -19,7 +20,7 @@ before_script:
   - while [ ! -f ~/.config/gcloud/emulators/pubsub/env.yaml ]; do sleep 1; done
   - $(gcloud beta emulators pubsub env-init)
 before_install:
-  - if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then
+  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;
         export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - while [ ! -f ~/.config/gcloud/emulators/pubsub/env.yaml ]; do sleep 1; done
   - $(gcloud beta emulators pubsub env-init)
 before_install:
-  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;
         export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -38,6 +38,8 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
 import org.threeten.bp.Duration;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -122,12 +124,24 @@ public class GcpPubSubAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public PubSubTemplate pubSubTemplate(PublisherFactory publisherFactory,
-			SubscriberFactory subscriberFactory,
+	public PubSubPublisherTemplate pubSubPublisherTemplate(PublisherFactory publisherFactory,
 			ObjectProvider<PubSubMessageConverter> pubSubMessageConverter) {
-		PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
-		pubSubMessageConverter.ifUnique(pubSubTemplate::setMessageConverter);
-		return pubSubTemplate;
+		PubSubPublisherTemplate pubSubPublisherTemplate = new PubSubPublisherTemplate(publisherFactory);
+		pubSubMessageConverter.ifUnique(pubSubPublisherTemplate::setMessageConverter);
+		return pubSubPublisherTemplate;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PubSubSubscriberTemplate pubSubSubscriberTemplate(SubscriberFactory subscriberFactory) {
+		return new PubSubSubscriberTemplate(subscriberFactory);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PubSubTemplate pubSubTemplate(PubSubPublisherTemplate pubSubPublisherTemplate,
+			PubSubSubscriberTemplate pubSubSubscriberTemplate) {
+		return new PubSubTemplate(pubSubPublisherTemplate, pubSubSubscriberTemplate);
 	}
 
 	@Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -38,8 +38,7 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
-import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
-import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
+
 import org.threeten.bp.Duration;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -57,6 +56,8 @@ import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
 import org.springframework.cloud.gcp.pubsub.core.PubSubException;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
 import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -46,7 +46,7 @@ and then sends it to the bound output channel.
 Google Pub/Sub treats message payloads as byte arrays.
 So, by default, the inbound channel adapter will construct the Spring `Message` with `byte[]` as the payload.
 However, you can change the desired payload type by setting the `payloadType` property of the `PubSubInboundChannelAdapter`.
-The `PubSubInboundChannelAdapter` delegates to conversion to the desired payload type to the `PubSubMessageConverter` configured in the `PubSubTemplate`.
+The `PubSubInboundChannelAdapter` delegates the conversion to the desired payload type to the configured `PubSubMessageConverter`.
 
 
 To use the inbound channel adapter, a `PubSubInboundChannelAdapter` must be provided and configured

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -80,6 +80,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 
 		try {
 			sendMessage(MessageBuilder.withPayload(
+					// TODO: need to get the message converter from somewhere.
 					this.pubSubSubscriberOperations.getMessageConverter().fromPubSubMessage(pubsubMessage, this.payloadType))
 					.copyHeaders(messageHeaders)
 					.build());

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -144,10 +144,20 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		this.headerMapper = headerMapper;
 	}
 
+	/**
+	 * Returns the {@link PubSubMessageConverter} used to convert the {@code byte[]} Pub/Sub
+	 * payload to an object of the configured payload type.
+	 * @since 1.1
+	 */
 	public PubSubMessageConverter getMessageConverter() {
 		return this.pubSubMessageConverter;
 	}
 
+	/**
+	 * Sets the {@link PubSubMessageConverter} used to convert the {@code byte[]} Pub/Sub
+	 * payload to an object of the configured payload type.
+	 * @since 1.1
+	 */
 	public void setMessageConverter(
 			PubSubMessageConverter pubSubMessageConverter) {
 		Assert.notNull(pubSubMessageConverter, "The pubSubMessageConverter can't be null.");

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -48,7 +48,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 	private static final long DEFAULT_PUBLISH_TIMEOUT = 10000;
 
-	private final PubSubOperations pubSubTemplate;
+	private final PubSubOperations pubSubPublisherOperations;
 
 	private Expression topicExpression;
 
@@ -62,10 +62,10 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 	private HeaderMapper<Map<String, String>> headerMapper = new PubSubHeaderMapper();
 
-	public PubSubMessageHandler(PubSubOperations pubSubTemplate, String topic) {
-		Assert.notNull(pubSubTemplate, "Pub/Sub template cannot be null.");
+	public PubSubMessageHandler(PubSubOperations pubSubPublisherOperations, String topic) {
+		Assert.notNull(pubSubPublisherOperations, "Pub/Sub publisher template cannot be null.");
 		Assert.notNull(topic, "Pub/Sub topic cannot be null.");
-		this.pubSubTemplate = pubSubTemplate;
+		this.pubSubPublisherOperations = pubSubPublisherOperations;
 		this.topicExpression = new LiteralExpression(topic);
 	}
 
@@ -81,7 +81,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 		Map<String, String> headers = new HashMap<>();
 		this.headerMapper.fromHeaders(message.getHeaders(), headers);
 
-		pubsubFuture = this.pubSubTemplate.publish(topic, payload, headers);
+		pubsubFuture = this.pubSubPublisherOperations.publish(topic, payload, headers);
 
 		if (this.publishCallback != null) {
 			pubsubFuture.addCallback(this.publishCallback);

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -63,7 +63,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 	private HeaderMapper<Map<String, String>> headerMapper = new PubSubHeaderMapper();
 
-	public PubSubMessageHandler(PubSubOperations pubSubPublisherOperations, String topic) {
+	public PubSubMessageHandler(PubSubPublisherOperations pubSubPublisherOperations, String topic) {
 		Assert.notNull(pubSubPublisherOperations, "Pub/Sub publisher template cannot be null.");
 		Assert.notNull(topic, "Pub/Sub topic cannot be null.");
 		this.pubSubPublisherOperations = pubSubPublisherOperations;

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
+import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherOperations;
 import org.springframework.cloud.gcp.pubsub.integration.PubSubHeaderMapper;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.expression.EvaluationContext;
@@ -48,7 +49,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 
 	private static final long DEFAULT_PUBLISH_TIMEOUT = 10000;
 
-	private final PubSubOperations pubSubPublisherOperations;
+	private final PubSubPublisherOperations pubSubPublisherOperations;
 
 	private Expression topicExpression;
 


### PR DESCRIPTION
Updates GcpPubSubAutoConfiguration to create and use PubSubPublisherTemplate and PubSubSubscriberTemplate.

The Pub/Sub outbound channel adapter now uses PubSubPublisherTemplate rather than PubSubTemplate.

The Pub/Sub inbound channel adapter now uses PubSubSubscriberTemplate rather than PubSubTemplate.

Fixes #823.