### PR TITLE
Datastore ancestors key check fix

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactory.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactory.java
@@ -97,7 +97,7 @@ public class DatastoreServiceObjectToKeyFactory implements ObjectToKeyFactory {
 
 		KeyFactory keyFactory = getKeyFactory().setKind(datastorePersistentEntity.kindName());
 		Class idPropType = idProp.getType();
-		if (ancestors != null) {
+		if (ancestors != null && ancestors.length > 0) {
 			if (!idPropType.equals(Key.class)) {
 				throw new DatastoreDataException("Only Key types are allowed for descendants id");
 			}

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
@@ -143,11 +143,12 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 		this.expectedEx.expectMessage("Only Key types are allowed for descendants id");
 
 		TestEntityWithId testEntityWithId = new TestEntityWithId();
-
-		when(this.datastore.newKeyFactory()).thenReturn(new KeyFactory("project"));
+		KeyFactory keyFactory = new KeyFactory("project").setKind("kind");
+		when(this.datastore.newKeyFactory()).thenReturn(keyFactory);
 		this.datastoreServiceObjectToKeyFactory
 				.allocateKeyForObject(testEntityWithId, this.datastoreMappingContext
-						.getPersistentEntity(testEntityWithId.getClass()));
+						.getPersistentEntity(testEntityWithId.getClass()),
+						keyFactory.newKey("ancestor"));
 	}
 
 	@org.springframework.cloud.gcp.data.datastore.core.mapping.Entity(name = "custom_test_kind")


### PR DESCRIPTION
Fixes bug where we try to make ancestors even if none are given.