### PR TITLE
PubSubMessageConverter with generics

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/JacksonPubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/JacksonPubSubMessageConverter.java
@@ -65,7 +65,7 @@ public class JacksonPubSubMessageConverter implements PubSubMessageConverter {
 	}
 
 	@Override
-	public Object fromPubSubMessage(PubsubMessage message, Class<?> payloadType) {
+	public <T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType) {
 		try {
 			return this.objectMapper.readerFor(payloadType).readValue(message.getData().toByteArray());
 		}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/PubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/PubSubMessageConverter.java
@@ -42,5 +42,5 @@ public interface PubSubMessageConverter {
 	 * @param payloadType the desired type of the object
 	 * @return the object converted from the message's payload
 	 */
-	Object fromPubSubMessage(PubsubMessage message, Class<?> payloadType);
+	<T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType);
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverter.java
@@ -75,21 +75,21 @@ public class SimplePubSubMessageConverter implements PubSubMessageConverter {
 	}
 
 	@Override
-	public Object fromPubSubMessage(PubsubMessage message, Class<?> payloadType) {
-		Object result;
+	public <T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType) {
+		T result;
 		byte[] payload = message.getData().toByteArray();
 
 		if (payloadType == ByteString.class) {
-			result = message.getData();
+			result = (T) message.getData();
 		}
 		else if (payloadType == String.class) {
-			result = new String(payload, this.charset);
+			result = (T) new String(payload, this.charset);
 		}
 		else if (payloadType == ByteBuffer.class) {
-			result = ByteBuffer.wrap(payload);
+			result = (T) ByteBuffer.wrap(payload);
 		}
 		else if (payloadType == byte[].class) {
-			result = payload;
+			result = (T) payload;
 		}
 		else {
 			throw new PubSubMessageConversionException("Unable to convert Pub/Sub message to payload of type " +


### PR DESCRIPTION
Provides stricter generics for
PubSubMessageConverter.fromPubSubMessage().

Fixes #854.