### PR TITLE
Changed autoconfigured PubSubMessageConverter type

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -21,7 +21,6 @@ import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.core.ApiClock;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
@@ -44,7 +43,6 @@ import org.threeten.bp.Duration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -62,8 +60,8 @@ import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
-import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessageConverter;
 import org.springframework.cloud.gcp.pubsub.support.converter.PubSubMessageConverter;
+import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -344,14 +342,10 @@ public class GcpPubSubAutoConfiguration {
 		return InstantiatingGrpcChannelProvider.newBuilder().build();
 	}
 
-	@Configuration
-	@ConditionalOnBean(ObjectMapper.class)
-	static class JacksonPubSubMessageConverterAutoConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean
-		public PubSubMessageConverter pubSubMessageConverter(ObjectMapper objectMapper) {
-			return new JacksonPubSubMessageConverter(objectMapper);
-		}
+	@Bean
+	@ConditionalOnMissingBean
+	public PubSubMessageConverter pubSubMessageConverter() {
+		return new SimplePubSubMessageConverter();
 	}
+
 }


### PR DESCRIPTION
Changed auto-configured `PubSubMessageConverter` type to
`SimplePubSubMessageConverter` to prevent a `JacksonPubSubMessageConverter`
from being used simply because Jackson was included in the project
dependencies.

There are various use cases where Jackson may be included, yet JSON is
not used.  For example, If the project uses an `XmlMapper` (a subclass of `ObjectMapper`) to serialize / de-serialize XML, the auto-configure code would infer that the developer wants a `JacksonPubSubMessageConverter` configured ... even though the usage of the `XmlMapper` may be completely unrelated to any Pub / Sub functionality.

Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/865