### PR TITLE
Fix flakiness in Pub/Sub sample test

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
@@ -16,10 +16,12 @@
 
 package com.example;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.google.cloud.pubsub.v1.Subscriber;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -42,9 +44,12 @@ public class WebController {
 
 	private final PubSubAdmin pubSubAdmin;
 
+	private final ArrayList<Subscriber> allSubscribers;
+
 	public WebController(PubSubTemplate pubSubTemplate, PubSubAdmin pubSubAdmin) {
 		this.pubSubTemplate = pubSubTemplate;
 		this.pubSubAdmin = pubSubAdmin;
+		this.allSubscribers = new ArrayList<>();
 	}
 
 	@PostMapping("/createTopic")
@@ -125,13 +130,21 @@ public class WebController {
 
 	@GetMapping("/subscribe")
 	public RedirectView subscribe(@RequestParam("subscription") String subscriptionName) {
-		this.pubSubTemplate.subscribe(subscriptionName, (message) -> {
+		Subscriber subscriber = this.pubSubTemplate.subscribe(subscriptionName, (message) -> {
 			LOGGER.info("Message received from " + subscriptionName + " subscription. "
 					+ message.getPubsubMessage().getData().toStringUtf8());
 			message.ack();
 		});
 
+		allSubscribers.add(subscriber);
 		return buildStatusView("Subscribed.");
+	}
+
+	@GetMapping("/clearSubscribers")
+	public RedirectView clearSubscribers() {
+		allSubscribers.forEach(Subscriber::stopAsync);
+		return buildStatusView("Stopped All Subscribers. New messages from subscriptions "
+				+ "are no longer being ack'd and logged to console.");
 	}
 
 	@PostMapping("/deleteTopic")

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
@@ -140,13 +140,6 @@ public class WebController {
 		return buildStatusView("Subscribed.");
 	}
 
-	@GetMapping("/clearSubscribers")
-	public RedirectView clearSubscribers() {
-		allSubscribers.forEach(Subscriber::stopAsync);
-		return buildStatusView("Stopped All Subscribers. New messages from subscriptions "
-				+ "are no longer being ack'd and logged to console.");
-	}
-
 	@PostMapping("/deleteTopic")
 	public RedirectView deleteTopic(@RequestParam("topic") String topicName) {
 		this.pubSubAdmin.deleteTopic(topicName);

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
@@ -33,9 +33,9 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -60,15 +60,21 @@ import static org.junit.Assume.assumeThat;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { PubSubApplication.class })
 public class PubSubApplicationTests {
 
-	private static final int PUBSUB_CLIENT_TIMEOUT_SECONDS = 20;
+	private static final int PUBSUB_CLIENT_TIMEOUT_SECONDS = 10;
 
 	private static final String SAMPLE_TEST_TOPIC = "pubsub-sample-test-exampleTopic";
+
+	private static final String SAMPLE_TEST_TOPIC2 = "pubsub-sample-test-exampleTopic2";
+
+	private static final String SAMPLE_TEST_TOPIC_DELETE = "pubsub-sample-test-topicdelete";
 
 	private static final String SAMPLE_TEST_SUBSCRIPTION1 = "pubsub-sample-test-exampleSubscription1";
 
 	private static final String SAMPLE_TEST_SUBSCRIPTION2 = "pubsub-sample-test-exampleSubscription2";
 
 	private static final String SAMPLE_TEST_SUBSCRIPTION3 = "pubsub-sample-test-exampleSubscription3";
+
+	private static final String SAMPLE_TEST_SUBSCRIPTION_DELETE = "pubsub-sample-test-subdelete";
 
 	private static TopicAdminClient topicAdminClient;
 
@@ -94,10 +100,58 @@ public class PubSubApplicationTests {
 		projectName = ProjectName.of(ServiceOptions.getDefaultProjectId()).getProject();
 		topicAdminClient = TopicAdminClient.create();
 		subscriptionAdminClient = SubscriptionAdminClient.create();
+
+		topicAdminClient.createTopic(ProjectTopicName.of(projectName, SAMPLE_TEST_TOPIC));
+		topicAdminClient.createTopic(ProjectTopicName.of(projectName, SAMPLE_TEST_TOPIC2));
+
+		subscriptionAdminClient.createSubscription(
+				ProjectSubscriptionName.of(projectName, SAMPLE_TEST_SUBSCRIPTION1),
+				ProjectTopicName.of(projectName, SAMPLE_TEST_TOPIC),
+				PushConfig.getDefaultInstance(),
+				10);
+
+		subscriptionAdminClient.createSubscription(
+				ProjectSubscriptionName.of(projectName, SAMPLE_TEST_SUBSCRIPTION2),
+				ProjectTopicName.of(projectName, SAMPLE_TEST_TOPIC2),
+				PushConfig.getDefaultInstance(),
+				10);
+		subscriptionAdminClient.createSubscription(
+				ProjectSubscriptionName.of(projectName, SAMPLE_TEST_SUBSCRIPTION3),
+				ProjectTopicName.of(projectName, SAMPLE_TEST_TOPIC2),
+				PushConfig.getDefaultInstance(),
+				10);
 	}
 
 	@AfterClass
 	public static void cleanupPubsubClients() {
+		List<String> testTopics = ImmutableList.of(
+				SAMPLE_TEST_TOPIC,
+				SAMPLE_TEST_TOPIC2,
+				SAMPLE_TEST_TOPIC_DELETE);
+
+		for (String topicName : testTopics) {
+			List<String> projectTopics = getTopicNamesFromProject();
+			String testTopicName = ProjectTopicName.format(projectName, topicName);
+			if (projectTopics.contains(testTopicName)) {
+				topicAdminClient.deleteTopic(testTopicName);
+			}
+		}
+
+		List<String> testSubscriptions = ImmutableList.of(
+				SAMPLE_TEST_SUBSCRIPTION1,
+				SAMPLE_TEST_SUBSCRIPTION2,
+				SAMPLE_TEST_SUBSCRIPTION3,
+				SAMPLE_TEST_SUBSCRIPTION_DELETE);
+
+		for (String testSubscription : testSubscriptions) {
+			String testSubscriptionName = ProjectSubscriptionName.format(
+					projectName, testSubscription);
+			List<String> projectSubscriptions = getSubscriptionNamesFromProject();
+			if (projectSubscriptions.contains(testSubscriptionName)) {
+				subscriptionAdminClient.deleteSubscription(testSubscriptionName);
+			}
+		}
+
 		if (topicAdminClient != null) {
 			topicAdminClient.close();
 		}
@@ -112,53 +166,21 @@ public class PubSubApplicationTests {
 		this.appUrl = "http://localhost:" + this.port;
 	}
 
-	@Before
-	@After
-	public void cleanupPubsubTestResources() {
-		clearSubscribers();
-
-		List<String> projectTopics = getTopicNamesFromProject();
-		String testTopicName = ProjectTopicName.format(projectName, SAMPLE_TEST_TOPIC);
-		if (projectTopics.contains(testTopicName)) {
-			topicAdminClient.deleteTopic(testTopicName);
-		}
-		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-				.until(() -> !getTopicNamesFromProject().contains(testTopicName));
-
-		List<String> testSubscriptions = ImmutableList.of(
-				SAMPLE_TEST_SUBSCRIPTION1,
-				SAMPLE_TEST_SUBSCRIPTION2,
-				SAMPLE_TEST_SUBSCRIPTION3);
-
-		for (String testSubscription : testSubscriptions) {
-			String testSubscriptionName = ProjectSubscriptionName.format(
-					projectName, testSubscription);
-			List<String> projectSubscriptions = getSubscriptionNamesFromProject();
-			if (projectSubscriptions.contains(testSubscriptionName)) {
-				subscriptionAdminClient.deleteSubscription(testSubscriptionName);
-			}
-			await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-					.until(() -> !getSubscriptionNamesFromProject().contains(testSubscriptionName));
-		}
-	}
-
 	@Test
 	public void testCreateAndDeleteTopicAndSubscriptions() {
-		createTopic(SAMPLE_TEST_TOPIC);
-		createSubscription(SAMPLE_TEST_SUBSCRIPTION1, SAMPLE_TEST_TOPIC);
+		createTopic(SAMPLE_TEST_TOPIC_DELETE);
+		createSubscription(SAMPLE_TEST_SUBSCRIPTION_DELETE, SAMPLE_TEST_TOPIC_DELETE);
 
-		deleteSubscription(SAMPLE_TEST_SUBSCRIPTION1);
-		deleteTopic(SAMPLE_TEST_TOPIC);
+		deleteSubscription(SAMPLE_TEST_SUBSCRIPTION_DELETE);
+		deleteTopic(SAMPLE_TEST_TOPIC_DELETE);
 	}
 
 	@Test
 	public void testReceiveMessage() {
-		createTopic(SAMPLE_TEST_TOPIC);
-		createSubscription(SAMPLE_TEST_SUBSCRIPTION1, SAMPLE_TEST_TOPIC);
-		postMessage("HelloWorld", SAMPLE_TEST_TOPIC);
+		postMessage("HelloWorld-Pull", SAMPLE_TEST_TOPIC);
 		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
 				() -> assertThat(getMessagesFromSubscription(SAMPLE_TEST_SUBSCRIPTION1))
-						.containsExactly("HelloWorld"));
+						.containsExactly("HelloWorld-Pull"));
 
 		// After subscribing, the message will be acked by the application and no longer be present.
 		subscribe(SAMPLE_TEST_SUBSCRIPTION1);
@@ -168,17 +190,14 @@ public class PubSubApplicationTests {
 
 	@Test
 	public void testMultiPull() {
-		createTopic(SAMPLE_TEST_TOPIC);
-		createSubscription(SAMPLE_TEST_SUBSCRIPTION2, SAMPLE_TEST_TOPIC);
-		createSubscription(SAMPLE_TEST_SUBSCRIPTION3, SAMPLE_TEST_TOPIC);
-		postMessage("HelloWorld", SAMPLE_TEST_TOPIC);
+		postMessage("HelloWorld-MultiPull", SAMPLE_TEST_TOPIC2);
 		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
 				.untilAsserted(
 						() -> {
 							assertThat(getMessagesFromSubscription(SAMPLE_TEST_SUBSCRIPTION2))
-									.containsExactly("HelloWorld");
+									.containsExactly("HelloWorld-MultiPull");
 							assertThat(getMessagesFromSubscription(SAMPLE_TEST_SUBSCRIPTION3))
-									.containsExactly("HelloWorld");
+									.containsExactly("HelloWorld-MultiPull");
 						});
 
 		// After multi pull, the message will be acked by both subscriptions and no longer be present.
@@ -288,20 +307,14 @@ public class PubSubApplicationTests {
 		testRestTemplate.getForEntity(url, null, String.class);
 	}
 
-	private void clearSubscribers() {
-		String url = UriComponentsBuilder.fromHttpUrl(appUrl + "/clearSubscribers")
-				.toUriString();
-		testRestTemplate.getForEntity(url, null, String.class);
-	}
-
-	private List<String> getTopicNamesFromProject() {
+	private static List<String> getTopicNamesFromProject() {
 		ListTopicsPagedResponse listTopicsResponse = topicAdminClient.listTopics("projects/" + projectName);
 		return StreamSupport.stream(listTopicsResponse.iterateAll().spliterator(), false)
 				.map(Topic::getName)
 				.collect(Collectors.toList());
 	}
 
-	private List<String> getSubscriptionNamesFromProject() {
+	private static List<String> getSubscriptionNamesFromProject() {
 		ListSubscriptionsPagedResponse response = subscriptionAdminClient.listSubscriptions("projects/" + projectName);
 		return StreamSupport.stream(response.iterateAll().spliterator(), false)
 				.map(Subscription::getName)

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
@@ -132,36 +132,11 @@ public class PubSubApplicationTests {
 
 	@Test
 	public void testCreateAndDeleteTopicAndSubscriptions() {
-		String projectTopicName = ProjectTopicName.format(projectName, SAMPLE_TEST_TOPIC);
-		String projectSubscriptionName = ProjectSubscriptionName.format(projectName, SAMPLE_TEST_SUBSCRIPTION1);
-
 		createTopic(SAMPLE_TEST_TOPIC);
-		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
-				() -> {
-					List<String> projectTopics = getTopicNamesFromProject();
-					assertThat(projectTopics).contains(projectTopicName);
-				});
-
 		createSubscription(SAMPLE_TEST_SUBSCRIPTION1, SAMPLE_TEST_TOPIC);
-		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
-				() -> {
-					List<String> subscriptions = getSubscriptionNamesFromProject();
-					assertThat(subscriptions).contains(projectSubscriptionName);
-				});
 
 		deleteSubscription(SAMPLE_TEST_SUBSCRIPTION1);
-		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
-				() -> {
-					List<String> subscriptions = getSubscriptionNamesFromProject();
-					assertThat(subscriptions).doesNotContain(projectSubscriptionName);
-				});
-
 		deleteTopic(SAMPLE_TEST_TOPIC);
-		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
-				() -> {
-					List<String> projectTopics = getTopicNamesFromProject();
-					assertThat(projectTopics).doesNotContain(projectTopicName);
-				});
 	}
 
 	@Test
@@ -212,6 +187,13 @@ public class PubSubApplicationTests {
 				.queryParam("topicName", topicName)
 				.toUriString();
 		ResponseEntity<String> response = testRestTemplate.postForEntity(url, null, String.class);
+
+		String projectTopicName = ProjectTopicName.format(projectName, topicName);
+		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
+				() -> {
+					List<String> projectTopics = getTopicNamesFromProject();
+					assertThat(projectTopics).contains(projectTopicName);
+				});
 	}
 
 	private void deleteTopic(String topicName) {
@@ -219,6 +201,13 @@ public class PubSubApplicationTests {
 				.queryParam("topic", topicName)
 				.toUriString();
 		testRestTemplate.postForEntity(url, null, String.class);
+
+		String projectTopicName = ProjectTopicName.format(projectName, topicName);
+		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
+				() -> {
+					List<String> projectTopics = getTopicNamesFromProject();
+					assertThat(projectTopics).doesNotContain(projectTopicName);
+				});
 	}
 
 	private void createSubscription(String subscriptionName, String topicName) {
@@ -227,6 +216,13 @@ public class PubSubApplicationTests {
 				.queryParam("subscriptionName", subscriptionName)
 				.toUriString();
 		testRestTemplate.postForEntity(url, null, String.class);
+
+		String projectSubscriptionName = ProjectSubscriptionName.format(projectName, subscriptionName);
+		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
+				() -> {
+					List<String> subscriptions = getSubscriptionNamesFromProject();
+					assertThat(subscriptions).contains(projectSubscriptionName);
+				});
 	}
 
 	private void deleteSubscription(String subscriptionName) {
@@ -234,6 +230,13 @@ public class PubSubApplicationTests {
 				.queryParam("subscription", subscriptionName)
 				.toUriString();
 		testRestTemplate.postForEntity(url, null, String.class);
+
+		String projectSubscriptionName = ProjectSubscriptionName.format(projectName, subscriptionName);
+		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
+				() -> {
+					List<String> subscriptions = getSubscriptionNamesFromProject();
+					assertThat(subscriptions).doesNotContain(projectSubscriptionName);
+				});
 	}
 
 	private void subscribe(String subscriptionName) {


### PR DESCRIPTION
This improves the reliability of the Pub/Sub sample tests by adding additional waits and also moving the create/delete topics and subscriptions to only occur in the BeforeClass/AfterClass steps rather than in Before/After.

To verify reliability I ran: `mvn -Dit.pubsub test && mvn -Dit.pubsub test && .. (x10 times)`

In reference to #1116.