### PR TITLE
GH-973: Add metadata for extra config properties

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,29 @@
+{
+  "properties": [
+    {
+      "name": "spring.cloud.gcp.logging.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud Stackdriver logging for Spring MVC.",
+      "defaultValue": true
+    },
+    {
+      "name": "spring.cloud.gcp.pubsub.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud Pub/Sub components.",
+      "defaultValue": true
+    },
+    {
+      "name": "spring.cloud.gcp.sql.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud SQL support components.",
+      "defaultValue": true
+    },
+    {
+      "name": "spring.cloud.gcp.trace.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud Stackdriver tracing components.",
+      "defaultValue": true
+    }
+  ]
+}
+


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/973

If configuration properties are not covered with the
`@ConfigurationProperties` class, there is no a JSON metadata generated
for them and content assistant in the IDE throws warning about not
existed properties

* Add `additional-spring-configuration-metadata.json` and describe all
the properties without `@ConfigurationProperties`