### PR TITLE
Add Null check in PubSub sample test AfterClass

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
@@ -124,39 +124,39 @@ public class PubSubApplicationTests {
 
 	@AfterClass
 	public static void cleanupPubsubClients() {
-		List<String> testTopics = ImmutableList.of(
-				SAMPLE_TEST_TOPIC,
-				SAMPLE_TEST_TOPIC2,
-				SAMPLE_TEST_TOPIC_DELETE);
-
-		for (String topicName : testTopics) {
-			List<String> projectTopics = getTopicNamesFromProject();
-			String testTopicName = ProjectTopicName.format(projectName, topicName);
-			if (projectTopics.contains(testTopicName)) {
-				topicAdminClient.deleteTopic(testTopicName);
-			}
-		}
-
-		List<String> testSubscriptions = ImmutableList.of(
-				SAMPLE_TEST_SUBSCRIPTION1,
-				SAMPLE_TEST_SUBSCRIPTION2,
-				SAMPLE_TEST_SUBSCRIPTION3,
-				SAMPLE_TEST_SUBSCRIPTION_DELETE);
-
-		for (String testSubscription : testSubscriptions) {
-			String testSubscriptionName = ProjectSubscriptionName.format(
-					projectName, testSubscription);
-			List<String> projectSubscriptions = getSubscriptionNamesFromProject();
-			if (projectSubscriptions.contains(testSubscriptionName)) {
-				subscriptionAdminClient.deleteSubscription(testSubscriptionName);
-			}
-		}
-
 		if (topicAdminClient != null) {
+			List<String> testTopics = ImmutableList.of(
+					SAMPLE_TEST_TOPIC,
+					SAMPLE_TEST_TOPIC2,
+					SAMPLE_TEST_TOPIC_DELETE);
+
+			for (String topicName : testTopics) {
+				List<String> projectTopics = getTopicNamesFromProject();
+				String testTopicName = ProjectTopicName.format(projectName, topicName);
+				if (projectTopics.contains(testTopicName)) {
+					topicAdminClient.deleteTopic(testTopicName);
+				}
+			}
+
 			topicAdminClient.close();
 		}
 
 		if (subscriptionAdminClient != null) {
+			List<String> testSubscriptions = ImmutableList.of(
+					SAMPLE_TEST_SUBSCRIPTION1,
+					SAMPLE_TEST_SUBSCRIPTION2,
+					SAMPLE_TEST_SUBSCRIPTION3,
+					SAMPLE_TEST_SUBSCRIPTION_DELETE);
+
+			for (String testSubscription : testSubscriptions) {
+				String testSubscriptionName = ProjectSubscriptionName.format(
+						projectName, testSubscription);
+				List<String> projectSubscriptions = getSubscriptionNamesFromProject();
+				if (projectSubscriptions.contains(testSubscriptionName)) {
+					subscriptionAdminClient.deleteSubscription(testSubscriptionName);
+				}
+			}
+
 			subscriptionAdminClient.close();
 		}
 	}


### PR DESCRIPTION
Adds a null check around the pubsub clients in the AfterClass block if the test does not get run.

This is necessary because assumeThat can skip a test and will skip all the variable initialization that is done in `BeforeClass`. In this case, the `AfterClass` block must check the variables are not null before using since they may not have been initialized in BeforeClass.