### PR TITLE
Fix PubSubChannelAdaptersIntegrationTests

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.pubsub.integration.inbound;
 
 import java.util.Map;
 
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.Subscriber;
 
 import org.springframework.cloud.gcp.pubsub.core.PubSubException;
@@ -120,7 +121,17 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 
 		if (this.ackMode == AckMode.MANUAL) {
 			// Send the consumer downstream so user decides on when to ack/nack.
-			messageHeaders.put(GcpPubSubHeaders.ACKNOWLEDGEMENT, message);
+			messageHeaders.put(GcpPubSubHeaders.ACKNOWLEDGEMENT, new AckReplyConsumer() {
+				@Override
+				public void ack() {
+					message.ack();
+				}
+
+				@Override
+				public void nack() {
+					message.nack();
+				}
+			});
 		}
 
 		try {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/GcpPubSubHeaders.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/GcpPubSubHeaders.java
@@ -29,7 +29,4 @@ public abstract class GcpPubSubHeaders {
 
 	public static final String TOPIC = PREFIX + "topic";
 
-	public static final String ACK_ID = PREFIX + "ackId";
-
-	public static final String SUBSCRIPTION = PREFIX + "subscriptionName";
 }


### PR DESCRIPTION
Implement `AckReplyConsumer` using `ConvertedBasicAcknowledgeablePubsubMessage` and store it
in `GcpPubSubHeaders.ACKNOWLEDGEMENT`.

Fixes #976.