### PR TITLE
Bump version of zipkin-gcp to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<spring-cloud-commons.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-sleuth.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Fishtown.BUILD-SNAPSHOT</spring-cloud-stream.version>
-		<zipkin-gcp.version>0.6.4</zipkin-gcp.version>
+		<zipkin-gcp.version>0.8.0</zipkin-gcp.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Fixes the Trace sample.

Fixes #972.