### PR TITLE
Create Separate Subscription in Pub/Sub JSON Test

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/main/java/com/example/Person.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/main/java/com/example/Person.java
@@ -16,6 +16,8 @@
 
 package com.example;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -43,5 +45,23 @@ public class Person {
 				"name='" + name + '\'' +
 				", age=" + age +
 				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		Person person = (Person) o;
+		return this.age == person.age &&
+				Objects.equals(this.name, person.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.name, this.age);
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/main/java/com/example/ReceiverConfiguration.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/main/java/com/example/ReceiverConfiguration.java
@@ -16,6 +16,8 @@
 
 package com.example;
 
+import java.util.ArrayList;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -44,6 +46,8 @@ public class ReceiverConfiguration {
 
 	private static final String SUBSCRIPTION_NAME = "json-payload-sample-subscription";
 
+	private final ArrayList<Person> processedPersonsList = new ArrayList<>();
+
 	@Bean
 	public DirectChannel pubSubInputChannel() {
 		return new DirectChannel();
@@ -64,7 +68,13 @@ public class ReceiverConfiguration {
 	public void messageReceiver(Person payload,
 			@Header(GcpPubSubHeaders.ORIGINAL_MESSAGE) BasicAcknowledgeablePubsubMessage message) {
 		LOGGER.info("Message arrived! Payload: " + payload);
+		this.processedPersonsList.add(payload);
 		message.ack();
 	}
 
+	@Bean
+	@Qualifier("ProcessedPersonsList")
+	public ArrayList<Person> processedPersonsList() {
+		return this.processedPersonsList;
+	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/main/java/com/example/WebController.java
@@ -16,8 +16,14 @@
 
 package com.example;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.example.SenderConfiguration.PubSubPersonGateway;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,6 +40,10 @@ public class WebController {
 
 	private final PubSubPersonGateway pubSubPersonGateway;
 
+	@Autowired
+	@Qualifier("ProcessedPersonsList")
+	private ArrayList<Person> processedPersonsList;
+
 	public WebController(PubSubPersonGateway pubSubPersonGateway) {
 		this.pubSubPersonGateway = pubSubPersonGateway;
 	}
@@ -43,5 +53,10 @@ public class WebController {
 		Person person = new Person(name, age);
 		this.pubSubPersonGateway.sendPersonToPubSub(person);
 		return new RedirectView("/");
+	}
+
+	@GetMapping("/listPersons")
+	public List<Person> listPersons() {
+		return this.processedPersonsList;
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/test/java/com/example/PubSubJsonPayloadApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/test/java/com/example/PubSubJsonPayloadApplicationTests.java
@@ -16,12 +16,12 @@
 
 package com.example;
 
-import com.google.pubsub.v1.Subscription;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.pubsub.v1.Subscription;
+import org.awaitility.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -71,22 +71,22 @@ public class PubSubJsonPayloadApplicationTests {
 
 	@Before
 	public void setupTestSubscription() {
-		testSubscriptionName = SUBSCRIPTION_NAME_PREFIX + UUID.randomUUID();
-		pubSubAdmin.createSubscription(testSubscriptionName, TOPIC_NAME);
+		this.testSubscriptionName = SUBSCRIPTION_NAME_PREFIX + UUID.randomUUID();
+		this.pubSubAdmin.createSubscription(this.testSubscriptionName, TOPIC_NAME);
 	}
 
 	@After
 	public void deleteTestSubscription() {
-		Subscription subscription = pubSubAdmin.getSubscription(testSubscriptionName);
+		Subscription subscription = this.pubSubAdmin.getSubscription(this.testSubscriptionName);
 		if (subscription != null) {
-			pubSubAdmin.deleteSubscription(testSubscriptionName);
+			this.pubSubAdmin.deleteSubscription(this.testSubscriptionName);
 		}
 	}
 
 	@Test
 	public void testReceivesJsonPayload() {
 		TestMessageConsumer messageConsumer = new TestMessageConsumer();
-		this.pubSubTemplate.subscribeAndConvert(testSubscriptionName, messageConsumer, Person.class);
+		this.pubSubTemplate.subscribeAndConvert(this.testSubscriptionName, messageConsumer, Person.class);
 
 		ImmutableMap<String, String> params = ImmutableMap.of(
 				"name", "Bob",
@@ -94,7 +94,7 @@ public class PubSubJsonPayloadApplicationTests {
 		this.testRestTemplate.postForObject(
 				"/createPerson?name={name}&age={age}", null, String.class, params);
 
-		await().atMost(10, TimeUnit.SECONDS).until(() -> messageConsumer.isMessageProcessed());
+		await().atMost(Duration.TEN_SECONDS).until(() -> messageConsumer.isMessageProcessed());
 	}
 
 	/**


### PR DESCRIPTION
This modifies the Pub/Sub JSON Payload test to create a separate test subscription which subscribes to the topic that is producing the messages.

I noticed that if we subscribe to the existing subscription used by the sample app, sometimes we would not receive a message in the test since the message is already acked by the subscriber in the sample application. So this will increase reliability of the test.

Followup to #1152.