### PR TITLE
Bump dep versions to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<spring-cloud-commons.version>2.0.0.RELEASE</spring-cloud-commons.version>
-		<spring-cloud-sleuth.version>2.0.0.RELEASE</spring-cloud-sleuth.version>
-		<spring-cloud-stream.version>Elmhurst.RELEASE</spring-cloud-stream.version>
-		<zipkin-gcp.version>0.6.2</zipkin-gcp.version>
+		<spring-cloud-commons.version>2.0.1.RELEASE</spring-cloud-commons.version>
+		<spring-cloud-sleuth.version>2.0.1.RELEASE</spring-cloud-sleuth.version>
+		<spring-cloud-stream.version>Elmhurst.SR1</spring-cloud-stream.version>
+		<zipkin-gcp.version>0.6.4</zipkin-gcp.version>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -118,31 +118,31 @@ public class StackdriverTraceAutoConfiguration {
 				.withExecutor(executorProvider.getExecutor());
 
 		if (traceProperties.getAuthority() != null) {
-			callOptions.withAuthority(traceProperties.getAuthority());
+			callOptions = callOptions.withAuthority(traceProperties.getAuthority());
 		}
 
 		if (traceProperties.getCompression() != null) {
-			callOptions.withCompression(traceProperties.getCompression());
+			callOptions = callOptions.withCompression(traceProperties.getCompression());
 		}
 
 		if (traceProperties.getDeadlineMs() != null) {
-			callOptions.withDeadlineAfter(traceProperties.getDeadlineMs(), TimeUnit.MILLISECONDS);
+			callOptions = callOptions.withDeadlineAfter(traceProperties.getDeadlineMs(), TimeUnit.MILLISECONDS);
 		}
 
 		if (traceProperties.getMaxInboundSize() != null) {
-			callOptions.withMaxInboundMessageSize(traceProperties.getMaxInboundSize());
+			callOptions = callOptions.withMaxInboundMessageSize(traceProperties.getMaxInboundSize());
 		}
 
 		if (traceProperties.getMaxOutboundSize() != null) {
-			callOptions.withMaxOutboundMessageSize(traceProperties.getMaxOutboundSize());
+			callOptions = callOptions.withMaxOutboundMessageSize(traceProperties.getMaxOutboundSize());
 		}
 
 		if (traceProperties.isWaitForReady() != null) {
 			if (Boolean.TRUE.equals(traceProperties.isWaitForReady())) {
-				callOptions.withWaitForReady();
+				callOptions = callOptions.withWaitForReady();
 			}
 			else {
-				callOptions.withoutWaitForReady();
+				callOptions = callOptions.withoutWaitForReady();
 			}
 		}
 

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,9 +16,9 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<google-cloud-bom.version>0.53.0-alpha</google-cloud-bom.version>
-		<google-auth-library-oauth2-http.version>0.9.1</google-auth-library-oauth2-http.version>
-		<mysql-socket-factory.version>1.0.9</mysql-socket-factory.version>
+		<google-cloud-bom.version>0.56.0-alpha</google-cloud-bom.version>
+		<google-auth-library-oauth2-http.version>0.10.0</google-auth-library-oauth2-http.version>
+		<mysql-socket-factory.version>1.0.10</mysql-socket-factory.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
The new versions highlighted a bug in the `stackdriverSender` definition, which this change also fixes.