### PR TITLE
Spanner allow resetting columns to null

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -297,8 +297,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 							iterablePropertyType2ToMethodMap.get(targetType);
 					toMethod.accept(valueBinder,
 							value == null ? null
-									:
-							ConversionUtils.convertIterable(value, targetType, this.writeConverter));
+									: ConversionUtils.convertIterable(value, targetType, this.writeConverter));
 					valueSet = true;
 					break;
 				}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -236,10 +236,6 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 			SpannerPersistentProperty property) {
 		Object propertyValue = accessor.getProperty(property);
 
-		if (propertyValue == null) {
-			return;
-		}
-
 		Class<?> propertyType = property.getType();
 		ValueBinder<WriteBuilder> valueBinder = sink.set(property.getColumnName());
 
@@ -255,11 +251,12 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 					property);
 		}
 		else {
-			valueSet = attemptSetSingleItemValue(propertyValue, valueBinder,
+			valueSet = attemptSetSingleItemValue(propertyValue, propertyType, valueBinder,
 					propertyType);
 			if (!valueSet) {
 				for (Class<?> targetType : singleItemType2ToMethodMap.keySet()) {
-					valueSet = attemptSetSingleItemValue(propertyValue, valueBinder,
+					valueSet = attemptSetSingleItemValue(propertyValue, propertyType,
+							valueBinder,
 							targetType);
 					if (valueSet) {
 						break;
@@ -299,6 +296,8 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 					BiConsumer<ValueBinder<?>, Iterable> toMethod =
 							iterablePropertyType2ToMethodMap.get(targetType);
 					toMethod.accept(valueBinder,
+							value == null ? null
+									:
 							ConversionUtils.convertIterable(value, targetType, this.writeConverter));
 					valueSet = true;
 					break;
@@ -309,9 +308,9 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T> boolean attemptSetSingleItemValue(Object value,
+	private <T> boolean attemptSetSingleItemValue(Object value, Class<?> sourceType,
 			ValueBinder<WriteBuilder> valueBinder, Class<T> targetType) {
-		if (!this.writeConverter.canConvert(value.getClass(), targetType)) {
+		if (!this.writeConverter.canConvert(sourceType, targetType)) {
 			return false;
 		}
 		Class innerType = ConversionUtils.boxIfNeeded(targetType);
@@ -321,7 +320,9 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 			return false;
 		}
 		// We're just checking for the bind to have succeeded, we don't need to chain the result.
-		Object ignored = toMethod.apply(valueBinder, this.writeConverter.convert(value, targetType));
+		// Spanner allows binding of null values.
+		Object ignored = toMethod.apply(valueBinder,
+				value == null ? null : this.writeConverter.convert(value, targetType));
 		return true;
 	}
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -37,6 +37,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -147,6 +149,17 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 				this.tradeRepository.findBySymbolAndActionStruct(Struct.newBuilder()
 						.set("symbol").to("ABCD").set("action").to("BUY").build())
 						.size());
+
+		// testing setting some columns to null.
+		Trade someTrade = this.tradeRepository.findBySymbolContains("ABCD").get(0);
+		assertNotNull(someTrade.getExecutionTimes());
+		assertNotNull(someTrade.getSymbol());
+		someTrade.setExecutionTimes(null);
+		someTrade.setSymbol(null);
+		this.tradeRepository.save(someTrade);
+		someTrade = this.tradeRepository.findById(this.spannerSchemaUtils.getKey(someTrade)).get();
+		assertNull(someTrade.getExecutionTimes());
+		assertNull(someTrade.getSymbol());
 	}
 
 	protected List<Trade> insertTrades(String traderId1, String action, int numTrades) {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractSpannerIntegrationTest {
 	SpannerDatabaseAdminTemplate spannerDatabaseAdminTemplate;
 
 	@Autowired
-	SpannerSchemaUtils spannerSchemaUtils;
+	protected SpannerSchemaUtils spannerSchemaUtils;
 
 	@Autowired
 	SpannerMappingContext spannerMappingContext;


### PR DESCRIPTION
fixes #919 

Previously we did not expect users would save an entity and then save it again with some columns set to null. However based on user feedback and that the client lib supports this directly, it has been enabled. Conveniently, the client lib allows binding of any column type to null when creating a mutation.