### PR TITLE
Spanner allow missing columns in STRUCTs

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReader.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReader.java
@@ -77,7 +77,7 @@ class ConverterAwareMappingSpannerEntityReader implements SpannerEntityReader {
 		StructPropertyValueProvider propertyValueProvider = new StructPropertyValueProvider(
 				structAccessor,
 				this.converter,
-				this, includeColumns, allowMissingColumns);
+				this, allowMissingColumns);
 
 		PreferredConstructor<?, SpannerPersistentProperty> persistenceConstructor = persistentEntity
 				.getPersistenceConstructor();

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReader.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReader.java
@@ -77,7 +77,7 @@ class ConverterAwareMappingSpannerEntityReader implements SpannerEntityReader {
 		StructPropertyValueProvider propertyValueProvider = new StructPropertyValueProvider(
 				structAccessor,
 				this.converter,
-				this);
+				this, includeColumns, allowMissingColumns);
 
 		PreferredConstructor<?, SpannerPersistentProperty> persistenceConstructor = persistentEntity
 				.getPersistenceConstructor();

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructPropertyValueProvider.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.gcp.data.spanner.core.convert;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import com.google.cloud.spanner.Struct;
 
@@ -44,21 +43,18 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
 
 	private StructAccessor structAccessor;
 
-	private Set<String> includeColumns;
-
 	private boolean allowMissingColumns;
 
 	StructPropertyValueProvider(StructAccessor structAccessor, SpannerCustomConverter readConverter,
 			SpannerEntityReader entityReader) {
-		this(structAccessor, readConverter, entityReader, null, false);
+		this(structAccessor, readConverter, entityReader, false);
 	}
 
 	StructPropertyValueProvider(StructAccessor structAccessor, SpannerCustomConverter readConverter,
-			SpannerEntityReader entityReader, Set<String> includeColumns, boolean allowMissingColumns) {
+			SpannerEntityReader entityReader, boolean allowMissingColumns) {
 		this.structAccessor = structAccessor;
 		this.readConverter = readConverter;
 		this.entityReader = entityReader;
-		this.includeColumns = includeColumns;
 		this.allowMissingColumns = allowMissingColumns;
 	}
 
@@ -96,7 +92,7 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
 		Class<?> sourceClass = sourceValue.getClass();
 		return Struct.class.isAssignableFrom(sourceClass)
 				&& !this.readConverter.canConvert(sourceClass, targetType)
-						? this.entityReader.read(targetType, (Struct) sourceValue, this.includeColumns,
+						? this.entityReader.read(targetType, (Struct) sourceValue, null,
 								this.allowMissingColumns)
 				: this.readConverter.convert(sourceValue, targetType);
 	}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructPropertyValueProvider.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.data.spanner.core.convert;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.google.cloud.spanner.Struct;
 
@@ -43,11 +44,22 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
 
 	private StructAccessor structAccessor;
 
+	private Set<String> includeColumns;
+
+	private boolean allowMissingColumns;
+
 	StructPropertyValueProvider(StructAccessor structAccessor, SpannerCustomConverter readConverter,
 			SpannerEntityReader entityReader) {
+		this(structAccessor, readConverter, entityReader, null, false);
+	}
+
+	StructPropertyValueProvider(StructAccessor structAccessor, SpannerCustomConverter readConverter,
+			SpannerEntityReader entityReader, Set<String> includeColumns, boolean allowMissingColumns) {
 		this.structAccessor = structAccessor;
 		this.readConverter = readConverter;
 		this.entityReader = entityReader;
+		this.includeColumns = includeColumns;
+		this.allowMissingColumns = allowMissingColumns;
 	}
 
 	@Override
@@ -84,7 +96,8 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
 		Class<?> sourceClass = sourceValue.getClass();
 		return Struct.class.isAssignableFrom(sourceClass)
 				&& !this.readConverter.canConvert(sourceClass, targetType)
-				? this.entityReader.read(targetType, (Struct) sourceValue)
+						? this.entityReader.read(targetType, (Struct) sourceValue, this.includeColumns,
+								this.allowMissingColumns)
 				: this.readConverter.convert(sourceValue, targetType);
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructPropertyValueProvider.java
@@ -45,11 +45,28 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
 
 	private boolean allowMissingColumns;
 
