### PR TITLE
Rename .getMessage() to .getPubsubMessage

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
@@ -141,14 +141,14 @@ public class PubSubTemplateIntegrationTests {
 				List<AcknowledgeablePubsubMessage> newMessages = pubSubTemplate.pull(subscriptionName, 4, false);
 				ackableMessages.addAll(newMessages);
 				messagesSet.addAll(newMessages.stream()
-						.map(message -> message.getMessage().getData().toStringUtf8())
+						.map(message -> message.getPubsubMessage().getData().toStringUtf8())
 						.collect(Collectors.toList()));
 			}
 
 			assertThat(messagesSet.size()).as("check that we received all the messages").isEqualTo(3);
 
 			ackableMessages.forEach(message -> {
-				if (message.getMessage().getData().toStringUtf8().equals("message1")) {
+				if (message.getPubsubMessage().getData().toStringUtf8().equals("message1")) {
 					message.ack(); //sync call
 				}
 				else {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -187,7 +187,7 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 				.map(AcknowledgeablePubsubMessage::getAckId)
 				.collect(Collectors.toList()), pullRequest.getSubscription());
 
-		return ackableMessages.stream().map(AcknowledgeablePubsubMessage::getMessage)
+		return ackableMessages.stream().map(AcknowledgeablePubsubMessage::getPubsubMessage)
 				.collect(Collectors.toList());
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/AcknowledgeablePubsubMessage.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/AcknowledgeablePubsubMessage.java
@@ -47,7 +47,7 @@ public class AcknowledgeablePubsubMessage {
 		this.acknowledger = acknowledger;
 	}
 
-	public PubsubMessage getMessage() {
+	public PubsubMessage getPubsubMessage() {
 		return this.message;
 	}
 


### PR DESCRIPTION
Renames AcknowledgeablePubsubMessage.getMessage() to .getPubsubMessage()
in order to make the API change in 1.1 backwards compatible.