### PR TITLE
WIP: PubSub ExtendedPropertiesBindings doesn't seem to propagate default settings

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -47,15 +47,17 @@ public class PubSubMessageChannelBinder
 		PubSubProducerProperties> {
 
 	private final PubSubTemplate pubSubTemplate;
+	private final PubSubExtendedBindingProperties pubSubExtendedBindingProperties;
 
-	private final PubSubExtendedBindingProperties pubSubExtendedBindingProperties =
-			new PubSubExtendedBindingProperties();
-
-	public PubSubMessageChannelBinder(String[] headersToEmbed,
-			PubSubChannelProvisioner provisioningProvider, PubSubTemplate pubSubTemplate) {
+	public PubSubMessageChannelBinder(
+			String[] headersToEmbed,
+			PubSubChannelProvisioner provisioningProvider,
+			PubSubTemplate pubSubTemplate,
+			PubSubExtendedBindingProperties pubSubExtendedBindingProperties) {
 
 		super(headersToEmbed, provisioningProvider);
 		this.pubSubTemplate = pubSubTemplate;
+		this.pubSubExtendedBindingProperties = pubSubExtendedBindingProperties;
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
@@ -43,7 +43,8 @@ public class PubSubBinderConfiguration {
 	@Bean
 	public PubSubMessageChannelBinder pubSubBinder(
 			PubSubChannelProvisioner pubSubChannelProvisioner,
-			PubSubTemplate pubSubTemplate) {
-		return new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate);
+			PubSubTemplate pubSubTemplate,
+			PubSubExtendedBindingProperties pubSubExtendedBindingProperties) {
+		return new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate, pubSubExtendedBindingProperties);
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubTestBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubTestBinder.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
+import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubExtendedBindingProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.provisioning.PubSubChannelProvisioner;
 import org.springframework.cloud.stream.binder.AbstractTestBinder;
@@ -96,7 +97,7 @@ public class PubSubTestBinder extends AbstractTestBinder<PubSubMessageChannelBin
 		PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
 
 		PubSubMessageChannelBinder binder =
-				new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate);
+				new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate, new PubSubExtendedBindingProperties());
 		GenericApplicationContext context = new GenericApplicationContext();
 		binder.setApplicationContext(context);
 		this.setBinder(binder);

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTest.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTest.java
@@ -1,5 +1,7 @@
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,13 +20,10 @@ import org.springframework.messaging.SubscribableChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@EnableAutoConfiguration
-@EnableConfigurationProperties(PubSubExtendedBindingProperties.class)
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.NONE,
     properties = {
 				"spring.cloud.stream.gcp.pubsub.default.consumer.auto-create-resources=false",
-				"spring.cloud.stream.gcp.pubsub.bindings.input.consumer.auto-create-resources=false",
 		})
 public class PubSubExtendedBindingsPropertiesTest {
 
@@ -36,14 +35,19 @@ public class PubSubExtendedBindingsPropertiesTest {
 		BinderFactory binderFactory = context.getBeanFactory().getBean(BinderFactory.class);
 		PubSubMessageChannelBinder binder = (PubSubMessageChannelBinder) binderFactory.getBinder("pubsub", MessageChannel.class);
 
+		// Print out the default values; they should both be false.
 		System.out.println("default for INPUT: " + binder.getExtendedConsumerProperties("input").isAutoCreateResources());
 		System.out.println("default for CUSTOM INPUT: " + binder.getExtendedConsumerProperties("custom-in").isAutoCreateResources());
+
+		assertThat(binder.getExtendedConsumerProperties("input").isAutoCreateResources()).isFalse();
+		assertThat(binder.getExtendedConsumerProperties("custom-in").isAutoCreateResources()).isFalse();
 	}
 
+	@EnableAutoConfiguration
 	@EnableBinding(CustomTestSink.class)
 	public static class PubSubTestBindings {
 
-		@StreamListener(CustomTestSink.INPUT)
+		@StreamListener("input")
 		public void process(String payload) {
 			System.out.println(payload);
 		}

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTest.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTest.java
@@ -1,0 +1,63 @@
+package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gcp.stream.binder.pubsub.PubSubMessageChannelBinder;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.Input;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binder.BinderFactory;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@EnableAutoConfiguration
+@EnableConfigurationProperties(PubSubExtendedBindingProperties.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    properties = {
+				"spring.cloud.stream.gcp.pubsub.default.consumer.auto-create-resources=false",
+				"spring.cloud.stream.gcp.pubsub.bindings.input.consumer.auto-create-resources=false",
+		})
+public class PubSubExtendedBindingsPropertiesTest {
+
+	@Autowired
+	private ConfigurableApplicationContext context;
+
+	@Test
+	public void testExtendedProperties() {
+		BinderFactory binderFactory = context.getBeanFactory().getBean(BinderFactory.class);
+		PubSubMessageChannelBinder binder = (PubSubMessageChannelBinder) binderFactory.getBinder("pubsub", MessageChannel.class);
+
+		System.out.println("default for INPUT: " + binder.getExtendedConsumerProperties("input").isAutoCreateResources());
+		System.out.println("default for CUSTOM INPUT: " + binder.getExtendedConsumerProperties("custom-in").isAutoCreateResources());
+	}
+
+	@EnableBinding(CustomTestSink.class)
+	public static class PubSubTestBindings {
+
+		@StreamListener(CustomTestSink.INPUT)
+		public void process(String payload) {
+			System.out.println(payload);
+		}
+
+		@StreamListener("custom-in")
+		public void processCustom(String payload) {
+			System.out.println(payload);
+		}
+	}
+
+	interface CustomTestSink extends Sink {
+		@Input("custom-in")
+		SubscribableChannel customIn();
+	}
+}
+
+

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTest.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTest.java
@@ -20,6 +20,7 @@ import org.springframework.messaging.SubscribableChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
+@EnableAutoConfiguration
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.NONE,
     properties = {
@@ -36,14 +37,15 @@ public class PubSubExtendedBindingsPropertiesTest {
 		PubSubMessageChannelBinder binder = (PubSubMessageChannelBinder) binderFactory.getBinder("pubsub", MessageChannel.class);
 
 		// Print out the default values; they should both be false.
-		System.out.println("default for INPUT: " + binder.getExtendedConsumerProperties("input").isAutoCreateResources());
-		System.out.println("default for CUSTOM INPUT: " + binder.getExtendedConsumerProperties("custom-in").isAutoCreateResources());
+		System.out.println("default for INPUT: "
+				+ binder.getExtendedConsumerProperties("input").isAutoCreateResources());
+		System.out.println("default for CUSTOM INPUT: "
+				+ binder.getExtendedConsumerProperties("custom-in").isAutoCreateResources());
 
 		assertThat(binder.getExtendedConsumerProperties("input").isAutoCreateResources()).isFalse();
 		assertThat(binder.getExtendedConsumerProperties("custom-in").isAutoCreateResources()).isFalse();
 	}
 
-	@EnableAutoConfiguration
 	@EnableBinding(CustomTestSink.class)
 	public static class PubSubTestBindings {
 


### PR DESCRIPTION
This is a followup to #1039 and #1036.
@meltsufin @artembilan 

It seems like the default extended properties binding support doesn't quite work yet; I have an example unit test in this PR to demo this. In the test, I set the default value of auto-create-resources to false and will now expect the 2 bindings to also have auto-create-resources=false, but they retain the value of true.

Run:
cd spring-cloud-gcp-pubsub-stream-binder/
mvn -Dtest=PubSubExtendedBindingsPropertiesTest test

To try fixing the problem, I modified [PubSubConsumerProperties](https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java) to implement  [`MergableProperties`](https://docs.spring.io/spring-cloud-stream/docs/Fishtown.BUILD-SNAPSHOT/api/org/springframework/cloud/stream/config/MergableProperties.html). This follows what is done by Kafka in [KafkaConsumerProperties](https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/blob/5446485cbf129c4800033b35f3b364b9559ef19f/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java).

It turns out that implementing `MergableProperties` does propagate the default values but with 2 caveats:
1. The interface is marked "Not intended for public use" in the API docs
2. While the default value is propagated, it doesn't seem like you can override the default values with additional properties being set.

Any suggestions on how to proceed here?