### PR TITLE
Fixed parameter naming inconsistency

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -132,8 +132,8 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 	}
 
 	@Override
-	public Subscriber subscribe(String subscription, MessageReceiver messageHandler) {
-		return this.pubSubSubscriberTemplate.subscribe(subscription, messageHandler);
+	public Subscriber subscribe(String subscription, MessageReceiver messageReceiver) {
+		return this.pubSubSubscriberTemplate.subscribe(subscription, messageReceiver);
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -40,10 +40,10 @@ public interface PubSubSubscriberOperations {
 	 * Add a callback method to an existing subscription.
 	 * <p>The created {@link Subscriber} is returned so it can be stopped.
 	 * @param subscription the name of an existing subscription
-	 * @param messageHandler the callback method triggered when new messages arrive
+	 * @param messageReceiver the callback method triggered when new messages arrive
 	 * @return subscriber listening to new messages
 	 */
-	Subscriber subscribe(String subscription, MessageReceiver messageHandler);
+	Subscriber subscribe(String subscription, MessageReceiver messageReceiver);
 
 	/**
 	 * Pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
@@ -66,9 +66,9 @@ public class PubSubSubscriberTemplate implements PubSubSubscriberOperations {
 	}
 
 	@Override
-	public Subscriber subscribe(String subscription, MessageReceiver messageHandler) {
+	public Subscriber subscribe(String subscription, MessageReceiver messageReceiver) {
 		Subscriber subscriber =
-				this.subscriberFactory.createSubscriber(subscription, messageHandler);
+				this.subscriberFactory.createSubscriber(subscription, messageReceiver);
 		subscriber.startAsync();
 		return subscriber;
 	}


### PR DESCRIPTION
Fixed parameter naming inconsistency.

The parameter type is `MessageReceiver` so the parameter would be better named `messageReceiver`.