### PR TITLE
Spanner Simple Repo constructor public

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SimpleSpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SimpleSpannerRepository.java
@@ -43,7 +43,7 @@ public class SimpleSpannerRepository<T, ID> implements SpannerRepository<T, ID> 
 
 	private final Class<T> entityType;
 
-	SimpleSpannerRepository(SpannerTemplate spannerTemplate, Class<T> entityType) {
+	public SimpleSpannerRepository(SpannerTemplate spannerTemplate, Class<T> entityType) {
 		Assert.notNull(spannerTemplate, "A valid SpannerTemplate object is required.");
 		Assert.notNull(entityType, "A valid entity type is required.");
 		this.spannerTemplate = spannerTemplate;


### PR DESCRIPTION
Based on customer feedback, to provide more flexibility.

For comparison, the JDBC Simple Repo implementation also does not have a private package private constructor https://github.com/spring-projects/spring-data-jdbc/blob/master/src/main/java/org/springframework/data/jdbc/repository/support/SimpleJdbcRepository.java