### PR TITLE
Make trace sample deployable to app engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 		<spring-cloud-sleuth.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Fishtown.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.8.2</zipkin-gcp.version>
+		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -198,6 +199,11 @@
 						</manifest>
 					</archive>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>appengine-maven-plugin</artifactId>
+				<version>${app-engine-maven-plugin.version}</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/README.adoc
@@ -32,3 +32,10 @@ Additionally, if you logged in with the Google Cloud SDK or have the `GOOGLE_CLO
 Note that the trace transmission delay default value is 10 seconds, so it can take a little while for the traces to show up in the Trace List page.
 You can shorten this delay using the `spring.cloud.gcp.trace.scheduled-delay-seconds` property.
 
+== Deploy to AppEngine Flex
+
+This command will deploy the application to AppEngine Flex:
+
+----
+$ mvn appengine:deploy
+----

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/README.adoc
@@ -32,9 +32,9 @@ Additionally, if you logged in with the Google Cloud SDK or have the `GOOGLE_CLO
 Note that the trace transmission delay default value is 10 seconds, so it can take a little while for the traces to show up in the Trace List page.
 You can shorten this delay using the `spring.cloud.gcp.trace.scheduled-delay-seconds` property.
 
-== Deploy to AppEngine Flex
+== Deploy to App Engine Flexible Environment
 
-This command will deploy the application to AppEngine Flex:
+If you have Cloud SDK installed, https://cloud.google.com/appengine/docs/flexible/java/using-maven[Maven App Engine Plug-in] can be used to deploy the application to App Engine Flexible environment:
 
 ----
 $ mvn appengine:deploy

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -41,7 +41,6 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
-                <version>1.3.2</version>
             </plugin>
         </plugins>
     </build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -38,6 +38,11 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>appengine-maven-plugin</artifactId>
+                <version>1.3.2</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/appengine/app.yaml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/appengine/app.yaml
@@ -1,0 +1,12 @@
+runtime: java
+env: flex
+
+handlers:
+- url: /.*
+  script: this field is required, but ignored
+
+manual_scaling:
+  instances: 1
+
+resources:
+  memory_gb: 4


### PR DESCRIPTION
This is part of my trace debugging saga (trace broke from Zipkin GCP 0.8.0 to 0.8.1 -- no traces appear even though the spans are being sent through PatchTracesCall), but it's a useful change on its own.