### PR TITLE
Fix Pub/Sub stream binder to accommodate Spring changes.

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -38,6 +38,7 @@ import org.springframework.messaging.MessageHandler;
  * @author João André Martins
  * @author Mike Eltsufin
  * @author Artem Bilan
+ * @author Daniel Zou
  */
 public class PubSubMessageChannelBinder
 		extends AbstractMessageChannelBinder<ExtendedConsumerProperties<PubSubConsumerProperties>,

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -53,7 +53,6 @@ public class PubSubMessageChannelBinder
 	public PubSubMessageChannelBinder(String[] headersToEmbed,
 			PubSubChannelProvisioner provisioningProvider, PubSubTemplate pubSubTemplate,
 			PubSubExtendedBindingProperties pubSubExtendedBindingProperties) {
-
 		super(headersToEmbed, provisioningProvider);
 		this.pubSubTemplate = pubSubTemplate;
 		this.pubSubExtendedBindingProperties = pubSubExtendedBindingProperties;
@@ -63,7 +62,6 @@ public class PubSubMessageChannelBinder
 	protected MessageHandler createProducerMessageHandler(ProducerDestination destination,
 			ExtendedProducerProperties<PubSubProducerProperties> producerProperties,
 			MessageChannel errorChannel) {
-
 		PubSubMessageHandler messageHandler = new PubSubMessageHandler(this.pubSubTemplate, destination.getName());
 		messageHandler.setBeanFactory(getBeanFactory());
 		return messageHandler;
@@ -72,7 +70,6 @@ public class PubSubMessageChannelBinder
 	@Override
 	protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group,
 			ExtendedConsumerProperties<PubSubConsumerProperties> properties) {
-
 		return new PubSubInboundChannelAdapter(this.pubSubTemplate, destination.getName());
 	}
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -48,14 +48,15 @@ public class PubSubMessageChannelBinder
 
 	private final PubSubTemplate pubSubTemplate;
 
-	private final PubSubExtendedBindingProperties pubSubExtendedBindingProperties =
-			new PubSubExtendedBindingProperties();
+	private final PubSubExtendedBindingProperties pubSubExtendedBindingProperties;
 
 	public PubSubMessageChannelBinder(String[] headersToEmbed,
-			PubSubChannelProvisioner provisioningProvider, PubSubTemplate pubSubTemplate) {
+			PubSubChannelProvisioner provisioningProvider, PubSubTemplate pubSubTemplate,
+			PubSubExtendedBindingProperties pubSubExtendedBindingProperties) {
 
 		super(headersToEmbed, provisioningProvider);
 		this.pubSubTemplate = pubSubTemplate;
+		this.pubSubExtendedBindingProperties = pubSubExtendedBindingProperties;
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -54,6 +54,7 @@ public class PubSubMessageChannelBinder
 	public PubSubMessageChannelBinder(String[] headersToEmbed,
 			PubSubChannelProvisioner provisioningProvider, PubSubTemplate pubSubTemplate,
 			PubSubExtendedBindingProperties pubSubExtendedBindingProperties) {
+
 		super(headersToEmbed, provisioningProvider);
 		this.pubSubTemplate = pubSubTemplate;
 		this.pubSubExtendedBindingProperties = pubSubExtendedBindingProperties;
@@ -63,6 +64,7 @@ public class PubSubMessageChannelBinder
 	protected MessageHandler createProducerMessageHandler(ProducerDestination destination,
 			ExtendedProducerProperties<PubSubProducerProperties> producerProperties,
 			MessageChannel errorChannel) {
+
 		PubSubMessageHandler messageHandler = new PubSubMessageHandler(this.pubSubTemplate, destination.getName());
 		messageHandler.setBeanFactory(getBeanFactory());
 		return messageHandler;
@@ -71,6 +73,7 @@ public class PubSubMessageChannelBinder
 	@Override
 	protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group,
 			ExtendedConsumerProperties<PubSubConsumerProperties> properties) {
+
 		return new PubSubInboundChannelAdapter(this.pubSubTemplate, destination.getName());
 	}
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
@@ -50,6 +50,7 @@ public class PubSubBinderConfiguration {
 			PubSubChannelProvisioner pubSubChannelProvisioner,
 			PubSubTemplate pubSubTemplate,
 			PubSubExtendedBindingProperties pubSubExtendedBindingProperties) {
+
 		return new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate,
 				pubSubExtendedBindingProperties);
 	}

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
@@ -16,14 +16,18 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.config;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.stream.binder.pubsub.PubSubMessageChannelBinder;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubExtendedBindingProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.provisioning.PubSubChannelProvisioner;
 import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.config.BindingHandlerAdvise.MappingsProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -43,7 +47,16 @@ public class PubSubBinderConfiguration {
 	@Bean
 	public PubSubMessageChannelBinder pubSubBinder(
 			PubSubChannelProvisioner pubSubChannelProvisioner,
-			PubSubTemplate pubSubTemplate) {
-		return new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate);
+			PubSubTemplate pubSubTemplate,
+			PubSubExtendedBindingProperties pubSubExtendedBindingProperties) {
+		return new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate,
+				pubSubExtendedBindingProperties);
+	}
+
+	@Bean
+	public MappingsProvider pubSubExtendedPropertiesDefaultMappingsProvider() {
+		return () -> ImmutableMap.of(
+				ConfigurationPropertyName.of("spring.cloud.stream.gcp.pubsub.bindings"),
+				ConfigurationPropertyName.of("spring.cloud.stream.gcp.pubsub.default"));
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * @author João André Martins
+ * @author Daniel Zou
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
 /**
  * @author João André Martins
+ * @author Daniel Zou
  */
 public class PubSubConsumerProperties {
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -16,12 +16,10 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
-import org.springframework.cloud.stream.config.MergableProperties;
-
 /**
  * @author João André Martins
  */
-public class PubSubConsumerProperties implements MergableProperties {
+public class PubSubConsumerProperties {
 
 	private boolean autoCreateResources = true;
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingProperties.java
@@ -16,70 +16,19 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.stream.binder.AbstractExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
-import org.springframework.cloud.stream.binder.ExtendedBindingProperties;
 
 /**
  * @author João André Martins
  * @author Artem Bilan
  */
 @ConfigurationProperties("spring.cloud.stream.gcp.pubsub")
-public class PubSubExtendedBindingProperties
-		implements ExtendedBindingProperties<PubSubConsumerProperties, PubSubProducerProperties> {
+public class PubSubExtendedBindingProperties extends
+		AbstractExtendedBindingProperties<PubSubConsumerProperties, PubSubProducerProperties, PubSubBindingProperties> {
 
 	private static final String DEFAULTS_PREFIX = "spring.cloud.stream.gcp.pubsub.default";
-
-	private Map<String, PubSubBindingProperties> bindings = new HashMap<>();
-
-	public Map<String, PubSubBindingProperties> getBindings() {
-		return this.bindings;
-	}
-
-	@Override
-	public synchronized PubSubConsumerProperties getExtendedConsumerProperties(String channelName) {
-		PubSubConsumerProperties properties;
-		if (this.bindings.containsKey(channelName)) {
-			if (this.bindings.get(channelName).getConsumer() != null) {
-				properties = this.bindings.get(channelName).getConsumer();
-			}
-			else {
-				properties = new PubSubConsumerProperties();
-				this.bindings.get(channelName).setConsumer(properties);
-			}
-		}
-		else {
-			properties = new PubSubConsumerProperties();
-			PubSubBindingProperties rbp = new PubSubBindingProperties();
-			rbp.setConsumer(properties);
-			this.bindings.put(channelName, rbp);
-		}
-		return properties;
-	}
-
-	@Override
-	public synchronized PubSubProducerProperties getExtendedProducerProperties(String channelName) {
-		PubSubProducerProperties properties;
-		if (this.bindings.containsKey(channelName)) {
-			if (this.bindings.get(channelName).getProducer() != null) {
-				properties = this.bindings.get(channelName).getProducer();
-			}
-			else {
-				properties = new PubSubProducerProperties();
-				this.bindings.get(channelName).setProducer(properties);
-			}
-		}
-		else {
-			properties = new PubSubProducerProperties();
-			PubSubBindingProperties rbp = new PubSubBindingProperties();
-			rbp.setProducer(properties);
-			this.bindings.put(channelName, rbp);
-		}
-		return properties;
-	}
 
 	@Override
 	public String getDefaultsPrefix() {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingProperties.java
@@ -23,6 +23,7 @@ import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
 /**
  * @author João André Martins
  * @author Artem Bilan
+ * @author Daniel Zou
  */
 @ConfigurationProperties("spring.cloud.stream.gcp.pubsub")
 public class PubSubExtendedBindingProperties extends

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
@@ -16,10 +16,8 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
-import org.springframework.cloud.stream.config.MergableProperties;
-
 /**
  * @author João André Martins
  */
-public class PubSubProducerProperties implements MergableProperties {
+public class PubSubProducerProperties {
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
 /**
  * @author João André Martins
+ * @author Daniel Zou
  */
 public class PubSubProducerProperties {
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubTestBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubTestBinder.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.support.DefaultPublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.DefaultSubscriberFactory;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
+import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubExtendedBindingProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.provisioning.PubSubChannelProvisioner;
 import org.springframework.cloud.stream.binder.AbstractTestBinder;
@@ -96,7 +97,8 @@ public class PubSubTestBinder extends AbstractTestBinder<PubSubMessageChannelBin
 		PubSubTemplate pubSubTemplate = new PubSubTemplate(publisherFactory, subscriberFactory);
 
 		PubSubMessageChannelBinder binder =
-				new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate);
+				new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate,
+						new PubSubExtendedBindingProperties());
 		GenericApplicationContext context = new GenericApplicationContext();
 		binder.setApplicationContext(context);
 		this.setBinder(binder);

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubTestBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubTestBinder.java
@@ -45,6 +45,7 @@ import org.springframework.context.support.GenericApplicationContext;
 
 /**
  * @author João André Martins
+ * @author Daniel Zou
  */
 public class PubSubTestBinder extends AbstractTestBinder<PubSubMessageChannelBinder,
 		ExtendedConsumerProperties<PubSubConsumerProperties>,


### PR DESCRIPTION
This addresses the changes in Spring Core which breaks our handling default extended binding properties in Pub/Sub stream binder. The changes in this PR follow the example: spring-cloud/spring-cloud-stream-binder-kafka#471

Fixes #1103.