### PR TITLE
Make SQL auto-config conditional on jdbc-socket-factory-core

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
@@ -55,9 +55,10 @@ import org.springframework.util.StringUtils;
  *
  * @author João André Martins
  * @author Artem Bilan
+ * @author Mike Eltsufin
  */
 @Configuration
-@ConditionalOnClass({ DataSource.class, EmbeddedDatabaseType.class })
+@ConditionalOnClass({ DataSource.class, EmbeddedDatabaseType.class, CredentialFactory.class })
 @ConditionalOnProperty(
 		name = "spring.cloud.gcp.sql.enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties({ GcpCloudSqlProperties.class, DataSourceProperties.class })


### PR DESCRIPTION
This disables the whole `GcpCloudSqlAutoConfiguration` class
if neither `com.google.cloud.sql:postgres-socket-factory` nor
`com.google.cloud.sql:jdbc-socket-factory-core` is present.

Fixes #914.