+	/**
+	 * Constructor. Missing columns in nested struct column values for corresponding nested Java
+	 * object properties is not allowed.
+	 * @param structAccessor an accessor used to obtain column values from the struct.
+	 * @param readConverter a converter used to convert between struct column types and the required
+	 * java types.
+	 * @param entityReader a reader used to access the data from each column of the struct.
+	 */
 	StructPropertyValueProvider(StructAccessor structAccessor, SpannerCustomConverter readConverter,
 			SpannerEntityReader entityReader) {
 		this(structAccessor, readConverter, entityReader, false);
 	}
 
+	/**
+	 * Constructor
+	 * @param structAccessor an accessor used to obtain column values from the struct.
+	 * @param readConverter a converter used to convert between struct column types and the required
+	 * java types.
+	 * @param entityReader a reader used to access the data from each column of the struct.
+	 * @param allowMissingColumns if a nested struct is within this struct's column, then if true
+	 * missing columns in the nested struct are also allowed for the corresponding nested Java object.
+	 */
 	StructPropertyValueProvider(StructAccessor structAccessor, SpannerCustomConverter readConverter,
 			SpannerEntityReader entityReader, boolean allowMissingColumns) {
 		this.structAccessor = structAccessor;

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
@@ -44,6 +44,7 @@ import org.springframework.lang.Nullable;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -78,10 +79,11 @@ public class ConverterAwareMappingSpannerEntityReaderTests {
 				.build();
 
 		OuterTestEntity result = this.spannerEntityReader.read(OuterTestEntity.class,
-				outerStruct);
+				outerStruct, null, true);
 		assertEquals("key1", result.id);
 		assertEquals(1, result.innerTestEntities.size());
 		assertEquals("inner-value", result.innerTestEntities.get(0).value);
+		assertNull(result.innerTestEntities.get(0).missingColumnValue);
 	}
 
 	@Test
@@ -225,7 +227,7 @@ public class ConverterAwareMappingSpannerEntityReaderTests {
 				.build();
 
 		TestEntities.OuterTestEntityWithConstructor result = this.spannerEntityReader
-				.read(TestEntities.OuterTestEntityWithConstructor.class, outerStruct);
+				.read(TestEntities.OuterTestEntityWithConstructor.class, outerStruct, null, true);
 		assertEquals("key1", result.id);
 		assertEquals(1, result.innerTestEntities.size());
 		assertEquals("value", result.innerTestEntities.get(0).value);

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
@@ -154,6 +154,8 @@ public class TestEntities {
 	static class InnerTestEntity {
 		@PrimaryKey
 		String value;
+
+		String missingColumnValue;
 	}
 
 	static class SimpleConstructorTester {

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spanner.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spanner.adoc
@@ -640,6 +640,7 @@ Sort.by(Order.desc("action").ignoreCase())
 ===== Partial read
 
 Partial read is only possible when using Queries. In case the rows returned by query have fewer columns than the entity that it will be mapped to, Spring Data will map the returned columns and leave the rest as they of the columns are.
+This setting also applies to nested structs and their corresponding nested POJO properties.
 
 [source,java]
 ----

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spanner.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spanner.adoc
@@ -639,7 +639,7 @@ Sort.by(Order.desc("action").ignoreCase())
 
 ===== Partial read
 
-Partial read is only possible when using Queries. In case the rows returned by query have fewer columns than the entity that it will be mapped to, Spring Data will map the returned columns and leave the rest as they of the columns are.
+Partial read is only possible when using Queries. In case the rows returned by the query have fewer columns than the entity that it will be mapped to, Spring Data will map the returned columns only.
 This setting also applies to nested structs and their corresponding nested POJO properties.
 
 [source,java]
@@ -648,6 +648,7 @@ List<Trade> trades = this.spannerTemplate.query(Trade.class, Statement.of("SELEC
     new SpannerQueryOptions().setAllowMissingResultSetColumns(true));
 ----
 
+If the setting is set to `false`, then an exception will be thrown if there are missing columns in the query result.
 
 ===== Summary of options for Query vs Read
 


### PR DESCRIPTION
fixes #894

This passes down the allow-missing-column setting so that nested STRUCTs can also allow missing parts.