### PR TITLE
Datastore autoconfig

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -122,6 +122,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Datastore -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-data-datastore</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Spanner -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/DatastoreRepositoriesAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/DatastoreRepositoriesAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.gcp.autoconfigure.spanner.SpannerRepositoriesAutoConfigureRegistrar;
+import org.springframework.cloud.gcp.data.datastore.repository.DatastoreRepository;
+import org.springframework.cloud.gcp.data.datastore.repository.config.DatastoreRepositoryConfigurationExtension;
+import org.springframework.cloud.gcp.data.datastore.repository.support.DatastoreRepositoryFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Enables autoconfiguration for
+ * {@link org.springframework.cloud.gcp.data.datastore.repository.config.EnableDatastoreRepositories}.
+ *
+ * @author Chengyuan Zhao
+ *
+ * @since 1.1
+ */
+@Configuration
+@ConditionalOnClass(DatastoreRepository.class)
+@ConditionalOnMissingBean({ DatastoreRepositoryFactory.class,
+		DatastoreRepositoryConfigurationExtension.class })
+@ConditionalOnProperty(value = "spring.cloud.gcp.datastore.enabled", matchIfMissing = true)
+@Import({ SpannerRepositoriesAutoConfigureRegistrar.class })
+@AutoConfigureBefore(GcpDatastoreAutoConfiguration.class)
+public class DatastoreRepositoriesAutoConfiguration {
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/DatastoreRepositoriesAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/DatastoreRepositoriesAutoConfiguration.java
@@ -20,7 +20,6 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.gcp.autoconfigure.spanner.SpannerRepositoriesAutoConfigureRegistrar;
 import org.springframework.cloud.gcp.data.datastore.repository.DatastoreRepository;
 import org.springframework.cloud.gcp.data.datastore.repository.config.DatastoreRepositoryConfigurationExtension;
 import org.springframework.cloud.gcp.data.datastore.repository.support.DatastoreRepositoryFactory;
@@ -40,7 +39,7 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnMissingBean({ DatastoreRepositoryFactory.class,
 		DatastoreRepositoryConfigurationExtension.class })
 @ConditionalOnProperty(value = "spring.cloud.gcp.datastore.enabled", matchIfMissing = true)
-@Import({ SpannerRepositoriesAutoConfigureRegistrar.class })
+@Import({ DatastoreRepositoriesAutoConfigureRegistrar.class })
 @AutoConfigureBefore(GcpDatastoreAutoConfiguration.class)
 public class DatastoreRepositoriesAutoConfiguration {
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/DatastoreRepositoriesAutoConfigureRegistrar.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/DatastoreRepositoriesAutoConfigureRegistrar.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gcp.autoconfigure.datastore;
 import java.lang.annotation.Annotation;
 
 import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurationSourceSupport;
+import org.springframework.cloud.gcp.data.datastore.repository.config.DatastoreRepositoryConfigurationExtension;
 import org.springframework.cloud.gcp.data.datastore.repository.config.EnableDatastoreRepositories;
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 
@@ -44,7 +45,7 @@ public class DatastoreRepositoriesAutoConfigureRegistrar
 
 	@Override
 	protected RepositoryConfigurationExtension getRepositoryConfigurationExtension() {
-		return new DatastoreRepositoriesAutoConfigureRegistrar().getRepositoryConfigurationExtension();
+		return new DatastoreRepositoryConfigurationExtension();
 	}
 
 	@EnableDatastoreRepositories

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/DatastoreRepositoriesAutoConfigureRegistrar.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/DatastoreRepositoriesAutoConfigureRegistrar.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurationSourceSupport;
+import org.springframework.cloud.gcp.data.datastore.repository.config.EnableDatastoreRepositories;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+
+/**
+ * Used to auto-configure Spring Data Cloud Datastore Repositories.
+ *
+ * @author Chengyuan Zhao
+ *
+ * @since 1.1
+ */
+public class DatastoreRepositoriesAutoConfigureRegistrar
+		extends AbstractRepositoryConfigurationSourceSupport {
+
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableDatastoreRepositories.class;
+	}
+
+	@Override
+	protected Class<?> getConfiguration() {
+		return DatastoreRepositoriesAutoConfigureRegistrar.EnableDatastoreRepositoriesConfiguration.class;
+	}
+
+	@Override
+	protected RepositoryConfigurationExtension getRepositoryConfigurationExtension() {
+		return new DatastoreRepositoriesAutoConfigureRegistrar().getRepositoryConfigurationExtension();
+	}
+
+	@EnableDatastoreRepositories
+	private static class EnableDatastoreRepositoriesConfiguration {
+
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+import java.io.IOException;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
+import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
+import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.data.datastore.core.DatastoreOperations;
+import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
+import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreEntityConverter;
+import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreEntityConverterImpl;
+import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreServiceObjectToKeyFactory;
+import org.springframework.cloud.gcp.data.datastore.core.convert.ObjectToKeyFactory;
+import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides Spring Data classes to use with Cloud Datastore.
+ *
+ * @author Chengyuan Zhao
+ *
+ * @since 1.1
+ */
+@Configuration
+@AutoConfigureAfter(GcpContextAutoConfiguration.class)
+@ConditionalOnProperty(value = "spring.cloud.gcp.datastore.enabled", matchIfMissing = true)
+@ConditionalOnClass({ DatastoreMappingContext.class, DatastoreOperations.class })
+@EnableConfigurationProperties(GcpDatastoreProperties.class)
+public class GcpDatastoreAutoConfiguration {
+
+	private final String projectId;
+
+	private final String namespace;
+
+	private final Credentials credentials;
+
+	GcpDatastoreAutoConfiguration(GcpDatastoreProperties gcpDatastoreProperties,
+			GcpProjectIdProvider projectIdProvider,
+			CredentialsProvider credentialsProvider) throws IOException {
+		this.credentials = (gcpDatastoreProperties.getCredentials().hasKey()
+				? new DefaultCredentialsProvider(gcpDatastoreProperties)
+				: credentialsProvider).getCredentials();
+		this.projectId = gcpDatastoreProperties.getProjectId() != null
+				? gcpDatastoreProperties.getProjectId()
+				: projectIdProvider.getProjectId();
+		this.namespace = gcpDatastoreProperties.getNamespace();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Datastore datastore() {
+		DatastoreOptions.Builder builder = DatastoreOptions.newBuilder()
+				.setProjectId(this.projectId)
+				.setHeaderProvider(new UsageTrackingHeaderProvider(this.getClass()))
+				.setCredentials(this.credentials);
+		if (this.namespace != null) {
+			builder.setNamespace(this.namespace);
+		}
+		return builder.build().getService();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public DatastoreMappingContext datastoreMappingContext() {
+		return new DatastoreMappingContext();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public DatastoreEntityConverter datastoreEntityConverter(DatastoreMappingContext datastoreMappingContext) {
+		return new DatastoreEntityConverterImpl(datastoreMappingContext);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ObjectToKeyFactory objectToKeyFactory(Datastore datastore) {
+		return new DatastoreServiceObjectToKeyFactory(datastore);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public DatastoreTemplate datastoreTemplate(Datastore datastore, DatastoreMappingContext datastoreMappingContext,
+			DatastoreEntityConverter datastoreEntityConverter, ObjectToKeyFactory objectToKeyFactory) {
+		return new DatastoreTemplate(datastore, datastoreEntityConverter, datastoreMappingContext, objectToKeyFactory);
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreProperties.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.cloud.gcp.core.Credentials;
+import org.springframework.cloud.gcp.core.CredentialsSupplier;
+import org.springframework.cloud.gcp.core.GcpScope;
+
+/**
+ * Properties for configuring Cloud Datastore.
+ *
+ * @author Chengyuan Zhao
+ *
+ * @since 1.1
+ */
+@ConfigurationProperties("spring.cloud.gcp.datastore")
+public class GcpDatastoreProperties implements CredentialsSupplier {
+
+	/** Overrides the GCP OAuth2 credentials specified in the Core module. */
+	@NestedConfigurationProperty
+	private final Credentials credentials = new Credentials(GcpScope.DATASTORE.getUrl());
+
+	private String projectId;
+
+	private String namespace;
+
+	@Override
+	public Credentials getCredentials() {
+		return this.credentials;
+	}
+
+	public String getProjectId() {
+		return this.projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	public String getNamespace() {
+		return this.namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.cloud.gcp.data.datastore.core.DatastoreOperations;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Chengyuan Zhao
+ */
+public class GcpDatastoreAutoConfigurationTests {
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(GcpDatastoreAutoConfiguration.class,
+					GcpContextAutoConfiguration.class,
+					DatastoreRepositoriesAutoConfiguration.class))
+			.withUserConfiguration(TestConfiguration.class)
+			.withPropertyValues("spring.cloud.gcp.datastore.project-id=test-project",
+					"spring.cloud.gcp.datastore.namespace-id=testNamespace");
+
+	@Test
+	public void testDatastoreOperationsCreated() {
+		this.contextRunner.run(context -> assertThat(context.getBean(DatastoreOperations.class)).isNotNull());
+	}
+
+	@Test
+	public void testTestRepositoryCreated() {
+		this.contextRunner.run(context -> assertThat(context.getBean(TestRepository.class)).isNotNull());
+	}
+
+	@AutoConfigurationPackage
+	static class TestConfiguration {
+
+		@Bean
+		public CredentialsProvider credentialsProvider() {
+			return () -> mock(Credentials.class);
+		}
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/TestRepository.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/TestRepository.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+import org.springframework.cloud.gcp.data.datastore.repository.DatastoreRepository;
+
+/**
+ * @author Chengyuan Zhao
+ */
+public interface TestRepository extends DatastoreRepository {
+}

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
@@ -25,6 +25,7 @@ public enum GcpScope {
 	PUBSUB("https://www.googleapis.com/auth/pubsub"),
 	SPANNER_ADMIN("https://www.googleapis.com/auth/spanner.admin"),
 	SPANNER_DATA("https://www.googleapis.com/auth/spanner.data"),
+	DATASTORE("https://www.googleapis.com/auth/datastore"),
 	SQLADMIN("https://www.googleapis.com/auth/sqlservice.admin"),
 	STORAGE_READ_ONLY("https://www.googleapis.com/auth/devstorage.read_only"),
 	STORAGE_READ_WRITE("https://www.googleapis.com/auth/devstorage.read_write"),

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreEntityConverterImpl.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreEntityConverterImpl.java
@@ -78,7 +78,7 @@ public class DatastoreEntityConverterImpl implements DatastoreEntityConverter {
 		valFactories = builder.build();
 	}
 
-	DatastoreEntityConverterImpl(DatastoreMappingContext mappingContext) {
+	public DatastoreEntityConverterImpl(DatastoreMappingContext mappingContext) {
 		this.mappingContext = mappingContext;
 	}
 

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -40,6 +40,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-gcp-data-datastore</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-gcp-data-spanner</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
fixes #677 

exposes the most fundamental settings Project Id and Namespace. there are more advanced settings like retry settings and such that can be added later.

includes unit test that uses Spring to create an instance of a TestRepository that extends DatastoreRepository, which tests the repository factory and config classes from previous PR.