### PR TITLE
Add batch pull functionality to sample pubsub app

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/resources/static/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/resources/static/index.html
@@ -43,11 +43,12 @@
 
 <div class="section">
     <h1>Pub/Sub -- post and subscribe</h1>
-
+    <div class="help">Send or retrieve/ack one message at a time</div>
     <div>
         <form action="/subscribe">
-            <span class="label">Subscribe to</span>
-            <input name="subscription" type="text" placeholder="subscription"> <input type="submit">
+            <span class="label">Message Retrieval</span>
+            <input name="subscription" type="text" placeholder="subscription">
+            <input type="submit" value="Subscribe"> (acks one message at a time)
         </form>
     </div>
     <div>
@@ -56,6 +57,21 @@
             <input name="message" type="text" placeholder="message text">
             to topic
             <input name="topicName" type="text" placeholder="topic name"> <input type="submit">
+        </form>
+    </div>
+</div>
+
+<div class="section">
+    <h1>Pub/Sub -- batch pull</h1>
+    <div class="help">Retrieve messages from different subscriptions, and ack as a batch</div>
+
+    <div>
+        <form action="/pull">
+            <span class="label">Subscription1</span>
+            <input name="subscription1" type="text" placeholder="first subscription name">
+            <span class="label">Subscription2</span>
+            <input name="subscription2" type="text" placeholder="second subscription name">
+            <input type="submit" value="Pull" formaction="/pull">
         </form>
     </div>
 </div>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/resources/static/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/resources/static/index.html
@@ -5,6 +5,9 @@
     <title>Title</title>
 
     <style>
+        div {
+            margin: 1em;
+        }
         span.label {
           display: inline-block;
           width: 10em;
@@ -13,14 +16,34 @@
 
         div.section {
           border: 1px solid grey;
-          margin: 1em;
           padding: 1em;
           width: 50em;
         }
 
+        div#statusMessage {
+            background-color: yellow;
+            width: fit-content;
+        }
+
     </style>
+
+    <script>
+
+        function escapeHTML(text) {
+            return text.replace(/[&<>]/g, (ch) => {
+                return {'&':'&amp;', '>': '&gt;', '<': '&lt;'}[ch];
+            })
+        }
+
+        function showStatus() {
+          const message = new URL(window.location.href).searchParams.get("statusMessage");
+          if (message) {
+            document.getElementById("statusMessage").innerHTML = "Status: " + escapeHTML(message);
+          }
+        }
+    </script>
 </head>
-<body>
+<body onload="showStatus();">
 
 <div class="section">
     <h1>Pub/Sub Admin -- create</h1>
@@ -67,10 +90,8 @@
 
     <div>
         <form action="/pull">
-            <span class="label">Subscription1</span>
-            <input name="subscription1" type="text" placeholder="first subscription name">
-            <span class="label">Subscription2</span>
-            <input name="subscription2" type="text" placeholder="second subscription name">
+            <span class="label">Subscription</span>
+            <input name="subscription" type="text" placeholder="subscription name">
             <input type="submit" value="Pull" formaction="/pull">
         </form>
     </div>
@@ -91,6 +112,10 @@
             <input name="subscription" type="text" placeholder="subscription name"> <input type="submit">
         </form>
     </div>
+</div>
+
+<div id="statusMessage">
+
 </div>
 
 </body>


### PR DESCRIPTION
New UI section and action for pulling multiple messages in a batch and acking them all at once. This is leading up to the next change addressing #975 , in which it will be possible to pull from two different subscriptions at a time, and ack intermingled messages from different subscriptions.

I also added basic status messaging. At this point, it would be good to add basic templating instead of mucking with parameter parsing from Javascript, but this can wait.

This PR depends on #1047 . The attempt to make stacked PRs will probably end badly... Suggestions welcome for how to have multiple small PRs in review/being worked on simultaneously!

Screenshot after trying to pull from an empty subscription:
![no_messages_available](https://user-images.githubusercontent.com/41136058/46092284-91279600-c182-11e8-8b14-477fe9b5b5c7.png)
