### PR TITLE
Add Google-hosted maven mirror

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
 					<name>GCS Maven Mirror</name>
 					<url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
 					<snapshots>
-						<enabled>true</enabled>
+						<enabled>false</enabled>
 					</snapshots>
 					<releases>
 						<enabled>true</enabled>
@@ -292,7 +292,7 @@
 					<name>GCS Maven Mirror</name>
 					<url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
 					<snapshots>
-						<enabled>true</enabled>
+						<enabled>false</enabled>
 					</snapshots>
 					<releases>
 						<enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,17 @@
 						<enabled>false</enabled>
 					</snapshots>
 				</repository>
+				<repository>
+					<id>gcs-mirror</id>
+					<name>GCS Maven Mirror</name>
+					<url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+				</repository>
 			</repositories>
 			<pluginRepositories>
 				<pluginRepository>
@@ -275,6 +286,17 @@
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
+				</pluginRepository>
+				<pluginRepository>
+					<id>gcs-mirror</id>
+					<name>GCS Maven Mirror</name>
+					<url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
 				</pluginRepository>
 			</pluginRepositories>
 		</profile>


### PR DESCRIPTION
This may be a little wasteful since for snapshots maven downloads metadata from
every listed repository, but it will prevent Travis builds from timing out.

Fixes #1035.