### PR TITLE
Filter project version in UsageTrackingHeaderProvider

### DIFF
--- a/spring-cloud-gcp-core/pom.xml
+++ b/spring-cloud-gcp-core/pom.xml
@@ -27,4 +27,23 @@
 			<artifactId>spring-context</artifactId>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>templating-maven-plugin</artifactId>
+				<version>1.0.0</version>
+				<executions>
+					<execution>
+						<id>filter-src</id>
+						<goals>
+							<goal>filter-sources</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/spring-cloud-gcp-core/src/main/java-templates/org/springframework/cloud/gcp/core/UsageTrackingHeaderProvider.java
+++ b/spring-cloud-gcp-core/src/main/java-templates/org/springframework/cloud/gcp/core/UsageTrackingHeaderProvider.java
@@ -27,10 +27,11 @@ import com.google.api.gax.rpc.HeaderProvider;
  *
  * @author João André Martins
  * @author Chengyuan Zhao
+ * @author Artem Bilan
  */
 public class UsageTrackingHeaderProvider implements HeaderProvider {
 
-	public static final String TRACKING_HEADER_PROJECT_VERSION = "1.1.0.BUILD-SNAPSHOT";
+	public static final String TRACKING_HEADER_PROJECT_VERSION = "${project.version}";
 
 	/** Class whose project name and version will be used in the header */
 	private Class clazz;
@@ -52,8 +53,9 @@ public class UsageTrackingHeaderProvider implements HeaderProvider {
 
 		headers.put("User-Agent",
 				"Spring/" + TRACKING_HEADER_PROJECT_VERSION
-				+ " " + springLibrary + "/" + TRACKING_HEADER_PROJECT_VERSION);
+						+ " " + springLibrary + "/" + TRACKING_HEADER_PROJECT_VERSION);
 
 		return headers;
 	}
+
 }


### PR DESCRIPTION
To make the release as automatic as possible it would be better to
inject the current version into the
`UsageTrackingHeaderProvider.TRACKING_HEADER_PROJECT_VERSION` constant

* Use `templating-maven-plugin` to allow to filter properties
placeholders in the Java source code