### PR TITLE
Use GcpPubSubHeaders.ORIGINAL_MESSAGE for manual acking

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -193,6 +193,14 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Test -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
@@ -196,6 +196,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void sendAndReceiveMessageManualAckThroughAcknowledgementHeader() {
 		this.contextRunner.run(context -> {
 			try {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
-import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -41,6 +40,7 @@ import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.integration.AckMode;
 import org.springframework.cloud.gcp.pubsub.integration.inbound.PubSubInboundChannelAdapter;
 import org.springframework.cloud.gcp.pubsub.integration.outbound.PubSubMessageHandler;
+import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
 import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
@@ -150,15 +150,16 @@ public class PubSubChannelAdaptersIntegrationTests {
 
 				Message<?> message = channel.receive(10000);
 				assertThat(message).isNotNull();
-				AckReplyConsumer acker =
-						(AckReplyConsumer) message.getHeaders().get(GcpPubSubHeaders.ACKNOWLEDGEMENT);
-				assertThat(acker).isNotNull();
-				acker.nack();
+				BasicAcknowledgeablePubsubMessage origMessage =
+						(BasicAcknowledgeablePubsubMessage) message.getHeaders().get(GcpPubSubHeaders.ORIGINAL_MESSAGE);
+				assertThat(origMessage).isNotNull();
+				origMessage.nack();
 				message = channel.receive(10000);
 				assertThat(message).isNotNull();
-				acker = (AckReplyConsumer) message.getHeaders().get(GcpPubSubHeaders.ACKNOWLEDGEMENT);
-				assertThat(acker).isNotNull();
-				acker.ack();
+				origMessage = (BasicAcknowledgeablePubsubMessage)
+						message.getHeaders().get(GcpPubSubHeaders.ORIGINAL_MESSAGE);
+				assertThat(origMessage).isNotNull();
+				origMessage.ack();
 				message = channel.receive(10000);
 				assertThat(message).isNull();
 			}

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -97,8 +97,8 @@ This is useful when using the subscription's ack deadline timeout as a retry del
 
 Manually acking (`AckMode.MANUAL`)
 
-The adapter attaches an `AckReplyConsumer` object to the `Message` headers.
-Users can extract the `AckReplyConsumer` using the `GcpPubSubHeaders.ACKNOWLEDGEMENT` key and use it to (n)ack a message.
+The adapter attaches a `BasicAcknowledgeablePubsubMessage` object to the `Message` headers.
+Users can extract the `BasicAcknowledgeablePubsubMessage` using the `GcpPubSubHeaders.ORIGINAL_MESSAGE` key and use it to (n)ack a message.
 
 [source,java]
 ----
@@ -107,9 +107,9 @@ Users can extract the `AckReplyConsumer` using the `GcpPubSubHeaders.ACKNOWLEDGE
 public MessageHandler messageReceiver() {
     return message -> {
         LOGGER.info("Message arrived! Payload: " + new String((byte[]) message.getPayload()));
-        AckReplyConsumer consumer =
-              message.getHeaders().get(GcpPubSubHeaders.ACKNOWLEDGEMENT, AckReplyConsumer.class);
-        consumer.ack();
+        BasicAcknowledgeablePubsubMessage originalMessage =
+              message.getHeaders().get(GcpPubSubHeaders.ORIGINAL_MESSAGE, BasicAcknowledgeablePubsubMessage.class);
+        originalMessage.ack();
     };
 }
 ----

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/PubSubHeaderMapper.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/PubSubHeaderMapper.java
@@ -43,10 +43,12 @@ public class PubSubHeaderMapper implements HeaderMapper<Map<String, String>> {
 	 * Patterns of headers to map in {@link #fromHeaders(MessageHeaders, Map)}.
 	 * First patterns take precedence.
 	 */
+	@SuppressWarnings("deprecation")
 	private String[] outboundHeaderPatterns = {
 			"!" + MessageHeaders.ID,
 			"!" + MessageHeaders.TIMESTAMP,
 			"!" + GcpPubSubHeaders.ACKNOWLEDGEMENT,
+			"!" + GcpPubSubHeaders.ORIGINAL_MESSAGE,
 			"!" + NativeMessageHeaderAccessor.NATIVE_HEADERS,
 			"*"};
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.gcp.pubsub.integration.inbound;
 
 import java.util.Map;
 
-import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.Subscriber;
 
 import org.springframework.cloud.gcp.pubsub.core.PubSubException;
@@ -121,17 +120,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 
 		if (this.ackMode == AckMode.MANUAL) {
 			// Send the consumer downstream so user decides on when to ack/nack.
-			messageHeaders.put(GcpPubSubHeaders.ACKNOWLEDGEMENT, new AckReplyConsumer() {
-				@Override
-				public void ack() {
-					message.ack();
-				}
-
-				@Override
-				public void nack() {
-					message.nack();
-				}
-			});
+			messageHeaders.put(GcpPubSubHeaders.ORIGINAL_MESSAGE, message);
 		}
 
 		try {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -18,7 +18,11 @@ package org.springframework.cloud.gcp.pubsub.integration.inbound;
 
 import java.util.Map;
 
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.Subscriber;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.gcp.pubsub.core.PubSubException;
 import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberOperations;
@@ -40,6 +44,8 @@ import org.springframework.util.Assert;
  * @author Doug Hoard
  */
 public class PubSubInboundChannelAdapter extends MessageProducerSupport {
+
+	private static final Log LOGGER = LogFactory.getLog(PubSubInboundChannelAdapter.class);
 
 	private final String subscriptionName;
 
@@ -114,6 +120,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		super.doStop();
 	}
 
+	@SuppressWarnings("deprecation")
 	private void consumeMessage(ConvertedBasicAcknowledgeablePubsubMessage message) {
 		Map<String, Object> messageHeaders =
 				this.headerMapper.toHeaders(message.getPubsubMessage().getAttributesMap());
@@ -121,6 +128,21 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		if (this.ackMode == AckMode.MANUAL) {
 			// Send the original message downstream so user decides on when to ack/nack.
 			messageHeaders.put(GcpPubSubHeaders.ORIGINAL_MESSAGE, message);
+
+			// Deprecated mechanism for manual (n)acking.
+			messageHeaders.put(GcpPubSubHeaders.ACKNOWLEDGEMENT, new AckReplyConsumer() {
+				@Override
+				public void ack() {
+					LOGGER.warn("ACKNOWLEDGEMENT header is deprecated. Please use ORIGINAL_MESSAGE header to ack.");
+					message.ack();
+				}
+
+				@Override
+				public void nack() {
+					LOGGER.warn("ACKNOWLEDGEMENT header is deprecated. Please use ORIGINAL_MESSAGE header to nack.");
+					message.nack();
+				}
+			});
 		}
 
 		try {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -119,7 +119,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 				this.headerMapper.toHeaders(message.getPubsubMessage().getAttributesMap());
 
 		if (this.ackMode == AckMode.MANUAL) {
-			// Send the consumer downstream so user decides on when to ack/nack.
+			// Send the original message downstream so user decides on when to ack/nack.
 			messageHeaders.put(GcpPubSubHeaders.ORIGINAL_MESSAGE, message);
 		}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/GcpPubSubHeaders.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/GcpPubSubHeaders.java
@@ -20,13 +20,19 @@ package org.springframework.cloud.gcp.pubsub.support;
  * Google Cloud Platform internal headers for Spring Messaging messages.
  *
  * @author João André Martins
+ * @author Elena Felder
  */
 public abstract class GcpPubSubHeaders {
 
 	private static final String PREFIX = "gcp_pubsub_";
 
+	/**
+	 * @deprecated as of 1.1, use {@link #ORIGINAL_MESSAGE} instead.
+	 */
+	@Deprecated
 	public static final String ACKNOWLEDGEMENT = PREFIX + "acknowledgement";
 
 	public static final String TOPIC = PREFIX + "topic";
 
+	public static final String ORIGINAL_MESSAGE = PREFIX + "original_message";
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/main/java/com/example/ReceiverApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/main/java/com/example/ReceiverApplication.java
@@ -16,7 +16,6 @@
 
 package com.example;
 
-import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -26,6 +25,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.integration.AckMode;
 import org.springframework.cloud.gcp.pubsub.integration.inbound.PubSubInboundChannelAdapter;
+import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -61,8 +61,8 @@ public class ReceiverApplication {
 
 	@ServiceActivator(inputChannel = "pubsubInputChannel")
 	public void messageReceiver(String payload,
-			@Header(GcpPubSubHeaders.ACKNOWLEDGEMENT) AckReplyConsumer ackReplyConsumer) {
+			@Header(GcpPubSubHeaders.ORIGINAL_MESSAGE) BasicAcknowledgeablePubsubMessage message) {
 		LOGGER.info("Message arrived! Payload: " + payload);
-		ackReplyConsumer.ack();
+		message.ack();
 	}
 }


### PR DESCRIPTION
GcpPubSubHeaders.ACKNOWLEDGEMENT is deprecated and unused, except in PubSubHeaderMapper.

I used BasicAcknowledgeablePubsubMessage and not ConvertedBasicAcknowledgeablePubsubMessage: since this header is only used for manual (n)acking, the exact implementation does not seem relevant. Besides, casting to PulledAcknowledgeablePubsubMessage is needed to get ackId, anyway. Might as well keep it as a clean base interface.

Fixes #979.