### PR TITLE
Add test rule for setting up Pub/Sub emulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ install:
   - ./mvnw -T 1.5C install -P it -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_install:
   - INTEGRATION_TEST_FLAGS="-Dit.localdeps"
-    if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;
         INTEGRATION_TEST_FLAGS="${INTEGRATION_TEST_FLAGS} -Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
             -Dit.cloudsql=true -Dit.datastore=true
             -Dspring.cloud.gcp.sql.instance-connection-name=spring-cloud-gcp-ci:us-central1:testmysql";
-    fi
-    export INTEGRATION_TEST_FLAGS
+      fi
+      export INTEGRATION_TEST_FLAGS
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   - source $HOME/google-cloud-sdk/path.bash.inc
   - gcloud components install beta pubsub-emulator --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 install:
   - ./mvnw -T 1.5C install -P it -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_install:
-  - INTEGRATION_TEST_FLAGS="-Dit.emulator";
+  - INTEGRATION_TEST_FLAGS="-Dit.pubsub-emulator";
       if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 install:
   - ./mvnw -T 1.5C install -P it -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_install:
-  - INTEGRATION_TEST_FLAGS="-Dit.localdeps";
+  - INTEGRATION_TEST_FLAGS="-Dit.emulator";
       if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,15 @@ script:
 install:
   - ./mvnw -T 1.5C install -P it -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_install:
-  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  - INTEGRATION_TEST_FLAGS="-Dit.localdeps"
+    if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;
-        export INTEGRATION_TEST_FLAGS="-Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
+        INTEGRATION_TEST_FLAGS="${INTEGRATION_TEST_FLAGS} -Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
             -Dit.cloudsql=true -Dit.datastore=true
             -Dspring.cloud.gcp.sql.instance-connection-name=spring-cloud-gcp-ci:us-central1:testmysql";
-      fi
+    fi
+    export INTEGRATION_TEST_FLAGS
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   - source $HOME/google-cloud-sdk/path.bash.inc
   - gcloud components install beta pubsub-emulator --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,15 @@ script:
 install:
   - ./mvnw -T 1.5C install -P it -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_install:
-  - INTEGRATION_TEST_FLAGS="-Dit.localdeps"
+  - INTEGRATION_TEST_FLAGS="-Dit.localdeps";
       if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
         tar -xzf travis.tar.gz;
         INTEGRATION_TEST_FLAGS="${INTEGRATION_TEST_FLAGS} -Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
             -Dit.cloudsql=true -Dit.datastore=true
             -Dspring.cloud.gcp.sql.instance-connection-name=spring-cloud-gcp-ci:us-central1:testmysql";
-      fi
-      export INTEGRATION_TEST_FLAGS
+      fi;
+      export INTEGRATION_TEST_FLAGS;
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   - source $HOME/google-cloud-sdk/path.bash.inc
   - gcloud components install beta pubsub-emulator --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ script:
   - ./mvnw -T 1.5C test -B ${INTEGRATION_TEST_FLAGS}
 install:
   - ./mvnw -T 1.5C install -P it -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-before_script:
-  - gcloud beta emulators pubsub start &
-  - while [ ! -f ~/.config/gcloud/emulators/pubsub/env.yaml ]; do sleep 1; done
-  - $(gcloud beta emulators pubsub env-init)
 before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.stream.binder.pubsub;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.rules.ExternalResource;
