### PR TITLE
Stop auto-configuring JacksonPubSubMessageConverter

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -21,7 +21,6 @@ import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.core.ApiClock;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
@@ -44,7 +43,6 @@ import org.threeten.bp.Duration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -62,7 +60,6 @@ import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
-import org.springframework.cloud.gcp.pubsub.support.converter.JacksonPubSubMessageConverter;
 import org.springframework.cloud.gcp.pubsub.support.converter.PubSubMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -344,14 +341,4 @@ public class GcpPubSubAutoConfiguration {
 		return InstantiatingGrpcChannelProvider.newBuilder().build();
 	}
 
-	@Configuration
-	@ConditionalOnBean(ObjectMapper.class)
-	static class JacksonPubSubMessageConverterAutoConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean
-		public PubSubMessageConverter pubSubMessageConverter(ObjectMapper objectMapper) {
-			return new JacksonPubSubMessageConverter(objectMapper);
-		}
-	}
 }

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -61,8 +61,6 @@ public void publishMessage() {
 By default, the `SimplePubSubMessageConverter` is used to convert payloads of type `byte[]`, `ByteString`, `ByteBuffer`, and `String` to Pub/Sub messages.
 
 For serialization and deserialization of POJOs using Jackson JSON, configure the `PubSubTemplate` to use the `JacksonPubSubMessageConverter` by calling the `setMessageConverter()` method.
-Alternatively, if you're using the starter and have an instance of the Jackson `ObjectMapper` in the application context, the `JacksonPubSubMessageConverter` will be automatically configured for you.
-
 
 ==== Subscribing to a subscription
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/main/java/com/example/ReceiverApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/main/java/com/example/ReceiverApplication.java
@@ -27,7 +27,6 @@ import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.integration.AckMode;
 import org.springframework.cloud.gcp.pubsub.integration.inbound.PubSubInboundChannelAdapter;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
-import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
@@ -46,11 +45,6 @@ public class ReceiverApplication {
 	@Bean
 	public MessageChannel pubsubInputChannel() {
 		return new DirectChannel();
-	}
-
-	@Bean
-	public SimplePubSubMessageConverter getConverter() {
-		return new SimplePubSubMessageConverter();
 	}
 
 	@Bean

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/test/java/com/example/SenderIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/test/java/com/example/SenderIntegrationTest.java
@@ -79,7 +79,7 @@ public class SenderIntegrationTest {
 			messages.forEach(AcknowledgeablePubsubMessage::ack);
 
 			if (messages.stream()
-					.anyMatch(m -> m.getMessage().getData().toStringUtf8().equals("\"" + message + "\""))) {
+					.anyMatch(m -> m.getMessage().getData().toStringUtf8().equals(message))) {
 				messageReceived = true;
 				break;
 			}


### PR DESCRIPTION
Auto-configuring JacksonPubSubMessage converter based on the
presence of ObjectMappber bean in the application context
has turned out to be too magical and surprising.

This PR ensures that by default only the SimplePubSubMessageConverter
will be used.

Fixes #865, #863.

Supersedes #867 and #871.