### PR TITLE
Fix SQL configuration test breakage

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfigurationMockTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfigurationMockTests.java
@@ -45,8 +45,9 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 
 	@Test
 	public void testCloudSqlDataSourceTest() {
-		this.contextRunner.withPropertyValues("spring.cloud.gcp.sql.instanceConnectionName="
-				+ "tubular-bells:singapore:test-instance")
+		this.contextRunner.withPropertyValues(
+				"spring.cloud.gcp.sql.instanceConnectionName=tubular-bells:singapore:test-instance",
+				"spring.datasource.password=")
 				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
@@ -67,7 +68,8 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 	public void testCloudSqlAppEngineDataSourceTest() {
 		this.contextRunner.withPropertyValues(
 				"spring.cloud.gcp.project-id=im-not-used-for-anything",
-				"spring.cloud.gcp.sql.instanceConnectionName=tubular-bells:australia:test-instance")
+				"spring.cloud.gcp.sql.instanceConnectionName=tubular-bells:australia:test-instance",
+				"spring.datasource.password=")
 				.withSystemProperties(
 						"com.google.appengine.runtime.version=Google App Engine/Some Server")
 				.run(context -> {


### PR DESCRIPTION
This is a patch for the SQL configuration tests to override properties provided by Travis.

Basically for the SQL integration tests, we added `-Dspring.datasource.password=test` in the Travis command line for running the integration tests. The properties are also used by the autoconfiguration tests, and these broke when Travis ran them with the additional properties.

@meltsufin - Should we look into modifying the Travis build somehow to better separate these two environments (i.e. split out a Unit test env and an Integration test env)?