+
+public class PubSubEmulator extends ExternalResource {
+	private PubSubTestBinder binder;
+
+	// Needed for cleanup.
+	private Process emulatorProcess;
+
+	private String emulatorHost;
+
+	private String emulatorPort;
+
+	private final Path emulatorConfigPath = Paths.get(System.getProperty("user.home")).resolve(
+			Paths.get(".config", "gcloud", "emulators", "pubsub", "env.yaml"));
+
+	@Override
+	protected void before() throws Throwable {
+
+		this.emulatorProcess = new ProcessBuilder("gcloud", "beta", "emulators", "pubsub", "start").start();
+		assertConfigPresent();
+
+		Process envInitProcess = new ProcessBuilder("gcloud", "beta", "emulators", "pubsub", "env-init").start();
+		String envVariable = new BufferedReader(new InputStreamReader(envInitProcess.getInputStream())).readLine();
+		envInitProcess.waitFor();
+
+		String emulatorHostPort = envVariable.substring(envVariable.indexOf('=') + 1);
+		System.out.println("initialization completed; property = " + System.getenv("PUBSUB_EMULATOR_HOST")
+				+ "; property from output = " + envVariable + "; hostname = " + emulatorHostPort);
+
+		int portSeparatorIndex = emulatorHostPort.indexOf(":");
+		if (portSeparatorIndex < 0 || !envVariable.contains("localhost")) {
+			throw new RuntimeException("Malformed host, can't create emulator: " + envVariable);
+		}
+		this.emulatorHost = emulatorHostPort.substring(0, portSeparatorIndex);
+		this.emulatorPort = emulatorHostPort.substring(portSeparatorIndex + 1);
+
+		this.binder = new PubSubTestBinder(emulatorHostPort);
+	}
+
+	/**
+	 * Shuts down the two emulator processes.
+	 *
+	 * gcloud command is shut down through the direct process handle.
+	 * java process is identified and shut down through shell commands.
+	 */
+	@Override
+	protected void after() {
+		try {
+			String hostPortParams = String.format("--host=%s --port=%s", this.emulatorHost, this.emulatorPort);
+			Process psProcess = new ProcessBuilder("ps", "-v").start();
+			new BufferedReader(new InputStreamReader(psProcess.getInputStream()))
+					.lines()
+					.filter(psLine -> psLine.contains(hostPortParams))
+					.map(psLine -> psLine.substring(0, psLine.indexOf(' ')))
+					.forEach(pid -> {
+						this.killProcess(pid);
+					});
+		}
+		catch (IOException e) {
+			System.out.println("Failed to cleanup: ");
+			e.printStackTrace();
+		}
+		this.emulatorProcess.destroy();
+
+	}
+
+	/**
+	 * Returns an already-configured emulator binder when called from within a JUnit method.
+	 */
+	public PubSubTestBinder getBinder() {
+		return this.binder;
+	}
+
+	/**
+	 * Waits until a PubSub emulator configuration file is present.
+	 *
+	 * Fails if the file does not appear after 1 second.
+	 *
+	 * @throws InterruptedException which should interrupt the peaceful slumber and bubble up to fail the test.
+	 */
+	private void assertConfigPresent() throws InterruptedException {
+		int attempts = 10;
+		while (!Files.exists(this.emulatorConfigPath) && --attempts >= 0) {
+			Thread.sleep(100);
+		}
+		if (attempts < 0) {
+			throw new RuntimeException("Emulator could not be configured -- env.yaml not found");
+		}
+	}
+
+	/**
+	 * Attempts to kill a process on best effort basis.
+	 *
+	 * @param pid Presumably a valid PID. No checking done to validate.
+	 */
+	private void killProcess(String pid) {
+		try {
+			new ProcessBuilder("kill", pid).start();
+		}
+		catch (IOException e) {
+			System.err.println(String.format("Failed to clean up PID %s", pid));
+		}
+	}
+}

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -23,21 +23,37 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.rules.ExternalResource;
 
