### PR TITLE
Added new AckMode.AUTO_ACK

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -72,24 +72,32 @@ public PubSubInboundChannelAdapter messageChannelAdapter(
 }
 ----
 
-In the example, we first specify the `MessageChannel` where the adapter is going to write incoming
-messages to.
+In the example, we first specify the `MessageChannel` where the adapter is going to write incoming messages to.
 The `MessageChannel` implementation isn't important here.
-Depending on your use case, you might want to use a `MessageChannel` other than
-`PublishSubscribeChannel`.
+Depending on your use case, you might want to use a `MessageChannel` other than `PublishSubscribeChannel`.
 
 Then, we declare a `PubSubInboundChannelAdapter` bean.
-It requires the channel we just created and a `SubscriberFactory`, which creates `Subscriber`
-objects from the Google Cloud Java Client for Pub/Sub.
+It requires the channel we just created and a `SubscriberFactory`, which creates `Subscriber` objects from the Google Cloud Java Client for Pub/Sub.
 The Spring Boot starter for GCP Pub/Sub provides a configured `SubscriberFactory`.
 
-It is also possible to set the message acknowledgement mode on the adapter, which is automatic by
-default.
-On automatic acking, a message is acked with GCP Pub/Sub if the adapter sent it to the channel and
-no exceptions were thrown.
-If a `RuntimeException` is thrown while the message is processed, then the message is nacked.
-On manual acking, the adapter attaches an `AckReplyConsumer` object to the `Message` headers, which
-users can extract using the `GcpPubSubHeaders.ACKNOWLEDGEMENT` key and use to (n)ack a message.
+The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `AckMode.AUTO` being the default value;
+
+Automatic acking (`AckMode.AUTO`)
+
+A message is acked with GCP Pub/Sub if the adapter sent it to the channel and no exceptions were thrown.
+If a RuntimeException is thrown while the message is processed, then the mssage is nacked.
+
+Automatic acking OK (`AckMode.AUTO_ACK`)
+
+A message is acked with GCP Pub/Sub if the adapter sent it to the channel and no exceptions were thrown.
+If a `RuntimeException` is thrown while the message is processed, then the message is neither neither acked / nor nacked.
+
+This is useful when using the subscription's ack deadline timeout as a retry delivery backoff mechanism.
+
+Manually acking (`AckMode.MANUAL`)
+
+The adapter attaches an `AckReplyConsumer` object to the `Message` headers.
+Users can extract the `AckReplyConsumer` using the `GcpPubSubHeaders.ACKNOWLEDGEMENT` key and use it to (n)ack a message.
 
 [source,java]
 ----

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -85,12 +85,12 @@ The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `Ac
 Automatic acking (`AckMode.AUTO`)
 
 A message is acked with GCP Pub/Sub if the adapter sent it to the channel and no exceptions were thrown.
-If a RuntimeException is thrown while the message is processed, then the mssage is nacked.
+If a `RuntimeException` is thrown while the message is processed, then the message is nacked.
 
 Automatic acking OK (`AckMode.AUTO_ACK`)
 
 A message is acked with GCP Pub/Sub if the adapter sent it to the channel and no exceptions were thrown.
-If a `RuntimeException` is thrown while the message is processed, then the message is neither neither acked / nor nacked.
+If a `RuntimeException` is thrown while the message is processed, then the message is neither acked / nor nacked.
 
 This is useful when using the subscription's ack deadline timeout as a retry delivery backoff mechanism.
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/AckMode.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/AckMode.java
@@ -44,7 +44,6 @@ public enum AckMode {
 	 * sent to the channel and processed successfully.
 	 * <p>The framework does not immediately nack the message when the exception occurs,
 	 * and allows the eventual redelivery to take effect.
-	 *
 	 * @since 1.1
 	 */
 	AUTO_ACK

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/AckMode.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/AckMode.java
@@ -20,6 +20,7 @@ package org.springframework.cloud.gcp.pubsub.integration;
  * Determines acknowledgement policy for incoming messages from Google Cloud Pub/Sub.
  *
  * @author João André Martins
+ * @author Doug Hoard
  */
 public enum AckMode {
 
@@ -36,5 +37,16 @@ public enum AckMode {
 	 * <p>The framework nacks the {@link com.google.pubsub.v1.PubsubMessage} when an exception
 	 * occurs while processing the message.
 	 */
-	AUTO
+	AUTO,
+
+	/**
+	 * The framework acks the {@link com.google.pubsub.v1.PubsubMessage} after it is
+	 * sent to the channel and processed successfully.
+	 * <p>The framework does nothing (no ack / no nack) of the {@link com.google.pubsub.v1.PubsubMessage}
+	 * when an exception occurs while processing the message.
+	 *
+	 * @since 1.1
+	 */
+	AUTO_ACK
+
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/AckMode.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/AckMode.java
@@ -42,8 +42,8 @@ public enum AckMode {
 	/**
 	 * The framework acks the {@link com.google.pubsub.v1.PubsubMessage} after it is
 	 * sent to the channel and processed successfully.
-	 * <p>The framework does nothing (no ack / no nack) of the {@link com.google.pubsub.v1.PubsubMessage}
-	 * when an exception occurs while processing the message.
+	 * <p>The framework does not immediately nack the message when the exception occurs,
+	 * and allows the eventual redelivery to take effect.
 	 *
 	 * @since 1.1
 	 */

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  *
  * @author João André Martins
  * @author Mike Eltsufin
+ * @author Doug Hoard
  */
 public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 
@@ -159,7 +160,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 			throw new PubSubException("Sending Spring message failed.", re);
 		}
 
-		if (this.ackMode == AckMode.AUTO) {
+		if ((this.ackMode == AckMode.AUTO) || (this.ackMode == AckMode.AUTO_ACK)) {
 			consumer.ack();
 		}
 	}

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -16,28 +16,171 @@
 
 package org.springframework.cloud.gcp.pubsub.integration.inbound;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
-import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
+import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberOperations;
+import org.springframework.cloud.gcp.pubsub.integration.AckMode;
+import org.springframework.messaging.MessageChannel;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link PubSubInboundChannelAdapter} unit tests.
  *
  * @author João André Martins
+ * @author Doug Hoard
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PubSubInboundChannelAdapterTests {
 
-	@Mock
-	private PubSubTemplate pubSubTemplate;
+	public static final String ACK = "ACK";
+
+	public static final String NACK = "NACK";
+
+	private PubSubOperations pubSubOperations;
+
+	private PubSubSubscriberOperations pubSubSubscriberOperations;
+
+	private MessageChannel messageChannel;
+
+	private AtomicReference<String> returnValue;
+
+	private CountDownLatch countDownLatch;
+
+	private AckReplyConsumer ackReplyConsumer;
+
+	private TestAnswer testAnswer;
+
+	@Before
+	public void setUp() {
+		this.pubSubOperations = mock(PubSubOperations.class);
+		this.pubSubSubscriberOperations = mock(PubSubSubscriberOperations.class);
+		this.messageChannel = mock(MessageChannel.class);
+
+		when(this.messageChannel.send(any())).thenThrow(new RuntimeException("Forced exception sending message"));
+
+		this.returnValue = new AtomicReference<>();
+		this.countDownLatch = new CountDownLatch(1);
+
+		NackAnswer nackAnwser = new NackAnswer(this.returnValue);
+
+		this.ackReplyConsumer = mock(AckReplyConsumer.class);
+
+		doAnswer(nackAnwser).when(this.ackReplyConsumer).nack();
+
+		this.testAnswer = new TestAnswer(this.countDownLatch, this.ackReplyConsumer);
+	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testNonNullAckMode() {
 		PubSubInboundChannelAdapter adapter = new PubSubInboundChannelAdapter(
-				this.pubSubTemplate, "testSubscription");
+				this.pubSubOperations, "testSubscription");
+
 		adapter.setAckMode(null);
+	}
+
+	@Test
+	public void testAckModeAuto() throws Exception {
+		PubSubInboundChannelAdapter adapter = new PubSubInboundChannelAdapter(
+				this.pubSubSubscriberOperations, "testSubscription");
+
+		adapter.setAckMode(AckMode.AUTO);
+
+		when(this.pubSubSubscriberOperations.subscribe(anyString(), any(MessageReceiver.class))).then(this.testAnswer);
+
+		adapter.setOutputChannel(this.messageChannel);
+
+		try {
+			adapter.start();
+		}
+		catch (Throwable t) {
+
+		}
+
+		Assert.assertTrue(this.countDownLatch.await(10, TimeUnit.SECONDS));
+		Assert.assertEquals(NACK, this.returnValue.get());
+	}
+
+	@Test
+	public void testAckModeAutoAck() throws Exception {
+		PubSubInboundChannelAdapter adapter = new PubSubInboundChannelAdapter(
+				this.pubSubSubscriberOperations, "testSubscription");
+
+		adapter.setAckMode(AckMode.AUTO_ACK);
+
+		when(this.pubSubSubscriberOperations.subscribe(anyString(), any(MessageReceiver.class))).then(this.testAnswer);
+
+		adapter.setOutputChannel(this.messageChannel);
+
+		try {
+			adapter.start();
+		}
+		catch (Throwable t) {
+
+		}
+
+		Assert.assertTrue(this.countDownLatch.await(10, TimeUnit.SECONDS));
+		Assert.assertNull(this.returnValue.get());
+	}
+
+	private class TestAnswer implements Answer<MessageReceiver> {
+
+		private CountDownLatch countDownLatch;
+
+		private AckReplyConsumer ackReplyConsumer;
+
+		TestAnswer(CountDownLatch countDownLatch, AckReplyConsumer ackReplyConsumer) {
+			this.countDownLatch = countDownLatch;
+			this.ackReplyConsumer = ackReplyConsumer;
+		}
+
+		public MessageReceiver answer(InvocationOnMock invocation) throws Throwable {
+			try {
+				PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(
+						ByteString.copyFrom("Testing 1 2 3".getBytes("UTF-8"))).build();
+
+				MessageReceiver messageReceiver = invocation.getArgument(1);
+				messageReceiver.receiveMessage(pubsubMessage, this.ackReplyConsumer);
+			}
+			finally {
+				this.countDownLatch.countDown();
+			}
+
+			return null;
+		}
+	}
+
+	private class NackAnswer implements Answer<Boolean> {
+
+		private AtomicReference<String> returnValue;
+
+		NackAnswer(AtomicReference<String> returnValue) {
+			this.returnValue = returnValue;
+		}
+
+		public Boolean answer(InvocationOnMock invocationOnMock) throws Throwable {
+			this.returnValue.set(NACK);
+
+			return null;
+		}
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
  * @author João André Martins
  * @author Doug Hoard
  */
-@RunWith(MockitoJUnitRunner.Silent.class)
+@RunWith(MockitoJUnitRunner.class)
 public class PubSubInboundChannelAdapterTests {
 
 	public static final String ACK = "ACK";


### PR DESCRIPTION
Added new AckMode.AUTO_ACK and implemented changes in
PubSubInboundChannelAdapter to process the new value.

AckMode.AUTO_ACK adds a new use case to PubSubInboundChannelAdapter in
which a message is only ack'ed if successfully processed. If an
exception occurs processing the message, the message will not be
nack'ed ... resulting in a re-delivery delay by Google Pub / Sub.

Closes #850.