### PR TITLE
Move SQL sample tests to be under 1 database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ before_install:
         INTEGRATION_TEST_FLAGS="${INTEGRATION_TEST_FLAGS} -Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
             -Dit.cloudsql=true -Dit.datastore=true
             -Dspring.cloud.gcp.sql.instance-connection-name=spring-cloud-gcp-ci:us-central1:testmysql
+            -Dspring.cloud.gcp.sql.database-name=code_samples_test_db
+            -Dspring.datasource.password=test
             -Dgcs-read-bucket=gcp-storage-bucket-sample-input
             -Dgcs-write-bucket=gcp-storage-bucket-sample-output
             -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample";

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/ApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/ApplicationTests.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.rule.OutputCapture;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.Matchers.is;
@@ -33,20 +33,18 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 /**
+ * This test verifies that the jpa-sample works.
+ *
+ * Run with: mvn -Dit.cloudsql test
+ *
+ * The test will inherit the properties set in resources/application.properties.
+ *
  * @author Mike Eltsufin
  * @author Dmitry Solomakha
- */
-
-
-/*
-	This tests verifies that the jpa-sample works.
-	In order to run it, use the following parameters:
-
-	-Dit.cloudsql=true -Dspring.cloud.gcp.sql.database-name=[...]
-	-Dspring.cloud.gcp.sql.instance-connection-name=[...] -Dspring.datasource.password=[...]
+ * @author Daniel Zou
  */
 @RunWith(SpringRunner.class)
-@TestPropertySource("classpath:application-test.properties")
+@PropertySource("classpath:application.properties")
 @SpringBootTest(classes = {DemoApplication.class})
 public class ApplicationTests {
 	@BeforeClass

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/ApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/ApplicationTests.java
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.rule.OutputCapture;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.Matchers.is;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/ApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/ApplicationTests.java
@@ -44,7 +44,6 @@ import static org.junit.Assume.assumeThat;
  * @author Daniel Zou
  */
 @RunWith(SpringRunner.class)
-@PropertySource("classpath:application.properties")
 @SpringBootTest(classes = {DemoApplication.class})
 public class ApplicationTests {
 	@BeforeClass

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/resources/application-test.properties
@@ -1,2 +1,0 @@
-spring.cloud.gcp.sql.database-name=houses
-spring.datasource.password=test

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/test/java/com/example/SqlApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/test/java/com/example/SqlApplicationTests.java
@@ -28,11 +28,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,16 +40,15 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assume.assumeThat;
 
 /**
- * Simple integration test to verify the SQL sample application.
+ * Simple integration test to verify the SQL sample application. This test will use the
+ * properties set in resources/application.properties.
  *
- * Run with: mvn -Dit.cloudsql -Dspring.cloud.gcp.sql.database-name=[...]
- * -Dspring.cloud.gcp.sql.instance-connection-name=[...]
- * -Dspring.datasource.password=[...] test
+ * Run with: mvn -Dit.cloudsql test
  *
  * @author Daniel Zou
  */
 @RunWith(SpringRunner.class)
-@TestPropertySource("classpath:application-test.properties")
+@PropertySource("classpath:application.properties")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { SqlApplication.class })
 public class SqlApplicationTests {
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/test/java/com/example/SqlApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/test/java/com/example/SqlApplicationTests.java
@@ -28,7 +28,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -48,7 +47,6 @@ import static org.junit.Assume.assumeThat;
  * @author Daniel Zou
  */
 @RunWith(SpringRunner.class)
-@PropertySource("classpath:application.properties")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { SqlApplication.class })
 public class SqlApplicationTests {
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/test/resources/application-test.properties
@@ -1,2 +1,0 @@
-spring.cloud.gcp.sql.database-name=sql_sample_test_users
-spring.datasource.password=test


### PR DESCRIPTION
This moves the SQL sample tests to a single database under the spring-cloud-gcp-ci project.

The purpose of doing this is to have the properties be set in travis.yml and have the tests inherit from the `application.properties` that users modify. This way allows the tests to work for users who want to try out the test.

Fixes #1125.