### PR TITLE
add configuration for setting the Spanner host to use

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
@@ -63,6 +63,8 @@ import org.springframework.data.rest.webmvc.spi.BackendIdConverter;
 public class GcpSpannerAutoConfiguration {
 
 	static class CoreSpannerAutoConfiguration {
+		
+		private final String host;
 
 		private final String projectId;
 
@@ -89,6 +91,7 @@ public class GcpSpannerAutoConfiguration {
 		CoreSpannerAutoConfiguration(GcpSpannerProperties gcpSpannerProperties,
 				GcpProjectIdProvider projectIdProvider,
 				CredentialsProvider credentialsProvider) throws IOException {
+			this.host = gcpSpannerProperties.getHost();
 			this.credentials = (gcpSpannerProperties.getCredentials().hasKey()
 					? new DefaultCredentialsProvider(gcpSpannerProperties)
 					: credentialsProvider).getCredentials();
@@ -114,6 +117,9 @@ public class GcpSpannerAutoConfiguration {
 					.setProjectId(this.projectId)
 					.setHeaderProvider(new UsageTrackingHeaderProvider(this.getClass()))
 					.setCredentials(this.credentials);
+			if(this.host != null) {
+				builder.setHost(this.host);
+			}
 			if (this.numRpcChannels >= 0) {
 				builder.setNumChannels(this.numRpcChannels);
 			}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
@@ -63,7 +63,7 @@ import org.springframework.data.rest.webmvc.spi.BackendIdConverter;
 public class GcpSpannerAutoConfiguration {
 
 	static class CoreSpannerAutoConfiguration {
-		
+
 		private final String host;
 
 		private final String projectId;
@@ -117,7 +117,7 @@ public class GcpSpannerAutoConfiguration {
 					.setProjectId(this.projectId)
 					.setHeaderProvider(new UsageTrackingHeaderProvider(this.getClass()))
 					.setCredentials(this.credentials);
-			if(this.host != null) {
+			if (this.host != null) {
 				builder.setHost(this.host);
 			}
 			if (this.numRpcChannels >= 0) {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
@@ -64,8 +64,6 @@ public class GcpSpannerAutoConfiguration {
 
 	static class CoreSpannerAutoConfiguration {
 
-		private final String host;
-
 		private final String projectId;
 
 		private final String instanceId;
@@ -91,7 +89,6 @@ public class GcpSpannerAutoConfiguration {
 		CoreSpannerAutoConfiguration(GcpSpannerProperties gcpSpannerProperties,
 				GcpProjectIdProvider projectIdProvider,
 				CredentialsProvider credentialsProvider) throws IOException {
-			this.host = gcpSpannerProperties.getHost();
 			this.credentials = (gcpSpannerProperties.getCredentials().hasKey()
 					? new DefaultCredentialsProvider(gcpSpannerProperties)
 					: credentialsProvider).getCredentials();
@@ -117,9 +114,6 @@ public class GcpSpannerAutoConfiguration {
 					.setProjectId(this.projectId)
 					.setHeaderProvider(new UsageTrackingHeaderProvider(this.getClass()))
 					.setCredentials(this.credentials);
-			if (this.host != null) {
-				builder.setHost(this.host);
-			}
 			if (this.numRpcChannels >= 0) {
 				builder.setNumChannels(this.numRpcChannels);
 			}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.spanner;
+
+import java.io.IOException;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.cloud.spanner.SessionPoolOptions;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.SpannerOptions.Builder;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
+import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * If <code>spring.cloud.gcp.spanner.emulator-host</code> is set, spring will connect to a
+ * Spanner emulator instead of a real Cloud Spanner instance.
+ *
+ * @author Andreas Berger
+ * @author Olav Loite
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "spring.cloud.gcp.spanner", name = "emulator-host")
+@AutoConfigureBefore(GcpSpannerAutoConfiguration.class)
+@EnableConfigurationProperties(GcpSpannerProperties.class)
+public class GcpSpannerEmulatorConfiguration {
+
+	private final GcpSpannerProperties gcpSpannerProperties;
+
+	private final Credentials credentials;
+
+	GcpSpannerEmulatorConfiguration(GcpSpannerProperties gcpSpannerProperties,
+			CredentialsProvider credentialsProvider) throws IOException {
+		this.gcpSpannerProperties = gcpSpannerProperties;
+		this.credentials = (gcpSpannerProperties.getCredentials().hasKey()
+				? new DefaultCredentialsProvider(gcpSpannerProperties)
+				: credentialsProvider).getCredentials();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SpannerOptions spannerOptions(SessionPoolOptions sessionPoolOptions) {
+		Builder builder = SpannerOptions.newBuilder()
+				.setProjectId(this.gcpSpannerProperties.getProjectId())
+				.setHeaderProvider(new UsageTrackingHeaderProvider(this.getClass()))
+				.setCredentials(this.credentials);
+		builder.setHost(this.gcpSpannerProperties.getEmulatorHost());
+		if (this.gcpSpannerProperties.getNumRpcChannels() >= 0) {
+			builder.setNumChannels(this.gcpSpannerProperties.getNumRpcChannels());
+		}
+		if (this.gcpSpannerProperties.getPrefetchChunks() >= 0) {
+			builder.setPrefetchChunks(this.gcpSpannerProperties.getPrefetchChunks());
+		}
+		builder.setSessionPoolOption(sessionPoolOptions);
+		return builder.build();
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
@@ -33,6 +33,8 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 	@NestedConfigurationProperty
 	private final Credentials credentials = new Credentials(
 			GcpScope.SPANNER_DATA.getUrl(), GcpScope.SPANNER_ADMIN.getUrl());
+	
+	private String host;
 
 	private String projectId;
 
@@ -63,6 +65,14 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 
 	public Credentials getCredentials() {
 		return this.credentials;
+	}
+	
+	public String getHost() {
+		return this.host;
+	}
+	
+	public void setHost(String host) {
+		this.host = host;
 	}
 
 	public String getProjectId() {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
@@ -33,7 +33,7 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 	@NestedConfigurationProperty
 	private final Credentials credentials = new Credentials(
 			GcpScope.SPANNER_DATA.getUrl(), GcpScope.SPANNER_ADMIN.getUrl());
-	
+
 	private String host;
 
 	private String projectId;
@@ -66,11 +66,11 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 	public Credentials getCredentials() {
 		return this.credentials;
 	}
-	
+
 	public String getHost() {
 		return this.host;
 	}
-	
+
 	public void setHost(String host) {
 		this.host = host;
 	}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
@@ -34,7 +34,7 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 	private final Credentials credentials = new Credentials(
 			GcpScope.SPANNER_DATA.getUrl(), GcpScope.SPANNER_ADMIN.getUrl());
 
-	private String host;
+	private String emulatorHost;
 
 	private String projectId;
 
@@ -67,12 +67,12 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 		return this.credentials;
 	}
 
-	public String getHost() {
-		return this.host;
+	public String getEmulatorHost() {
+		return this.emulatorHost;
 	}
 
-	public void setHost(String host) {
-		this.host = host;
+	public void setEmulatorHost(String emulatorHost) {
+		this.emulatorHost = emulatorHost;
 	}
 
 	public String getProjectId() {

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubEmulatorConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.spanner.GcpSpannerEmulatorConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.logging.StackdriverLoggingAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfiguration,\

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorConfigurationTests.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.spanner;
+
+import com.google.cloud.spanner.SpannerOptions;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+
+/**
+ * @author Olav Loite
+ */
+public class GcpSpannerEmulatorConfigurationTests {
+	private static final String DEFAULT_CLOUDSPANNER_HOST = "https://spanner.googleapis.com";
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.gcp.spanner.emulator-host=https://localhost:8443",
+					"spring.cloud.gcp.spanner.project-id=test-project",
+					"spring.cloud.gcp.spanner.instance-id=test-instance",
+					"spring.cloud.gcp.spanner.database=test-database")
+			.withConfiguration(AutoConfigurations.of(GcpSpannerEmulatorConfiguration.class,
+					GcpContextAutoConfiguration.class,
+					GcpSpannerAutoConfiguration.class));
+
+	@Test
+	public void testEmulatorConfig() {
+		this.contextRunner.run(context -> {
+			SpannerOptions spannerOptions = context.getBean(SpannerOptions.class);
+			Assert.assertEquals("SpannerOptions#host is not correct", "https://localhost:8443",
+					spannerOptions.getHost());
+		});
+	}
+
+	private ApplicationContextRunner contextRunnerWithoutEmulator = new ApplicationContextRunner()
+			.withPropertyValues(
+					"spring.cloud.gcp.spanner.project-id=test-project",
+					"spring.cloud.gcp.spanner.instance-id=test-instance",
+					"spring.cloud.gcp.spanner.database=test-database")
+			.withConfiguration(AutoConfigurations.of(GcpSpannerEmulatorConfiguration.class,
+					GcpContextAutoConfiguration.class,
+					GcpSpannerAutoConfiguration.class));
+
+	@Test
+	public void testWithoutEmulatorConfig() {
+		this.contextRunnerWithoutEmulator.run(context -> {
+			SpannerOptions spannerOptions = context.getBean(SpannerOptions.class);
+			Assert.assertEquals("SpannerOptions#host is not correct", DEFAULT_CLOUDSPANNER_HOST,
+					spannerOptions.getHost());
+		});
+	}
+
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorConfigurationTests.java
@@ -16,13 +16,19 @@
 
 package org.springframework.cloud.gcp.autoconfigure.spanner;
 
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
 import com.google.cloud.spanner.SpannerOptions;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Olav Loite
@@ -35,6 +41,7 @@ public class GcpSpannerEmulatorConfigurationTests {
 					"spring.cloud.gcp.spanner.project-id=test-project",
 					"spring.cloud.gcp.spanner.instance-id=test-instance",
 					"spring.cloud.gcp.spanner.database=test-database")
+			.withUserConfiguration(TestConfiguration.class)
 			.withConfiguration(AutoConfigurations.of(GcpSpannerEmulatorConfiguration.class,
 					GcpContextAutoConfiguration.class,
 					GcpSpannerAutoConfiguration.class));
@@ -53,6 +60,7 @@ public class GcpSpannerEmulatorConfigurationTests {
 					"spring.cloud.gcp.spanner.project-id=test-project",
 					"spring.cloud.gcp.spanner.instance-id=test-instance",
 					"spring.cloud.gcp.spanner.database=test-database")
+			.withUserConfiguration(TestConfiguration.class)
 			.withConfiguration(AutoConfigurations.of(GcpSpannerEmulatorConfiguration.class,
 					GcpContextAutoConfiguration.class,
 					GcpSpannerAutoConfiguration.class));
@@ -64,6 +72,15 @@ public class GcpSpannerEmulatorConfigurationTests {
 			Assert.assertEquals("SpannerOptions#host is not correct", DEFAULT_CLOUDSPANNER_HOST,
 					spannerOptions.getHost());
 		});
+	}
+
+	@AutoConfigurationPackage
+	static class TestConfiguration {
+
+		@Bean
+		public CredentialsProvider credentialsProvider() {
+			return () -> mock(Credentials.class);
+		}
 	}
 
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/resources/application.properties
@@ -2,3 +2,13 @@
 #spring.cloud.gcp.spanner.credentials.location=<spanner-specific-credentials>
 spring.cloud.gcp.spanner.instance-id=spring-demo
 spring.cloud.gcp.spanner.database=trades
+
+
+#The below example configuration shows how you could run the sample code on an emulator instead of a real Cloud Spanner instance.
+#See http://www.googlecloudspanner.com/2018/07/create-trial-account-for-cloud-spanner.html for a tutorial on how to setup a trial account for the emulator.
+
+#spring.cloud.gcp.spanner.host=https://emulator.googlecloudspanner.com:8443
+#spring.cloud.gcp.spanner.project-id=<your-project-id>
+#spring.cloud.gcp.spanner.credentials.location=<spanner-specific-credentials>
+#spring.cloud.gcp.spanner.instance-id=spring-demo
+#spring.cloud.gcp.spanner.database=trades

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.cloud.gcp.spanner.database=trades
 #The below example configuration shows how you could run the sample code on an emulator instead of a real Cloud Spanner instance.
 #See http://www.googlecloudspanner.com/2018/07/create-trial-account-for-cloud-spanner.html for a tutorial on how to setup a trial account for the emulator.
 
-#spring.cloud.gcp.spanner.host=https://emulator.googlecloudspanner.com:8443
+#spring.cloud.gcp.spanner.emulator-host=https://emulator.googlecloudspanner.com:8443
 #spring.cloud.gcp.spanner.project-id=<your-project-id>
 #spring.cloud.gcp.spanner.credentials.location=<spanner-specific-credentials>
 #spring.cloud.gcp.spanner.instance-id=spring-demo


### PR DESCRIPTION
This PR adds the functionality described in #930 

If a host is specified in the configuration file, that host will be used when creating a Spanner instance. This could be a (local) emulator instead of a real Cloud Spanner instance.
If no host is specified, the default Google Cloud Spanner host will automatically be used.

See http://www.googlecloudspanner.com/2018/07/create-trial-account-for-cloud-spanner.html for a short description on how to create an account for an emulator that you could use to test this.