### PR TITLE
Spanner admin template doesn't check database exists as often

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/it/SpannerTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/it/SpannerTemplateIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gcp.data.spanner.core.it;
 
 import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.KeySet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,6 +45,9 @@ public class SpannerTemplateIntegrationTests extends AbstractSpannerIntegrationT
 
 	@Test
 	public void insertAndDeleteSequence() {
+
+		this.spannerOperations.delete(Trade.class, KeySet.all());
+
 		assertThat(this.spannerOperations.count(Trade.class), is(0L));
 
 		Trade trade = Trade.aTrade();

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -69,6 +69,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 
 	@Test
 	public void queryMethodsTest() {
+		this.tradeRepository.deleteAll();
 		List<Trade> trader1BuyTrades = insertTrades("trader1", "BUY", 3);
 		List<Trade> trader1SellTrades = insertTrades("trader1", "SELL", 2);
 		List<Trade> trader2Trades = insertTrades("trader2", "SELL", 3);

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
@@ -20,8 +20,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -95,15 +94,12 @@ public abstract class AbstractSpannerIntegrationTest {
 	private boolean setupFailed;
 
 	@BeforeClass
-	public static void checkToRun() {
+	public void setup() {
 		assumeThat(
 				"Spanner integration tests are disabled. Please use '-Dit.spanner=true' "
 						+ "to enable them. ",
 				System.getProperty("it.spanner"), is("true"));
-	}
 
-	@Before
-	public void setup() {
 		try {
 			createDatabaseWithSchema();
 		}
@@ -150,7 +146,7 @@ public abstract class AbstractSpannerIntegrationTest {
 				.getDropTableDdlStringsForInterleavedHierarchy(Trade.class);
 	}
 
-	@After
+	@AfterClass
 	public void clean() {
 		try {
 			// this is to reduce duplicated errors reported by surefire plugin

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractSpannerIntegrationTest {
 
 	private static boolean tablesInitialized;
 
-	private static boolean tablesCleanedUp;
+	private static int initializeAttempts;
 
 	@BeforeClass
 	public static void checkToRun() {
@@ -109,6 +109,7 @@ public abstract class AbstractSpannerIntegrationTest {
 	@Before
 	public void setup() {
 		try {
+			initializeAttempts++;
 			if (tablesInitialized) {
 				return;
 			}
@@ -162,12 +163,12 @@ public abstract class AbstractSpannerIntegrationTest {
 	public void clean() {
 		try {
 			// this is to reduce duplicated errors reported by surefire plugin
-			if (setupFailed || tablesCleanedUp) {
+			if (setupFailed || initializeAttempts > 0) {
+				initializeAttempts--;
 				return;
 			}
 			this.spannerDatabaseAdminTemplate.executeDdlStrings(dropSchemaStatements(),
 					false);
-			tablesCleanedUp = true;
 			LOGGER.debug("Integration database cleaned up!");
 		}
 		finally {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
@@ -38,7 +38,6 @@ import org.springframework.test.context.ContextConfiguration;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 /**
@@ -122,19 +121,20 @@ public abstract class AbstractSpannerIntegrationTest {
 		String tableName = this.spannerMappingContext.getPersistentEntity(Trade.class)
 				.tableName();
 
+		List<String> createStatements = createSchemaStatements();
+
 		if (!this.spannerDatabaseAdminTemplate.databaseExists()) {
 			assertFalse(this.spannerDatabaseAdminTemplate.tableExists(tableName));
 			LOGGER.debug(
 					this.getClass() + " - Integration database created with schema: "
-							+ createSchemaStatements());
+							+ createStatements);
+			this.spannerDatabaseAdminTemplate.executeDdlStrings(createStatements, true);
 		}
 		else {
 			LOGGER.debug(
-					this.getClass() + " - schema created: " + createSchemaStatements());
+					this.getClass() + " - schema created: " + createStatements);
+			this.spannerDatabaseAdminTemplate.executeDdlStrings(createStatements, false);
 		}
-		this.spannerDatabaseAdminTemplate.executeDdlStrings(createSchemaStatements(),
-				true);
-		assertTrue(this.spannerDatabaseAdminTemplate.tableExists(tableName));
 	}
 
 	protected List<String> createSchemaStatements() {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -37,7 +38,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 /**
@@ -112,19 +113,21 @@ public abstract class AbstractSpannerIntegrationTest {
 		}
 	}
 
+	@Test
+	public void tableCreatedTest() {
+		assertTrue(this.spannerDatabaseAdminTemplate.tableExists(
+				this.spannerMappingContext.getPersistentEntity(Trade.class).tableName()));
+	}
+
 	protected void createDatabaseWithSchema() {
 		this.tableNameSuffix = String.valueOf(System.currentTimeMillis());
 		ConfigurableListableBeanFactory beanFactory =
 				((ConfigurableApplicationContext) this.applicationContext).getBeanFactory();
 		beanFactory.registerSingleton("tableNameSuffix", this.tableNameSuffix);
 
-		String tableName = this.spannerMappingContext.getPersistentEntity(Trade.class)
-				.tableName();
-
 		List<String> createStatements = createSchemaStatements();
 
 		if (!this.spannerDatabaseAdminTemplate.databaseExists()) {
-			assertFalse(this.spannerDatabaseAdminTemplate.tableExists(tableName));
 			LOGGER.debug(
 					this.getClass() + " - Integration database created with schema: "
 							+ createStatements);


### PR DESCRIPTION
fixes #1149

Doesn't check for database existence as often to reduce calls to that API.

This reduces several usages of databaseExists and tableExists, which both need to get the list of databases.