### PR TITLE
Bump zipkin version to 0.8.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<spring-cloud-commons.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-sleuth.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Fishtown.BUILD-SNAPSHOT</spring-cloud-stream.version>
-		<zipkin-gcp.version>0.8.0</zipkin-gcp.version>
+		<zipkin-gcp.version>0.8.2</zipkin-gcp.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Fixes the tracing sample.

Original error, for posterity:
`[ERROR] Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:2.1.0.M4:run (default-cli) on project spring-cloud-gcp-trace-sample: An exception occurred while running. null: InvocationTargetException: Unable to start web server; nested exception is org.springframework.boot.web.server.WebServerException: Unable to start embedded Tomcat: Error creating bean with name 'traceWebFilter' defined in class path resource [org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.class]: Unsatisfied dependency expressed through method 'traceWebFilter' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'tracingFilter' defined in class path resource [org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.class]: Unsatisfied dependency expressed through method 'tracingFilter' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'httpTracing' defined in class path resource [org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfiguration.class]: Unsatisfied dependency expressed through method 'httpTracing' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration': Injection of autowired dependencies failed; nested exception is java.lang.TypeNotPresentException: Type brave.handler.FinishedSpanHandler not present -> [Help 1]`
