### PR TITLE
Add the spring.cloud.gcp.storage.enabled Spring Boot Property

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageAutoConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.context.annotation.Import;
  * @author Vinicius Carvalho
  * @author Artem Bilan
  * @author Mike Eltsufin
+ * @author Daniel Zou
  *
  * @see GoogleStorageProtocolResolver
  */

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageAutoConfiguration.java
@@ -24,6 +24,7 @@ import com.google.cloud.storage.StorageOptions;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpProperties;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
@@ -48,6 +49,7 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @ConditionalOnClass({ GoogleStorageProtocolResolverSettings.class, Storage.class })
+@ConditionalOnProperty(value = "spring.cloud.gcp.storage.enabled", matchIfMissing = true)
 @EnableConfigurationProperties({GcpProperties.class, GcpStorageProperties.class})
 @Import(GoogleStorageProtocolResolver.class)
 public class GcpStorageAutoConfiguration {

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -23,6 +23,12 @@
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud Stackdriver tracing components.",
       "defaultValue": true
+    },
+    {
+      "name": "spring.cloud.gcp.storage.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud Storage components.",
+      "defaultValue": true
     }
   ]
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageDisableTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageDisableTests.java
@@ -16,15 +16,15 @@
 
 package org.springframework.cloud.gcp.autoconfigure.storage;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Java6Assertions.catchThrowable;
-
 import com.google.cloud.storage.Storage;
 import org.junit.Test;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Verifies that GCP Storage may be disabled via the property:

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageDisableTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageDisableTests.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2017 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.catchThrowable;
+
+import com.google.cloud.storage.Storage;
+import org.junit.Test;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Verifies that GCP Storage may be disabled via the property:
+ * "spring.cloud.gcp.storage.enabled=false"
+ *
+ * @author dzou
+ */
+public class GcpStorageDisableTests {
+	ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(GcpStorageAutoConfiguration.class))
+			.withPropertyValues("spring.cloud.gcp.storage.enabled=false");
+
+	@Test
+	public void testStorageBeanIsNotProvided() {
+		contextRunner.run(context -> {
+			Throwable thrown = catchThrowable(() -> context.getBean(Storage.class));
+			assertThat(thrown).isInstanceOf(NoSuchBeanDefinitionException.class);
+		});
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageDisableTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageDisableTests.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 original author or authors.
+ *  Copyright 2018 original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -30,9 +30,10 @@ import static org.assertj.core.api.Assertions.catchThrowable;
  * Verifies that GCP Storage may be disabled via the property:
  * "spring.cloud.gcp.storage.enabled=false"
  *
- * @author dzou
+ * @author Daniel Zou
  */
 public class GcpStorageDisableTests {
+
 	ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(GcpStorageAutoConfiguration.class))
 			.withPropertyValues("spring.cloud.gcp.storage.enabled=false");

--- a/spring-cloud-gcp-docs/src/main/asciidoc/storage.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/storage.adoc
@@ -82,6 +82,7 @@ The Spring Boot Starter for Google Cloud Storage provides the following configur
 
 |===
 | Name | Description | Required | Default value
+| `spring.cloud.gcp.storage.enabled` | Enables the GCP storage APIs. | No | `true`
 | `spring.cloud.gcp.storage.auto-create-files` | Creates files and buckets on Google Cloud Storage
 when writes are made to non-existent files | No | `true`
 | `spring.cloud.gcp.storage.credentials.location` | OAuth2 credentials for authenticating with the


### PR DESCRIPTION
This adds the Spring Boot Property `spring.cloud.gcp.storage.enabled` to the GCP Storage autoconfiguration so users may depend on the starter but elect to disable it if it is not necessary.

Fixes #1119.