### PR TITLE
Spanner admin template method checking interleaved tables

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplate.java
@@ -155,6 +155,28 @@ public class SpannerDatabaseAdminTemplate {
 	}
 
 	/**
+	 * Return true if the given table names are interleaved as ancestor and descendant.
+	 * These may be separated by more than one generation.
+	 * @param ancestor the name of the ancestor table
+	 * @param descendant the name of the descendant table. this may be a direct child or
+	 * further down in the family tree.
+	 * @return true the descendant is indeed a descendant table. false otherwise.
+	 */
+	public boolean isInterleaved(String ancestor, String descendant) {
+		Assert.notNull(ancestor, "A non-null ancestor table name is required.");
+		Set<String> directChildren = getParentChildTablesMap().get(ancestor);
+		if (ancestor.equals(descendant) || directChildren == null) {
+			return false;
+		}
+		for (String child : directChildren) {
+			if (child.equals(descendant) || isInterleaved(child, descendant)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Return a map of parent and child table relationships in the database at the
 	 * moment.
 	 * @return A map where the keys are parent table names, and the value is a set of that

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
@@ -31,11 +31,10 @@ import com.google.cloud.spanner.Value;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -91,15 +90,19 @@ public class SpannerDatabaseAdminTemplateTests {
 		assertThat(relationships.get("grandpa"),
 				containsInAnyOrder("parent_a", "parent_b"));
 		assertThat(relationships.get("parent_a"), containsInAnyOrder("child"));
-		assertTrue(this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "child"));
-		assertTrue(
-				this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "parent_a"));
-		assertTrue(this.spannerDatabaseAdminTemplate.isInterleaved("parent_a", "child"));
-		assertTrue(
-				this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "parent_b"));
-		assertFalse(
-				this.spannerDatabaseAdminTemplate.isInterleaved("parent_a", "parent_b"));
-		assertFalse(this.spannerDatabaseAdminTemplate.isInterleaved("parent_b", "child"));
+
+		assertThat(this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "child"))
+				.as("verify grand-child relationship").isTrue();
+		assertThat(this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "parent_a"))
+				.as("verify parent-child relationship").isTrue();
+		assertThat(this.spannerDatabaseAdminTemplate.isInterleaved("parent_a", "child"))
+				.as("verify parent-child relationship").isTrue();
+		assertThat(this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "parent_b"))
+				.as("verify parent-child relationship").isTrue();
+		assertThat(this.spannerDatabaseAdminTemplate.isInterleaved("parent_a", "parent_b"))
+				.as("verify not parent-child relationship").isFalse();
+		assertThat(this.spannerDatabaseAdminTemplate.isInterleaved("parent_b", "child"))
+				.as("verify not parent-child relationship").isFalse();
 	}
 
 	private static class MockResults {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
@@ -112,7 +112,7 @@ public class SpannerDatabaseAdminTemplateTests {
 				this.counter++;
 				return true;
 			}
-			counter = -1;
+			this.counter = -1;
 			return false;
 		}
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
@@ -33,7 +33,9 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -61,7 +63,7 @@ public class SpannerDatabaseAdminTemplateTests {
 	}
 
 	@Test
-	public void getParentChildTablesMapTest() {
+	public void getTableRelationshipsTest() {
 		ReadContext readContext = mock(ReadContext.class);
 
 		Struct s1 = Struct.newBuilder().set("table_name").to(Value.string("grandpa"))
@@ -89,6 +91,15 @@ public class SpannerDatabaseAdminTemplateTests {
 		assertThat(relationships.get("grandpa"),
 				containsInAnyOrder("parent_a", "parent_b"));
 		assertThat(relationships.get("parent_a"), containsInAnyOrder("child"));
+		assertTrue(this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "child"));
+		assertTrue(
+				this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "parent_a"));
+		assertTrue(this.spannerDatabaseAdminTemplate.isInterleaved("parent_a", "child"));
+		assertTrue(
+				this.spannerDatabaseAdminTemplate.isInterleaved("grandpa", "parent_b"));
+		assertFalse(
+				this.spannerDatabaseAdminTemplate.isInterleaved("parent_a", "parent_b"));
+		assertFalse(this.spannerDatabaseAdminTemplate.isInterleaved("parent_b", "child"));
 	}
 
 	private static class MockResults {
@@ -101,6 +112,7 @@ public class SpannerDatabaseAdminTemplateTests {
 				this.counter++;
 				return true;
 			}
+			counter = -1;
 			return false;
 		}
 


### PR DESCRIPTION
related to #853

This is a method for checking if two tables are related. This is the first step mentioned in the related issue. 