### PR TITLE
Spanner test fix from merge

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerPersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerPersistentEntityImplTests.java
@@ -217,7 +217,7 @@ public class SpannerPersistentEntityImplTests {
 				this.spannerMappingContext.getPersistentEntity(ParentInRelationship.class);
 		doAnswer(invocation -> {
 			String colName = ((SpannerPersistentProperty) invocation.getArgument(0))
-					.getColumnName();
+					.getName();
 			assertTrue(colName.equals("childrenA") || colName.equals("childrenB"));
 			return null;
 		}).when(mockHandler).doWithPersistentProperty(any());


### PR DESCRIPTION
When merging PRs in a later PR we no longer allowed calling getColumnName for child-properties, since they don't actually correspond to real columns. 