+/**
+ * Rule for instantiating and tearing down a Pub/Sub emulator instance.
+ */
 public class PubSubEmulator extends ExternalResource {
-	private PubSubTestBinder binder;
-
-	// Needed for cleanup.
-	private Process emulatorProcess;
-
-	private String emulatorHost;
-
-	private String emulatorPort;
-
-	private final Path emulatorConfigPath = Paths.get(System.getProperty("user.home")).resolve(
+	private static final Path emulatorConfigPath = Paths.get(System.getProperty("user.home")).resolve(
 			Paths.get(".config", "gcloud", "emulators", "pubsub", "env.yaml"));
 
+	private static final Log LOGGER = LogFactory.getLog(PubSubEmulator.class);
+
+
+	// Binder to Pub/Sub emulator for use in individual tests.
+	private PubSubTestBinder binder;
+
+	// Reference to emulator instance, for cleanup.
+	private Process emulatorProcess;
+
+	// Hostname for cleanup, should always be localhost.
+	private String emulatorHost;
+
+	// Port for cleanup.
+	private String emulatorPort;
+
+	/**
+	 * Launches an instance of pubsub simulator, creates a binder.
+	 *
+	 * @throws Throwable for any failed setup.
+	 */
 	@Override
 	protected void before() throws Throwable {
 
@@ -45,19 +61,13 @@ public class PubSubEmulator extends ExternalResource {
 		assertConfigPresent();
 
 		Process envInitProcess = new ProcessBuilder("gcloud", "beta", "emulators", "pubsub", "env-init").start();
-		String envVariable = new BufferedReader(new InputStreamReader(envInitProcess.getInputStream())).readLine();
+
+		// env-init output is a shell command of the form "export PUBSUB_EMULATOR_HOST=localhost:8085".
+		String emulatorInitString
+				= new BufferedReader(new InputStreamReader(envInitProcess.getInputStream())).readLine();
 		envInitProcess.waitFor();
-
-		String emulatorHostPort = envVariable.substring(envVariable.indexOf('=') + 1);
-		System.out.println("initialization completed; property = " + System.getenv("PUBSUB_EMULATOR_HOST")
-				+ "; property from output = " + envVariable + "; hostname = " + emulatorHostPort);
-
-		int portSeparatorIndex = emulatorHostPort.indexOf(":");
-		if (portSeparatorIndex < 0 || !envVariable.contains("localhost")) {
-			throw new RuntimeException("Malformed host, can't create emulator: " + envVariable);
-		}
-		this.emulatorHost = emulatorHostPort.substring(0, portSeparatorIndex);
-		this.emulatorPort = emulatorHostPort.substring(portSeparatorIndex + 1);
+		String emulatorHostPort = emulatorInitString.substring(emulatorInitString.indexOf('=') + 1);
+		extractTeardownParams(emulatorHostPort);
 
 		this.binder = new PubSubTestBinder(emulatorHostPort);
 	}
@@ -67,9 +77,13 @@ public class PubSubEmulator extends ExternalResource {
 	 *
 	 * gcloud command is shut down through the direct process handle.
 	 * java process is identified and shut down through shell commands.
+	 *
+	 * There should normally be only one process with that host/port combination, but if there are more, they will be
+	 * cleaned up as well.
 	 */
 	@Override
 	protected void after() {
+		this.emulatorProcess.destroy();
 		try {
 			String hostPortParams = String.format("--host=%s --port=%s", this.emulatorHost, this.emulatorPort);
 			Process psProcess = new ProcessBuilder("ps", "-v").start();
@@ -82,11 +96,8 @@ public class PubSubEmulator extends ExternalResource {
 					});
 		}
 		catch (IOException e) {
-			System.out.println("Failed to cleanup: ");
-			e.printStackTrace();
+			LOGGER.error("Failed to cleanup: ", e);
 		}
-		this.emulatorProcess.destroy();
-
 	}
 
 	/**
@@ -109,12 +120,32 @@ public class PubSubEmulator extends ExternalResource {
 			Thread.sleep(100);
 		}
 		if (attempts < 0) {
-			throw new RuntimeException("Emulator could not be configured -- env.yaml not found");
+			throw new RuntimeException(
+					"Emulator could not be configured due to missing env.yaml. Are PubSub and beta tools installed?");
 		}
 	}
 
 	/**
+	 * Remembers host/port combination for future process cleanup.
+	 *
+	 * Validates that localhost is the only valid value; this will stop the test if emulator decides to start with an
+	 * IPv6 ::1 address.
+	 *
+	 * @param emulatorHostPort typically "localhost:8085"
+	 */
+	private void extractTeardownParams(String emulatorHostPort) {
+		int portSeparatorIndex = emulatorHostPort.indexOf(":");
+		if (portSeparatorIndex < 0 || !emulatorHostPort.contains("localhost")) {
+			throw new RuntimeException("Malformed host, can't create emulator: " + emulatorHostPort);
+		}
+		this.emulatorHost = emulatorHostPort.substring(0, portSeparatorIndex);
+		this.emulatorPort = emulatorHostPort.substring(portSeparatorIndex + 1);
+	}
+
+	/**
 	 * Attempts to kill a process on best effort basis.
+	 *
+	 * Failure is logged and ignored.
 	 *
 	 * @param pid Presumably a valid PID. No checking done to validate.
 	 */
@@ -123,7 +154,7 @@ public class PubSubEmulator extends ExternalResource {
 			new ProcessBuilder("kill", pid).start();
 		}
 		catch (IOException e) {
-			System.err.println(String.format("Failed to clean up PID %s", pid));
+			LOGGER.error("Failed to clean up PID " + pid);
 		}
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -38,6 +38,10 @@ import org.junit.rules.ExternalResource;
  * Rule for instantiating and tearing down a Pub/Sub emulator instance.
  *
  * Tests can access the emulator's host/port combination by calling {@link #getEmulatorHostPort()} method.
+ *
+ * @author Elena Felder
+ *
+ * @since 1.1
  */
 public class PubSubEmulator extends ExternalResource {
 	private static final Path EMULATOR_CONFIG_DIR = Paths.get(System.getProperty("user.home")).resolve(
@@ -57,7 +61,7 @@ public class PubSubEmulator extends ExternalResource {
 
 
 	/**
-	 * Launches an instance of pubsub simulator, creates a binder.
+	 * Launch an instance of pubsub simulator, creates a binder.
 	 *
 	 * @throws Throwable for any failed setup.
 	 */
@@ -92,7 +96,7 @@ public class PubSubEmulator extends ExternalResource {
 	}
 
 	/**
-	 * Shuts down the two emulator processes.
+	 * Shut down the two emulator processes.
 	 *
 	 * gcloud command is shut down through the direct process handle. java process is
 	 * identified and shut down through shell commands.
@@ -128,14 +132,14 @@ public class PubSubEmulator extends ExternalResource {
 	}
 
 	/**
-	 * Returns the already-started emulator's host/port combination when called from within a JUnit method.
+	 * Return the already-started emulator's host/port combination when called from within a JUnit method.
 	 */
 	public String getEmulatorHostPort() {
 		return this.emulatorHostPort;
 	}
 
 	/**
-	 * Waits until a PubSub emulator configuration file is present.
+	 * Wait until a PubSub emulator configuration file is present.
 	 *
 	 * Fails if the file does not appear after 10 seconds.
 	 *
@@ -154,9 +158,9 @@ public class PubSubEmulator extends ExternalResource {
 	}
 
 	/**
-	 * Waits until a PubSub emulator configuration file is updated.
+	 * Wait until a PubSub emulator configuration file is updated.
 	 *
-	 * Fails if the file does not update after 1 second.
+	 * Fail if the file does not update after 1 second.
 	 *
 	 * @throws InterruptedException which should interrupt the peaceful slumber and bubble up
 	 * to fail the test.
@@ -167,8 +171,7 @@ public class PubSubEmulator extends ExternalResource {
 			WatchKey key = watchService.poll(100, TimeUnit.MILLISECONDS);
 
 			if (key != null) {
-				Optional<Path> configFilePath = key.pollEvents().stream().filter(
-						event -> event.kind() == StandardWatchEventKinds.ENTRY_MODIFY)
+				Optional<Path> configFilePath = key.pollEvents().stream()
 						.map(event -> (Path) event.context())
 						.filter(path -> ENV_FILE_NAME.equals(path.toString()))
 						.findAny();
@@ -184,7 +187,7 @@ public class PubSubEmulator extends ExternalResource {
 	}
 
 	/**
-	 * Attempts to kill a process on best effort basis.
+	 * Attempt to kill a process on best effort basis.
 	 *
 	 * Failure is logged and ignored.
 	 *

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -61,9 +61,9 @@ public class PubSubEmulator extends ExternalResource {
 
 
 	/**
-	 * Launch an instance of pubsub simulator, creates a binder.
+	 * Launch an instance of pubsub emulator.
 	 *
-	 * @throws Throwable for any failed setup.
+	 * @throws Throwable for any unexpected setup failure.
 	 */
 	@Override
 	protected void before() throws Throwable {
@@ -144,6 +144,8 @@ public class PubSubEmulator extends ExternalResource {
 
 	/**
 	 * Return the already-started emulator's host/port combination when called from within a JUnit method.
+	 *
+	 * @return Emulator host/port string or null if emulator setup failed.
 	 */
 	public String getEmulatorHostPort() {
 		return this.emulatorHostPort;
@@ -152,7 +154,9 @@ public class PubSubEmulator extends ExternalResource {
 	/**
 	 * Wait until a PubSub emulator configuration file is present.
 	 *
-	 * Fails if the file does not appear after 10 seconds.
+	 * Give up and log warning if the file does not appear after 10 seconds.
+	 *
+	 * @return whether configuration creation succeeded
 	 *
 	 * @throws InterruptedException which should interrupt the peaceful slumber and bubble up
 	 * to fail the test.
@@ -173,8 +177,9 @@ public class PubSubEmulator extends ExternalResource {
 	/**
 	 * Wait until a PubSub emulator configuration file is updated.
 	 *
-	 * Fail if the file does not update after 1 second.
+	 * Give up and log warning if the file does not update after 1 second.
 	 *
+	 * @return whether configuration update succeeded
 	 * @throws InterruptedException which should interrupt the peaceful slumber and bubble up
 	 * to fail the test.
 	 */

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -27,6 +27,7 @@ import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.Optional;
+import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
@@ -107,14 +108,13 @@ public class PubSubEmulator extends ExternalResource {
 	 */
 	@Override
 	protected void after() {
-		this.emulatorProcess.destroy();
 		try {
 			String hostPortParams = String.format("--host=%s --port=%s", this.emulatorHost, this.emulatorPort);
 			Process psProcess = new ProcessBuilder("ps", "-v").start();
 			new BufferedReader(new InputStreamReader(psProcess.getInputStream()))
 					.lines()
 					.filter(psLine -> psLine.contains(hostPortParams))
-					.map(psLine -> psLine.substring(0, psLine.indexOf(' ')))
+					.map(psLine -> new StringTokenizer(psLine).nextToken())
 					.forEach(pid -> {
 						this.killProcess(pid);
 					});
@@ -122,6 +122,7 @@ public class PubSubEmulator extends ExternalResource {
 		catch (IOException e) {
 			LOGGER.error("Failed to cleanup: ", e);
 		}
+		this.emulatorProcess.destroy();
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -124,11 +124,13 @@ public class PubSubEmulator extends ExternalResource {
 
 			String hostPortParams = String.format("--host=%s --port=%s", emulatorHost, emulatorPort);
 			Process psProcess = new ProcessBuilder("ps", "-v").start();
-			new BufferedReader(new InputStreamReader(psProcess.getInputStream()))
-					.lines()
-					.filter(psLine -> psLine.contains(hostPortParams))
-					.map(psLine -> new StringTokenizer(psLine).nextToken())
-					.forEach(this::killProcess);
+
+			try (BufferedReader br = new BufferedReader(new InputStreamReader(psProcess.getInputStream()))) {
+				br.lines()
+						.filter(psLine -> psLine.contains(hostPortParams))
+						.map(psLine -> new StringTokenizer(psLine).nextToken())
+						.forEach(this::killProcess);
+			}
 		}
 		catch (IOException e) {
 			LOGGER.warn("Failed to cleanup: ", e);
@@ -162,6 +164,7 @@ public class PubSubEmulator extends ExternalResource {
 
 		if (configPresent) {
 			updateConfig(watchService);
+			watchService.close();
 		}
 		else {
 			createConfig();

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -135,7 +135,7 @@ public class PubSubEmulator extends ExternalResource {
 	/**
 	 * Waits until a PubSub emulator configuration file is present.
 	 *
-	 * Fails if the file does not appear after 1 second.
+	 * Fails if the file does not appear after 10 seconds.
 	 *
 	 * @throws InterruptedException which should interrupt the peaceful slumber and bubble up
 	 * to fail the test.
@@ -143,7 +143,7 @@ public class PubSubEmulator extends ExternalResource {
 	private void waitForConfigCreation() throws InterruptedException {
 		int attempts = 10;
 		while (!Files.exists(this.EMULATOR_CONFIG_PATH) && --attempts >= 0) {
-			Thread.sleep(100);
+			Thread.sleep(1000);
 		}
 		if (attempts < 0) {
 			throw new RuntimeException(

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -47,6 +47,7 @@ import static org.junit.Assume.assumeTrue;
  * @since 1.1
  */
 public class PubSubEmulator extends ExternalResource {
+
 	private static final Path EMULATOR_CONFIG_DIR = Paths.get(System.getProperty("user.home")).resolve(
 			Paths.get(".config", "gcloud", "emulators", "pubsub"));
 
@@ -76,11 +77,8 @@ public class PubSubEmulator extends ExternalResource {
 
 	/**
 	 * Launch an instance of pubsub emulator or skip all tests.
-	 *
 	 * If it.pubsub-emulator environmental property is off, all tests will be skipped through the failed assumption.
-	 *
 	 * If the property is on, any setup failure will trigger test failure. Failures during teardown are merely logged.
-	 *
 	 * @throws IOException if config file creation or directory watcher on existing file fails.
 	 * @throws InterruptedException if process is stopped while waiting to retry.
 	 */
@@ -89,25 +87,22 @@ public class PubSubEmulator extends ExternalResource {
 
 		assumeTrue(this.enableTests);
 
-		this.startEmulator();
-		this.determineHostPort();
+		startEmulator();
+		determineHostPort();
 	}
 
 	/**
 	 * Shut down the two emulator processes.
-	 *
 	 * gcloud command is shut down through the direct process handle. java process is
 	 * identified and shut down through shell commands.
-	 *
 	 * There should normally be only one process with that host/port combination, but if there
 	 * are more, they will be cleaned up as well.
-	 *
 	 * Any failure is logged and ignored since it's not critical to the tests' operation.
 	 */
 	@Override
 	protected void after() {
 		if (this.emulatorProcess == null) {
-			LOGGER.warn("Emulator process no longer alive after the test.");
+			LOGGER.warn("Emulator process null after tests; nothing to terminate.");
 			return;
 		}
 
@@ -142,7 +137,6 @@ public class PubSubEmulator extends ExternalResource {
 
 	/**
 	 * Return the already-started emulator's host/port combination when called from within a JUnit method.
-	 *
 	 * @return Emulator host/port string or null if emulator setup failed.
 	 */
 	public String getEmulatorHostPort() {
@@ -189,9 +183,7 @@ public class PubSubEmulator extends ExternalResource {
 
 	/**
 	 * Wait until a PubSub emulator configuration file is present.
-	 *
 	 * Fail if the file does not appear after 10 seconds.
-	 *
 	 * @throws InterruptedException which should interrupt the peaceful slumber and bubble up
 	 * to fail the test.
 	 */
@@ -208,9 +200,7 @@ public class PubSubEmulator extends ExternalResource {
 
 	/**
 	 * Wait until a PubSub emulator configuration file is updated.
-	 *
 	 * Fail if the file does not update after 1 second.
-	 *
 	 * @throws InterruptedException which should interrupt the peaceful slumber and bubble up
 	 * to fail the test.
 	 */
@@ -235,9 +225,7 @@ public class PubSubEmulator extends ExternalResource {
 
 	/**
 	 * Attempt to kill a process on best effort basis.
-	 *
 	 * Failure is logged and ignored, as it is not critical to the tests' functionality.
-	 *
 	 * @param pid Presumably a valid PID. No checking done to validate.
 	 */
 	private void killProcess(String pid) {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -71,7 +71,7 @@ public class PubSubEmulator extends ExternalResource {
 			this.enableTests = true;
 		}
 		else {
-			LOGGER.warn("PubSubEmulator rule disabled. Please enable with -Dit.pubsub-emulator");
+			LOGGER.warn("PubSubEmulator rule disabled. Please enable with -Dit.pubsub-emulator.");
 		}
 	}
 
@@ -85,7 +85,7 @@ public class PubSubEmulator extends ExternalResource {
 	@Override
 	protected void before() throws IOException, InterruptedException {
 
-		assumeTrue(this.enableTests);
+		assumeTrue("PubSubEmulator rule disabled. Please enable with -Dit.pubsub-emulator.", this.enableTests);
 
 		startEmulator();
 		determineHostPort();

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubEmulator.java
@@ -178,10 +178,12 @@ public class PubSubEmulator extends ExternalResource {
 	private void determineHostPort() throws IOException, InterruptedException {
 		Process envInitProcess = new ProcessBuilder("gcloud", "beta", "emulators", "pubsub", "env-init").start();
 
-		String emulatorInitString = new BufferedReader(new InputStreamReader(envInitProcess.getInputStream()))
-				.readLine();
-		envInitProcess.waitFor();
-		this.emulatorHostPort = emulatorInitString.substring(emulatorInitString.indexOf('=') + 1);
+
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(envInitProcess.getInputStream()))) {
+			String emulatorInitString = br.readLine();
+			envInitProcess.waitFor();
+			this.emulatorHostPort = emulatorInitString.substring(emulatorInitString.indexOf('=') + 1);
+		}
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -26,11 +26,8 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
 
-//import java.nio.file.;
-
 /**
- * Integration tests that require the Pub/Sub emulator to be installed and only run if the
- * GCP_PUBSUB_EMULATOR envvar is present.
+ * Integration tests that require the Pub/Sub emulator to be installed.
  *
  * @author João André Martins
  */
@@ -40,19 +37,6 @@ public class PubSubMessageChannelBinderTests extends
 
 	@ClassRule
 	public static PubSubEmulator emulator = new PubSubEmulator();
-
-	//private static final String EMULATOR_HOST_ENVVAR_NAME = "PUBSUB_EMULATOR_HOST";
-
-	//private PubSubTestBinder binder;
-
-	//public PubSubMessageChannelBinderTests() {
-	// this.binder = new PubSubTestBinder(System.getenv(EMULATOR_HOST_ENVVAR_NAME));
-	//}
-
-	//@BeforeClass
-	//public static void enableTests() {
-	//	assumeThat(System.getenv(EMULATOR_HOST_ENVVAR_NAME)).isNotNull();
-	//}
 
 	@Override
 	protected PubSubTestBinder getBinder() throws Exception {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -16,7 +16,8 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub;
 
-import org.junit.BeforeClass;
+
+import org.junit.ClassRule;
 
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
@@ -25,7 +26,7 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
 
-import static org.assertj.core.api.Assumptions.assumeThat;
+//import java.nio.file.;
 
 /**
  * Integration tests that require the Pub/Sub emulator to be installed and only run if the
@@ -33,26 +34,29 @@ import static org.assertj.core.api.Assumptions.assumeThat;
  *
  * @author João André Martins
  */
-public class PubSubMessageChannelBinderTests extends AbstractBinderTests<PubSubTestBinder,
-		ExtendedConsumerProperties<PubSubConsumerProperties>,
-		ExtendedProducerProperties<PubSubProducerProperties>> {
+public class PubSubMessageChannelBinderTests extends
+		AbstractBinderTests<PubSubTestBinder, ExtendedConsumerProperties<PubSubConsumerProperties>,
+				ExtendedProducerProperties<PubSubProducerProperties>> {
 
-	private static final String EMULATOR_HOST_ENVVAR_NAME = "PUBSUB_EMULATOR_HOST";
+	@ClassRule
+	public static PubSubEmulator emulator = new PubSubEmulator();
 
-	private PubSubTestBinder binder;
+	//private static final String EMULATOR_HOST_ENVVAR_NAME = "PUBSUB_EMULATOR_HOST";
 
-	public PubSubMessageChannelBinderTests() {
-		this.binder = new PubSubTestBinder(System.getenv(EMULATOR_HOST_ENVVAR_NAME));
-	}
+	//private PubSubTestBinder binder;
 
-	@BeforeClass
-	public static void enableTests() {
-		assumeThat(System.getenv(EMULATOR_HOST_ENVVAR_NAME)).isNotNull();
-	}
+	//public PubSubMessageChannelBinderTests() {
+	// this.binder = new PubSubTestBinder(System.getenv(EMULATOR_HOST_ENVVAR_NAME));
+	//}
+
+	//@BeforeClass
+	//public static void enableTests() {
+	//	assumeThat(System.getenv(EMULATOR_HOST_ENVVAR_NAME)).isNotNull();
+	//}
 
 	@Override
 	protected PubSubTestBinder getBinder() throws Exception {
-		return this.binder;
+		return this.emulator.getBinder();
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub;
 
-
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
@@ -25,6 +25,8 @@ import org.springframework.cloud.stream.binder.AbstractBinderTests;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
+
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Integration tests that require the Pub/Sub emulator to be installed.
@@ -37,6 +39,12 @@ public class PubSubMessageChannelBinderTests extends
 
 	@ClassRule
 	public static PubSubEmulator emulator = new PubSubEmulator();
+
+	@BeforeClass
+	public static void enableTests() {
+		assumeTrue(
+				"true".equals(System.getProperty("it.pubsub")) || "true".equals(System.getProperty("it.localdeps")));
+	}
 
 	@Override
 	protected PubSubTestBinder getBinder() throws Exception {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -16,13 +16,7 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub;
 
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
-
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
@@ -30,9 +24,6 @@ import org.springframework.cloud.stream.binder.AbstractBinderTests;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
-
-import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.junit.Assert.fail;
 
 /**
  * Integration tests that require the Pub/Sub emulator to be installed.
@@ -46,24 +37,6 @@ public class PubSubMessageChannelBinderTests extends
 
 	@ClassRule
 	public static PubSubEmulator emulator = new PubSubEmulator();
-
-	@Rule
-	public TestRule failOnAbsentEmulator = new TestRule() {
-		@Override
-		public Statement apply(Statement statement, Description description) {
-			if (emulator.getEmulatorHostPort() == null) {
-				fail("Pub/Sub emulator missing");
-			}
-			return statement;
-		}
-	};
-
-	@BeforeClass
-	public static void enableTests() {
-		assumeThat(System.getProperty("it.pubsub"))
-				.withFailMessage("PubSub Binder tests are disabled. Please enable them with -Dit.pubsub.")
-				.isEqualTo("true");
-	}
 
 	@Override
 	protected PubSubTestBinder getBinder() {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -48,7 +48,7 @@ public class PubSubMessageChannelBinderTests extends
 
 	@Override
 	protected PubSubTestBinder getBinder() throws Exception {
-		return this.emulator.getBinder();
+		return new PubSubTestBinder(this.emulator.getEmulatorHostPort());
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -32,6 +32,7 @@ import static org.junit.Assume.assumeTrue;
  * Integration tests that require the Pub/Sub emulator to be installed.
  *
  * @author João André Martins
+ * @author Elena Felder
  */
 public class PubSubMessageChannelBinderTests extends
 		AbstractBinderTests<PubSubTestBinder, ExtendedConsumerProperties<PubSubConsumerProperties>,

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -26,8 +26,8 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
 
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Integration tests that require the Pub/Sub emulator to be installed.
@@ -44,9 +44,8 @@ public class PubSubMessageChannelBinderTests extends
 
 	@BeforeClass
 	public static void enableTests() {
-		assumeThat(System.getProperty("it.emulator"))
-				.withFailMessage("PubSub Binder tests are disabled. Please enable them with -Dit.emulator")
-				.isEqualTo("true");
+		assumeTrue("PubSub Binder tests are disabled. Please enable them with -Dit.pubsub or -Dit.emulator",
+				"true".equals(System.getProperty("it.pubsub")) || "true".equals(System.getProperty("it.emulator")));
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -27,7 +27,7 @@ import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration tests that require the Pub/Sub emulator to be installed.
@@ -44,14 +44,16 @@ public class PubSubMessageChannelBinderTests extends
 
 	@BeforeClass
 	public static void enableTests() {
-		assumeTrue("PubSub Binder tests are disabled. Please enable them with -Dit.pubsub or -Dit.localdeps",
-				"true".equals(System.getProperty("it.pubsub")) || "true".equals(System.getProperty("it.localdeps")));
-		assumeThat(emulator.getEmulatorHostPort())
-				.withFailMessage("No PubSub emulator host configured").isNotNull();
+		assumeThat(System.getProperty("it.emulator"))
+				.withFailMessage("PubSub Binder tests are disabled. Please enable them with -Dit.emulator")
+				.isEqualTo("true");
 	}
 
 	@Override
 	protected PubSubTestBinder getBinder() {
+		if (emulator.getEmulatorHostPort() == null) {
+			fail("No PubSub emulator host found.");
+		}
 		return new PubSubTestBinder(emulator.getEmulatorHostPort());
 	}
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -19,6 +19,11 @@ package org.springframework.cloud.gcp.stream.binder.pubsub;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
 import org.springframework.cloud.stream.binder.AbstractBinderTests;
@@ -26,8 +31,8 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Integration tests that require the Pub/Sub emulator to be installed.
@@ -42,17 +47,26 @@ public class PubSubMessageChannelBinderTests extends
 	@ClassRule
 	public static PubSubEmulator emulator = new PubSubEmulator();
 
+	@Rule
+	public TestRule failOnAbsentEmulator = new TestRule() {
+		@Override
+		public Statement apply(Statement statement, Description description) {
+			if (emulator.getEmulatorHostPort() == null) {
+				fail("Pub/Sub emulator missing");
+			}
+			return statement;
+		}
+	};
+
 	@BeforeClass
 	public static void enableTests() {
-		assumeTrue("PubSub Binder tests are disabled. Please enable them with -Dit.pubsub or -Dit.emulator",
-				"true".equals(System.getProperty("it.pubsub")) || "true".equals(System.getProperty("it.emulator")));
+		assumeThat(System.getProperty("it.pubsub"))
+				.withFailMessage("PubSub Binder tests are disabled. Please enable them with -Dit.pubsub.")
+				.isEqualTo("true");
 	}
 
 	@Override
 	protected PubSubTestBinder getBinder() {
-		if (emulator.getEmulatorHostPort() == null) {
-			fail("No PubSub emulator host found.");
-		}
 		return new PubSubTestBinder(emulator.getEmulatorHostPort());
 	}
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -43,13 +44,15 @@ public class PubSubMessageChannelBinderTests extends
 
 	@BeforeClass
 	public static void enableTests() {
-		assumeTrue(
+		assumeTrue("PubSub Binder tests are disabled. Please enable them with -Dit.pubsub or -Dit.localdeps",
 				"true".equals(System.getProperty("it.pubsub")) || "true".equals(System.getProperty("it.localdeps")));
+		assumeThat(emulator.getEmulatorHostPort())
+				.withFailMessage("No PubSub emulator host configured").isNotNull();
 	}
 
 	@Override
-	protected PubSubTestBinder getBinder() throws Exception {
-		return new PubSubTestBinder(this.emulator.getEmulatorHostPort());
+	protected PubSubTestBinder getBinder() {
+		return new PubSubTestBinder(emulator.getEmulatorHostPort());
 	}
 
 	@Override
@@ -68,7 +71,7 @@ public class PubSubMessageChannelBinderTests extends
 	}
 
 	@Override
-	public void testClean() throws Exception {
+	public void testClean() {
 		// Do nothing. Original test tests for Lifecycle logic that we don't need.
 	}
 }


### PR DESCRIPTION
The new rule sets up an emulator, creates a binder for it, and kills the emulator process when the tests are done.

In the future, the rule should move to some place more easily accessible from other tests.

Fixes #435.