### PR TITLE
Remove SubscriberFactory.createAcknowledger

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
@@ -27,6 +27,7 @@ import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
 
 import org.springframework.cloud.gcp.pubsub.support.AcknowledgeablePubsubMessage;
+import org.springframework.cloud.gcp.pubsub.support.DefaultPubSubAcknowledger;
 import org.springframework.cloud.gcp.pubsub.support.PubSubAcknowledger;
 import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.util.Assert;
@@ -63,7 +64,7 @@ public class PubSubSubscriberTemplate implements PubSubSubscriberOperations {
 
 		this.subscriberFactory = subscriberFactory;
 		this.subscriberStub = this.subscriberFactory.createSubscriberStub();
-		this.acknowledger = this.subscriberFactory.createAcknowledger();
+		this.acknowledger = new DefaultPubSubAcknowledger(this.subscriberFactory.createSubscriberStub());
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPubSubAcknowledger.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPubSubAcknowledger.java
@@ -28,11 +28,11 @@ import com.google.pubsub.v1.ModifyAckDeadlineRequest;
  *
  * @author João André Martins
  */
-class DefaultPubSubAcknowledger implements PubSubAcknowledger {
+public class DefaultPubSubAcknowledger implements PubSubAcknowledger {
 
 	private SubscriberStub subscriberStub;
 
-	DefaultPubSubAcknowledger(SubscriberStub subscriberStub) {
+	public DefaultPubSubAcknowledger(SubscriberStub subscriberStub) {
 		this.subscriberStub = subscriberStub;
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/SubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/SubscriberFactory.java
@@ -58,11 +58,4 @@ public interface SubscriberFactory {
 	 */
 	SubscriberStub createSubscriberStub();
 
-	/**
-	 * Create a {@link PubSubAcknowledger} to (negatively) acknowledge messages in bulk.
-	 */
-	default PubSubAcknowledger createAcknowledger() {
-		return new DefaultPubSubAcknowledger(createSubscriberStub());
-	}
-
 }


### PR DESCRIPTION
Currently this default method is just a passthrough,
and the acknowledger can be easily created in the subscriber template.

See [discussion](https://github.com/spring-cloud/spring-cloud-gcp/pull/859#discussion_r203773939).