### PR TITLE
Re-enable RequireThis checkstyle check

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageDisableTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageDisableTests.java
@@ -40,7 +40,7 @@ public class GcpStorageDisableTests {
 
 	@Test
 	public void testStorageBeanIsNotProvided() {
-		contextRunner.run(context -> {
+		this.contextRunner.run(context -> {
 			Throwable thrown = catchThrowable(() -> context.getBean(Storage.class));
 			assertThat(thrown).isInstanceOf(NoSuchBeanDefinitionException.class);
 		});

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTransactionManagerTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTransactionManagerTests.java
@@ -64,7 +64,7 @@ public class DatastoreTransactionManagerTests {
 		this.manager = new DatastoreTransactionManager(this.datastore) {
 			@Override
 			protected Tx getCurrentTX() {
-				return tx;
+				return DatastoreTransactionManagerTests.this.tx;
 			}
 		};
 	}

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -80,7 +80,7 @@ public class PartTreeDatastoreQueryTests {
 		when(this.spannerTemplate.getDatastoreEntityConverter())
 				.thenReturn(this.datastoreEntityConverter);
 		when(this.datastoreEntityConverter.getConversions())
-				.thenReturn(readWriteConversions);
+				.thenReturn(this.readWriteConversions);
 	}
 
 	private PartTreeDatastoreQuery<Trade> createQuery() {

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerQueryOptions.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerQueryOptions.java
@@ -58,7 +58,7 @@ public class SpannerQueryOptions {
 	}
 
 	public Set<String> getIncludeProperties() {
-		return includeProperties;
+		return this.includeProperties;
 	}
 
 	public SpannerQueryOptions setIncludeProperties(Set<String> includeProperties) {

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerReadOptions.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerReadOptions.java
@@ -59,7 +59,7 @@ public class SpannerReadOptions {
 	}
 
 	public Set<String> getIncludeProperties() {
-		return includeProperties;
+		return this.includeProperties;
 	}
 
 	public SpannerReadOptions setIncludeProperties(Set<String> includeProperties) {

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/AbstractSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/AbstractSpannerQuery.java
@@ -65,7 +65,7 @@ abstract class AbstractSpannerQuery<T> implements RepositoryQuery {
 		if (simpleConvertedType != null) {
 			return convertToSimpleReturnType(results, simpleConvertedType);
 		}
-		if (queryMethod.isCollectionQuery()) {
+		if (this.queryMethod.isCollectionQuery()) {
 			return applyProjection(results);
 		}
 		return results == null || results.isEmpty() ? null

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
@@ -69,7 +69,7 @@ public class PubSubExtendedBindingsPropertiesTests {
 
 	@Test
 	public void testExtendedPropertiesOverrideDefaults() {
-		BinderFactory binderFactory = context.getBeanFactory().getBean(BinderFactory.class);
+		BinderFactory binderFactory = this.context.getBeanFactory().getBean(BinderFactory.class);
 		PubSubMessageChannelBinder binder = (PubSubMessageChannelBinder) binderFactory.getBinder("pubsub",
 				MessageChannel.class);
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
@@ -293,11 +293,11 @@ public class PubSubAdmin implements AutoCloseable {
 
 	@Override
 	public void close() throws Exception {
-		if (topicAdminClient != null) {
-			topicAdminClient.close();
+		if (this.topicAdminClient != null) {
+			this.topicAdminClient.close();
 		}
-		if (subscriptionAdminClient != null) {
-			subscriptionAdminClient.close();
+		if (this.subscriptionAdminClient != null) {
+			this.subscriptionAdminClient.close();
 		}
 	}
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerRepositoryTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerRepositoryTests.java
@@ -79,18 +79,18 @@ public class SpannerRepositoryTests {
 	@Before
 	@After
 	public void cleanupAndSetupTables() {
-		spannerRepositoryExample.createTablesIfNotExists();
+		this.spannerRepositoryExample.createTablesIfNotExists();
 		this.tradeRepository.deleteAll();
 		this.traderRepository.deleteAll();
 	}
 
 	@Test
 	public void testRestEndpoint() {
-		spannerRepositoryExample.runExample();
+		this.spannerRepositoryExample.runExample();
 
 		TestRestTemplate testRestTemplate = new TestRestTemplate();
 		ResponseEntity<PagedResources<Trade>> tradesResponse = testRestTemplate.exchange(
-				String.format("http://localhost:%s/trades/", port),
+				String.format("http://localhost:%s/trades/", this.port),
 				HttpMethod.GET,
 				null,
 				new ParameterizedTypeReference<PagedResources<Trade>>() {
@@ -100,21 +100,21 @@ public class SpannerRepositoryTests {
 
 	@Test
 	public void testLoadsCorrectData() {
-		assertThat(traderRepository.count()).isEqualTo(0);
-		assertThat(tradeRepository.count()).isEqualTo(0);
+		assertThat(this.traderRepository.count()).isEqualTo(0);
+		assertThat(this.tradeRepository.count()).isEqualTo(0);
 
-		spannerRepositoryExample.runExample();
-		List<String> traderIds = ImmutableList.copyOf(traderRepository.findAll())
+		this.spannerRepositoryExample.runExample();
+		List<String> traderIds = ImmutableList.copyOf(this.traderRepository.findAll())
 				.stream()
 				.map(Trader::getTraderId)
 				.collect(Collectors.toList());
 		assertThat(traderIds).containsExactlyInAnyOrder("demo_trader1", "demo_trader2", "demo_trader3");
 
-		List<Trade> actualTrades = ImmutableList.copyOf(tradeRepository.findAll());
+		List<Trade> actualTrades = ImmutableList.copyOf(this.tradeRepository.findAll());
 		assertThat(actualTrades).hasSize(8);
 
 		Set<String> tradeSpannerKeys = actualTrades.stream()
-				.map(t -> spannerSchemaUtils.getKey(t).toString())
+				.map(t -> this.spannerSchemaUtils.getKey(t).toString())
 				.collect(Collectors.toSet());
 		assertThat(tradeSpannerKeys).containsExactlyInAnyOrder(
 				"[demo_trader1,1]",

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerTemplateTests.java
@@ -63,7 +63,7 @@ public class SpannerTemplateTests {
 	@Before
 	@After
 	public void cleanupSpannerTables() {
-		spannerTemplateExample.createTablesIfNotExists();
+		this.spannerTemplateExample.createTablesIfNotExists();
 		this.spannerOperations.delete(Trader.class, KeySet.all());
 		this.spannerOperations.delete(Trade.class, KeySet.all());
 	}
@@ -72,11 +72,11 @@ public class SpannerTemplateTests {
 	public void testSpannerTemplateLoadsData() {
 		assertThat(this.spannerOperations.readAll(Trade.class)).isEmpty();
 
-		spannerTemplateExample.runExample();
+		this.spannerTemplateExample.runExample();
 
 		Set<String> tradeSpannerKeys = this.spannerOperations.readAll(Trade.class)
 				.stream()
-				.map(t -> spannerSchemaUtils.getKey(t).toString())
+				.map(t -> this.spannerSchemaUtils.getKey(t).toString())
 				.collect(Collectors.toSet());
 
 		assertThat(tradeSpannerKeys).containsExactlyInAnyOrder(

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/test/java/com/example/PubSubJsonPayloadApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/test/java/com/example/PubSubJsonPayloadApplicationTests.java
@@ -60,7 +60,7 @@ public class PubSubJsonPayloadApplicationTests {
 	@Test
 	public void testReceivesJsonPayload() {
 		TestMessageConsumer messageConsumer = new TestMessageConsumer();
-		pubSubTemplate.subscribeAndConvert(SUBSCRIPTION_NAME, messageConsumer, Person.class);
+		this.pubSubTemplate.subscribeAndConvert(SUBSCRIPTION_NAME, messageConsumer, Person.class);
 
 		ImmutableMap<String, String> params = ImmutableMap.of(
 				"name", "Bob",
@@ -85,11 +85,11 @@ public class PubSubJsonPayloadApplicationTests {
 			message.ack();
 			assertThat(person.name).isEqualTo("Bob");
 			assertThat(person.age).isEqualTo(25);
-			messageHasBeenProcessed = true;
+			this.messageHasBeenProcessed = true;
 		}
 
 		public boolean isMessageProcessed() {
-			return messageHasBeenProcessed;
+			return this.messageHasBeenProcessed;
 		}
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/java/com/example/GcsSpringIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/java/com/example/GcsSpringIntegrationTests.java
@@ -95,13 +95,13 @@ public class GcsSpringIntegrationTests {
 
 	@Test
 	public void testFilePropagatedToLocalDirectory() {
-		BlobId blobId = BlobId.of(cloudInputBucket, TEST_FILE_NAME);
+		BlobId blobId = BlobId.of(this.cloudInputBucket, TEST_FILE_NAME);
 		BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
-		Blob blob = storage.create(blobInfo, "Hello World!".getBytes(StandardCharsets.UTF_8));
+		Blob blob = this.storage.create(blobInfo, "Hello World!".getBytes(StandardCharsets.UTF_8));
 
 		Awaitility.await().atMost(15, TimeUnit.SECONDS)
 				.untilAsserted(() -> {
-					Path outputFile = Paths.get(outputFolder + "/" + TEST_FILE_NAME);
+					Path outputFile = Paths.get(this.outputFolder + "/" + TEST_FILE_NAME);
 					assertThat(Files.exists(outputFile)).isTrue();
 					assertThat(Files.isRegularFile(outputFile)).isTrue();
 
@@ -109,7 +109,7 @@ public class GcsSpringIntegrationTests {
 					assertThat(firstLine).isEqualTo("Hello World!");
 
 					List<String> blobNamesInOutputBucket = ImmutableList
-							.copyOf(storage.list(cloudOutputBucket).iterateAll())
+							.copyOf(this.storage.list(this.cloudOutputBucket).iterateAll())
 							.stream()
 							.map(Blob::getName)
 							.collect(Collectors.toList());
@@ -118,18 +118,18 @@ public class GcsSpringIntegrationTests {
 	}
 
 	private void cleanupCloudStorage() {
-		Page<Blob> blobs = storage.list(cloudInputBucket);
+		Page<Blob> blobs = this.storage.list(this.cloudInputBucket);
 		for (Blob blob : blobs.iterateAll()) {
 			blob.delete();
 		}
 	}
 
 	private void cleanupLocalDirectory() throws IOException {
-		Path localDirectory = Paths.get(outputFolder);
+		Path localDirectory = Paths.get(this.outputFolder);
 		List<Path> files = Files.list(localDirectory).collect(Collectors.toList());
 		for (Path file : files) {
 			Files.delete(file);
 		}
-		Files.deleteIfExists(Paths.get(outputFolder));
+		Files.deleteIfExists(Paths.get(this.outputFolder));
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
@@ -81,7 +81,7 @@ public class LoggingSampleApplicationTests {
 
 	@Test
 	public void testLogRecordedInStackDriver() {
-		String url = String.format("http://localhost:%s/log", port);
+		String url = String.format("http://localhost:%s/log", this.port);
 		String traceHeader = "gcp-logging-test-" + Instant.now().toEpochMilli();
 
 		HttpHeaders headers = new HttpHeaders();

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
@@ -136,7 +136,7 @@ public class WebController {
 			message.ack();
 		});
 
-		allSubscribers.add(subscriber);
+		this.allSubscribers.add(subscriber);
 		return buildStatusView("Subscribed.");
 	}
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
@@ -227,10 +227,10 @@ public class PubSubApplicationTests {
 	}
 
 	private void createTopic(String topicName) {
-		String url = UriComponentsBuilder.fromHttpUrl(appUrl + "/createTopic")
+		String url = UriComponentsBuilder.fromHttpUrl(this.appUrl + "/createTopic")
 				.queryParam("topicName", topicName)
 				.toUriString();
-		ResponseEntity<String> response = testRestTemplate.postForEntity(url, null, String.class);
+		ResponseEntity<String> response = this.testRestTemplate.postForEntity(url, null, String.class);
 
 		String projectTopicName = ProjectTopicName.format(projectName, topicName);
 		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
@@ -241,10 +241,10 @@ public class PubSubApplicationTests {
 	}
 
 	private void deleteTopic(String topicName) {
-		String url = UriComponentsBuilder.fromHttpUrl(appUrl + "/deleteTopic")
+		String url = UriComponentsBuilder.fromHttpUrl(this.appUrl + "/deleteTopic")
 				.queryParam("topic", topicName)
 				.toUriString();
-		testRestTemplate.postForEntity(url, null, String.class);
+		this.testRestTemplate.postForEntity(url, null, String.class);
 
 		String projectTopicName = ProjectTopicName.format(projectName, topicName);
 		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
@@ -255,11 +255,11 @@ public class PubSubApplicationTests {
 	}
 
 	private void createSubscription(String subscriptionName, String topicName) {
-		String url = UriComponentsBuilder.fromHttpUrl(appUrl + "/createSubscription")
+		String url = UriComponentsBuilder.fromHttpUrl(this.appUrl + "/createSubscription")
 				.queryParam("topicName", topicName)
 				.queryParam("subscriptionName", subscriptionName)
 				.toUriString();
-		testRestTemplate.postForEntity(url, null, String.class);
+		this.testRestTemplate.postForEntity(url, null, String.class);
 
 		String projectSubscriptionName = ProjectSubscriptionName.format(projectName, subscriptionName);
 		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
@@ -270,10 +270,10 @@ public class PubSubApplicationTests {
 	}
 
 	private void deleteSubscription(String subscriptionName) {
-		String url = UriComponentsBuilder.fromHttpUrl(appUrl + "/deleteSubscription")
+		String url = UriComponentsBuilder.fromHttpUrl(this.appUrl + "/deleteSubscription")
 				.queryParam("subscription", subscriptionName)
 				.toUriString();
-		testRestTemplate.postForEntity(url, null, String.class);
+		this.testRestTemplate.postForEntity(url, null, String.class);
 
 		String projectSubscriptionName = ProjectSubscriptionName.format(projectName, subscriptionName);
 		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
@@ -284,27 +284,27 @@ public class PubSubApplicationTests {
 	}
 
 	private void subscribe(String subscriptionName) {
-		String url = UriComponentsBuilder.fromHttpUrl(appUrl + "/subscribe")
+		String url = UriComponentsBuilder.fromHttpUrl(this.appUrl + "/subscribe")
 				.queryParam("subscription", subscriptionName)
 				.toUriString();
-		testRestTemplate.getForEntity(url, null, String.class);
+		this.testRestTemplate.getForEntity(url, null, String.class);
 	}
 
 	private void postMessage(String message, String topicName) {
-		String url = UriComponentsBuilder.fromHttpUrl(appUrl + "/postMessage")
+		String url = UriComponentsBuilder.fromHttpUrl(this.appUrl + "/postMessage")
 				.queryParam("message", message)
 				.queryParam("topicName", topicName)
 				.queryParam("count", 1)
 				.toUriString();
-		testRestTemplate.getForEntity(url, null, String.class);
+		this.testRestTemplate.getForEntity(url, null, String.class);
 	}
 
 	private void multiPull(String subscription1, String subscription2) {
-		String url = UriComponentsBuilder.fromHttpUrl(appUrl + "/multipull")
+		String url = UriComponentsBuilder.fromHttpUrl(this.appUrl + "/multipull")
 				.queryParam("subscription1", subscription1)
 				.queryParam("subscription2", subscription2)
 				.toUriString();
-		testRestTemplate.getForEntity(url, null, String.class);
+		this.testRestTemplate.getForEntity(url, null, String.class);
 	}
 
 	private static List<String> getTopicNamesFromProject() {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/test/java/com/example/SqlApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/src/test/java/com/example/SqlApplicationTests.java
@@ -69,13 +69,13 @@ public class SqlApplicationTests {
 
 	@After
 	public void clearTable() {
-		jdbcTemplate.execute("DROP TABLE IF EXISTS users");
+		this.jdbcTemplate.execute("DROP TABLE IF EXISTS users");
 	}
 
 	@Test
 	public void testSqlRowsAccess() {
-		String url = String.format("http://localhost:%s/getTuples", port);
-		ResponseEntity<List<String>> result = testRestTemplate.exchange(
+		String url = String.format("http://localhost:%s/getTuples", this.port);
+		ResponseEntity<List<String>> result = this.testRestTemplate.exchange(
 				url, HttpMethod.GET, null, new ParameterizedTypeReference<List<String>>() {
 				});
 

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -73,6 +73,7 @@
         <module name="MultipleVariableDeclarations"/>
         <module name="RequireThis">
             <property name="checkMethods" value="false"/>
+            <property name="validateOnlyOverlapping" value="false"/>
         </module>
         <module name="OneStatementPerLine"/>
         <module name="ExplicitInitialization"/>


### PR DESCRIPTION
The new version of Checkstyle that we inherit from the Spring Cloud Build parent POM, requires `validateOnlyOverlapping` to be set to `false` in order for the `RequireThis` check to kick-in unconditionally for fields.

@artembilan You might like this. :smile: 