### PR TITLE
Group pubsub acks by subscription

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -68,11 +68,11 @@ For serialization and deserialization of POJOs using Jackson JSON, configure the
 ==== Subscribing to a subscription
 
 Google Cloud Pub/Sub allows many subscriptions to be associated to the same topic.
-`PubSubTemplate` allows you to subscribe to subscriptions via the `subscribe()` method.
+`PubSubTemplate` allows you to listen to subscriptions via the `subscribe()` method.
 It relies on a `SubscriberFactory` object, whose only task is to generate Google Cloud Pub/Sub
 `Subscriber` objects.
-When subscribing to a subscription, messages will be pulled from Google Cloud Pub/Sub
-asynchronously, on a certain interval.
+When listening to a subscription, messages will be pulled from Google Cloud Pub/Sub
+asynchronously, at a certain interval.
 
 The Spring Boot starter for Google Cloud Pub/Sub auto-configures a `SubscriberFactory`.
 
@@ -95,7 +95,7 @@ The `pullAndConvert()` method does the same as the `pull()` method and, addition
 To acknowledge multiple messages received from `pull()` or `pullAndConvert()` at once, you can use the `PubSubTemplate.ack()` method.
 You can also use the `PubSubTemplate.nack()` for negatively acknowledging messages.
 
-Using these methods for acknowledging messages in batches is more efficient than acknowledging messages individually, but they *require* the collection of messages to be from the same project and subscription.
+Using these methods for acknowledging messages in batches is more efficient than acknowledging messages individually, but they *require* the collection of messages to be from the same project.
 
 All `ack()`, `nack()`, and `modifyAckDeadline()` methods on messages as well as `PubSubSubscriberTemplate` are implemented asynchronously, returning a `ListenableFuture<Void>` to be able to process the asynchronous execution.
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -115,23 +115,21 @@ public interface PubSubSubscriberOperations {
 	PubsubMessage pullNext(String subscription);
 
 	/**
-	 * Acknowledge a batch of messages. The messages must have the same project id and be from the same subscription.
+	 * Acknowledge a batch of messages. The messages must have the same project id.
 	 * @param acknowledgeablePubsubMessages messages to be acknowledged
 	 * @return {@code ListenableFuture<Void>} the ListenableFuture for the asynchronous execution
 	 */
 	ListenableFuture<Void> ack(Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages);
 
 	/**
-	 * Negatively acknowledge a batch of messages. The messages must have the same project id and be from the same
-	 * subscription.
+	 * Negatively acknowledge a batch of messages. The messages must have the same project id.
 	 * @param acknowledgeablePubsubMessages messages to be negatively acknowledged
 	 * @return {@code ListenableFuture<Void>} the ListenableFuture for the asynchronous execution
 	 */
 	ListenableFuture<Void> nack(Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages);
 
 	/**
-	 * Modify the ack deadline of a batch of messages. The messages must have the same project id and be from the
-	 * same subscription.
+	 * Modify the ack deadline of a batch of messages. The messages must have the same project id.
 	 * @param acknowledgeablePubsubMessages messages to be modified
 	 * @param ackDeadlineSeconds the new ack deadline in seconds. A deadline of 0 effectively nacks the messages.
 	 * @return {@code ListenableFuture<Void>} the ListenableFuture for the asynchronous execution

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
@@ -310,9 +310,9 @@ public class PubSubSubscriberTemplate implements PubSubSubscriberOperations {
 		int numExpectedFutures = groupedMessages.size();
 		AtomicInteger numCompletedFutures = new AtomicInteger();
 
-		for (ProjectSubscriptionName psName : groupedMessages.keySet()) {
+		groupedMessages.forEach((ProjectSubscriptionName psName, List<String> ackIds) -> {
 
-			ApiFuture<Empty> ackApiFuture = asyncOperation.apply(psName.getSubscription(), groupedMessages.get(psName));
+			ApiFuture<Empty> ackApiFuture = asyncOperation.apply(psName.getSubscription(), ackIds);
 
 			ApiFutures.addCallback(ackApiFuture, new ApiFutureCallback<Empty>() {
 				@Override
@@ -334,8 +334,7 @@ public class PubSubSubscriberTemplate implements PubSubSubscriberOperations {
 					}
 				}
 			}, MoreExecutors.directExecutor());
-
-		}
+		});
 
 		return settableListenableFuture;
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
@@ -92,7 +92,6 @@ public class WebController {
 		try {
 			ListenableFuture<Void> ackFuture = this.pubSubTemplate.ack(mixedSubscriptionMessages);
 			ackFuture.get();
-			System.out.println("Got the results: " + System.currentTimeMillis());
 			returnView = buildStatusView(
 					String.format("Pulled and acked %s message(s)", mixedSubscriptionMessages.size()));
 		}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
@@ -92,6 +92,7 @@ public class WebController {
 		try {
 			ListenableFuture<Void> ackFuture = this.pubSubTemplate.ack(mixedSubscriptionMessages);
 			ackFuture.get();
+			System.out.println("Got the results: " + System.currentTimeMillis());
 			returnView = buildStatusView(
 					String.format("Pulled and acked %s message(s)", mixedSubscriptionMessages.size()));
 		}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/resources/static/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/resources/static/index.html
@@ -90,8 +90,12 @@
 
     <div>
         <form action="/pull">
-            <span class="label">Subscription</span>
-            <input name="subscription" type="text" placeholder="subscription name">
+            <span class="label">Subscription1</span>
+            <input name="subscription1" type="text" placeholder="first subscription name">
+            <br/>
+            <span class="label">Subscription2</span>
+            <input name="subscription2" type="text" placeholder="second subscription name">
+            <br/>
             <input type="submit" value="Pull" formaction="/pull">
         </form>
     </div>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/resources/static/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/resources/static/index.html
@@ -14,6 +14,11 @@
           line-height: 200%;
         }
 
+        span.narrow-label {
+          display: inline-block;
+          margin: 0 0.5em;
+        }
+
         div.section {
           border: 1px solid grey;
           padding: 1em;
@@ -24,6 +29,10 @@
             background-color: yellow;
             width: fit-content;
         }
+
+        input.small-number {
+            width: 2em;
+         }
 
     </style>
 
@@ -76,9 +85,11 @@
     </div>
     <div>
         <form action="/postMessage">
-            <span class="label">Send message</span>
+            <span class="narrow-label">Send</span>
+            <input class="small-number" name="count" type="text" value="1">
+            <span class="narrow-label">copies of message</span>
             <input name="message" type="text" placeholder="message text">
-            to topic
+            <span class="narrow-label">to topic</span>
             <input name="topicName" type="text" placeholder="topic name"> <input type="submit">
         </form>
     </div>
@@ -92,11 +103,11 @@
         <form action="/pull">
             <span class="label">Subscription1</span>
             <input name="subscription1" type="text" placeholder="first subscription name">
+            <input type="submit" value="Pull From Single Subscription" formaction="/pull">
             <br/>
             <span class="label">Subscription2</span>
             <input name="subscription2" type="text" placeholder="second subscription name">
-            <br/>
-            <input type="submit" value="Pull" formaction="/pull">
+            <input type="submit" value="Pull From Both Subscriptions" formaction="/multipull">
         </form>
     </div>
 </div>


### PR DESCRIPTION
The final ListenableFuture returned will complete when either all async calls complete successfully OR as soon as one fails.

Other changes:
* Added a second subscription field to the sample app to allow for testing of multiple-subscription acking.
* Cleaned up warnings in the touched files.