### PR TITLE
Anonymous consumer groups in Pub/Sub Binder

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -29,25 +29,45 @@ A https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-
 
 This binder binds producers to Google Cloud Pub/Sub topics and consumers to subscriptions.
 
-NOTE: Partitioning and consumer groups are not currently supported by this binder.
+NOTE: Partitioning is currently not supported by this binder.
 
 === Configuration
 
-You can configure the Spring Cloud Stream Binder for Google Cloud Pub/Sub to automatically generate the underlying resources, like the Google Cloud Pub/Sub subscriptions for the consumers.
-For that, you can use the `spring.cloud.stream.gcp.pubsub.bindings.[CHANNEL-NAME].consumer.auto-create-resources` property, which is turned ON by default.
+You can configure the Spring Cloud Stream Binder for Google Cloud Pub/Sub to automatically generate the underlying resources, like the Google Cloud Pub/Sub topics and subscriptions for producers and consumers.
+For that, you can use the `spring.cloud.stream.gcp.pubsub.bindings.<channelName>.<consumer|producer>.auto-create-resources` property, which is turned ON by default.
 
-If automatic resource creation is turned ON and the subscription and the topic do not exist for a consumer, a subscription and a topic will be created with the same name.
-For example, for the following configuration, a topic and a subscription called `myConsumer` would be created.
-
-.application.properties
-----
-spring.cloud.stream.bindings.output.destination=myConsumer
-
-spring.cloud.stream.gcp.pubsub.bindings.output.consumer.auto-create-resources=true
-----
-
-Starting with version 1.1, these properties can be configured globally for all the bindings, e.g. `spring.cloud.stream.gcp.pubsub.default.consumer.auto-create-resources`.
+Starting with version 1.1, these and other binder properties can be configured globally for all the bindings, e.g. `spring.cloud.stream.gcp.pubsub.default.consumer.auto-create-resources`.
 
 If you are using Pub/Sub auto-configuration from the Spring Cloud GCP Pub/Sub Starter, you should refer to the <<pubsub-configuration,configuration>> section for other Pub/Sub parameters.
 
 NOTE: To use this binder with a https://cloud.google.com/pubsub/docs/emulator[running emulator], configure its host and port via `spring.cloud.gcp.pubsub.emulator-host`.
+
+==== Producer Destination Configuration
+
+If automatic resource creation is turned ON and the topic corresponding to the destination name does not exist, it will be created.
+
+For example, for the following configuration, a topic called `myEvents` would be created.
+
+.application.properties
+----
+spring.cloud.stream.bindings.events.destination=myEvents
+spring.cloud.stream.gcp.pubsub.bindings.events.producer.auto-create-resources=true
+----
+
+==== Consumer Destination Configuration
+
+If automatic resource creation is turned ON and the subscription and/or the topic do not exist for a consumer, a subscription and potentially a topic will be created.
+The topic name will be the same as the destination name, and the subscription name will be the same as the consumer group name.
+If the consumer group is not specified, an anonymous one will be created with the name `anonymous.<destinationName>.<randomUUID>`.
+
+For example, for the following configuration, a topic named `myEvents` and a subscription called `counsumerGroup1` would be created.
+If the consumer group is not specified, a subscription called `anonymous.myEvents.a6d83782-c5a3-4861-ac38-e6e2af15a7be` would be created.
+
+.application.properties
+----
+spring.cloud.stream.bindings.events.destination=myEvents
+spring.cloud.stream.gcp.pubsub.bindings.events.consumer.auto-create-resources=true
+
+# specify consumer group, and avoid anonymous consumer group generation
+spring.cloud.stream.bindings.events.group=consumerGroup1
+----

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -57,10 +57,10 @@ spring.cloud.stream.gcp.pubsub.bindings.events.producer.auto-create-resources=tr
 ==== Consumer Destination Configuration
 
 If automatic resource creation is turned ON and the subscription and/or the topic do not exist for a consumer, a subscription and potentially a topic will be created.
-The topic name will be the same as the destination name, and the subscription name will be the same as the consumer group name.
+The topic name will be the same as the destination name, and the subscription name will be the destination name followed by the consumer group name.
 If the consumer group is not specified, an anonymous one will be created with the name `anonymous.<destinationName>.<randomUUID>`.
 
-For example, for the following configuration, a topic named `myEvents` and a subscription called `counsumerGroup1` would be created.
+For example, for the following configuration, a topic named `myEvents` and a subscription called `myEvents.counsumerGroup1` would be created.
 If the consumer group is not specified, a subscription called `anonymous.myEvents.a6d83782-c5a3-4861-ac38-e6e2af15a7be` would be created.
 
 .application.properties

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -57,10 +57,10 @@ spring.cloud.stream.gcp.pubsub.bindings.events.producer.auto-create-resources=tr
 ==== Consumer Destination Configuration
 
 If automatic resource creation is turned ON and the subscription and/or the topic do not exist for a consumer, a subscription and potentially a topic will be created.
-The topic name will be the same as the destination name, and the subscription name will be the destination name followed by the consumer group name.
+The topic name will be the same as the destination name, and the subscription name will be the same as the consumer group name.
 If the consumer group is not specified, an anonymous one will be created with the name `anonymous.<destinationName>.<randomUUID>`.
 
-For example, for the following configuration, a topic named `myEvents` and a subscription called `myEvents.counsumerGroup1` would be created.
+For example, for the following configuration, a topic named `myEvents` and a subscription called `counsumerGroup1` would be created.
 If the consumer group is not specified, a subscription called `anonymous.myEvents.a6d83782-c5a3-4861-ac38-e6e2af15a7be` would be created.
 
 .application.properties

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -62,7 +62,7 @@ public class PubSubChannelProvisioner
 		// Generate anonymous random group, if one not provided
 		String subscription = !StringUtils.hasText(group) ?
 				"anonymous." + name + "." + UUID.randomUUID().toString()
-				: group;
+				: name + "." + group;
 
 		if (this.pubSubAdmin.getSubscription(subscription) == null) {
 			if (properties.getExtension().isAutoCreateResources()) {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 original author or authors.
+ *  Copyright 2017-2018 original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.provisioning;
 
+import java.util.UUID;
+
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
@@ -25,9 +27,11 @@ import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
 import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
+import org.springframework.util.StringUtils;
 
 /**
  * @author João André Martins
+ * @author Mike Eltsufin
  */
 public class PubSubChannelProvisioner
 		implements ProvisioningProvider<ExtendedConsumerProperties<PubSubConsumerProperties>,
@@ -54,8 +58,10 @@ public class PubSubChannelProvisioner
 	public ConsumerDestination provisionConsumerDestination(String name, String group,
 			ExtendedConsumerProperties<PubSubConsumerProperties> properties)
 			throws ProvisioningException {
+		// Use group name as subscription name
+		// Generate anonymous random group, if one not provided
+		String subscription = !StringUtils.hasText(group) ? "anonymous." + UUID.randomUUID().toString() : group;
 
-		String subscription = group == null ? name : (name + '.' + group);
 		if (this.pubSubAdmin.getSubscription(subscription) == null) {
 			if (properties.getExtension().isAutoCreateResources()) {
 				if (this.pubSubAdmin.getTopic(name) == null) {
@@ -65,7 +71,7 @@ public class PubSubChannelProvisioner
 				this.pubSubAdmin.createSubscription(subscription, name);
 			}
 			else {
-				throw new ProvisioningException("Unexisting '" + subscription + "' subscription.");
+				throw new ProvisioningException("Non-existing '" + subscription + "' subscription.");
 			}
 		}
 		return new PubSubConsumerDestination(subscription);

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -60,7 +60,9 @@ public class PubSubChannelProvisioner
 			throws ProvisioningException {
 		// Use group name as subscription name
 		// Generate anonymous random group, if one not provided
-		String subscription = !StringUtils.hasText(group) ? "anonymous." + UUID.randomUUID().toString() : group;
+		String subscription = !StringUtils.hasText(group) ?
+				"anonymous." + name + "." + UUID.randomUUID().toString()
+				: group;
 
 		if (this.pubSubAdmin.getSubscription(subscription) == null) {
 			if (properties.getExtension().isAutoCreateResources()) {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -62,7 +62,7 @@ public class PubSubChannelProvisioner
 		// Generate anonymous random group, if one not provided
 		String subscription = !StringUtils.hasText(group) ?
 				"anonymous." + name + "." + UUID.randomUUID().toString()
-				: name + "." + group;
+				: group;
 
 		if (this.pubSubAdmin.getSubscription(subscription) == null) {
 			if (properties.getExtension().isAutoCreateResources()) {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -17,9 +17,9 @@
 package org.springframework.cloud.gcp.stream.binder.pubsub;
 
 import org.junit.ClassRule;
-
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
 import org.springframework.cloud.stream.binder.AbstractBinderTests;

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -65,7 +65,6 @@ public class PubSubMessageChannelBinderTests extends
 		// Do nothing. Original test tests for Lifecycle logic that we don't need.
 	}
 
-
 	@Test
 	@Ignore("Subscriptions with the same name for different topics are not allowed by Pub/Sub.")
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.gcp.stream.binder.pubsub;
 
 import org.junit.ClassRule;
 
+import org.junit.Ignore;
+import org.junit.Test;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
 import org.springframework.cloud.stream.binder.AbstractBinderTests;
@@ -61,5 +63,13 @@ public class PubSubMessageChannelBinderTests extends
 	@Override
 	public void testClean() {
 		// Do nothing. Original test tests for Lifecycle logic that we don't need.
+	}
+
+
+	@Test
+	@Ignore("Subscriptions with the same name for different topics are not allowed by Pub/Sub.")
+	@Override
+	public void testSendAndReceiveMultipleTopics() throws Exception {
+		super.testSendAndReceiveMultipleTopics();
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
@@ -33,7 +33,6 @@ import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.cloud.gcp.stream.binder.pubsub.PubSubMessageChannelBinder;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubExtendedBindingsPropertiesTests.PubSubBindingsTestConfiguration;
-import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubExtendedBindingsPropertiesTests.PubSubBindingsTestConfiguration.CustomTestSink;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.StreamListener;
@@ -78,7 +77,7 @@ public class PubSubExtendedBindingsPropertiesTests {
 	}
 
 	@Configuration
-	@EnableBinding(CustomTestSink.class)
+	@EnableBinding(PubSubBindingsTestConfiguration.CustomTestSink.class)
 	static class PubSubBindingsTestConfiguration {
 
 		@Bean

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -70,9 +70,9 @@ public class PubSubChannelProvisionerTests {
 		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
 				.provisionConsumerDestination("topic_A", "group_A", this.properties);
 
-		assertThat(result.getName()).isEqualTo("group_A");
+		assertThat(result.getName()).isEqualTo("topic_A.group_A");
 
-		verify(this.pubSubAdminMock).createSubscription("group_A", "topic_A");
+		verify(this.pubSubAdminMock).createSubscription("topic_A.group_A", "topic_A");
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Mike Eltsufin
+ *
+ * @since 1.1
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PubSubChannelProvisionerTests {
@@ -75,7 +77,7 @@ public class PubSubChannelProvisionerTests {
 
 	@Test
 	public void testProvisionConsumerDestination_anonymousGroup() {
-		String subscriptionNameRegex = "anonymous\\.[a-f0-9\\-]{36}";
+		String subscriptionNameRegex = "anonymous\\.topic_A\\.[a-f0-9\\-]{36}";
 
 		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
 				.provisionConsumerDestination("topic_A", null, this.properties);

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -70,9 +70,9 @@ public class PubSubChannelProvisionerTests {
 		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
 				.provisionConsumerDestination("topic_A", "group_A", this.properties);
 
-		assertThat(result.getName()).isEqualTo("topic_A.group_A");
+		assertThat(result.getName()).isEqualTo("group_A");
 
-		verify(this.pubSubAdminMock).createSubscription("topic_A.group_A", "topic_A");
+		verify(this.pubSubAdminMock).createSubscription("group_A", "topic_A");
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.stream.binder.pubsub.provisioning;
+
+import com.google.pubsub.v1.Subscription;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
+import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Mike Eltsufin
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PubSubChannelProvisionerTests {
+
+	@Mock
+	PubSubAdmin pubSubAdminMock;
+
+	@Mock
+	ExtendedConsumerProperties<PubSubConsumerProperties> properties;
+
+	@Mock
+	PubSubConsumerProperties pubSubConsumerProperties;
+
+	// class under test
+	PubSubChannelProvisioner pubSubChannelProvisioner;
+
+	@Before
+	public void setup() {
+		Subscription subscription = Subscription.newBuilder().build();
+		when(this.pubSubAdminMock.getSubscription(any())).thenReturn(null);
+		when(this.pubSubAdminMock.createSubscription(any(), any())).thenReturn(subscription);
+		when(this.properties.getExtension()).thenReturn(this.pubSubConsumerProperties);
+		when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(true);
+
+		this.pubSubChannelProvisioner = new PubSubChannelProvisioner(this.pubSubAdminMock);
+	}
+
+	@Test
+	public void testProvisionConsumerDestination_specifiedGroup() {
+		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
+				.provisionConsumerDestination("topic_A", "group_A", this.properties);
+
+		assertThat(result.getName()).isEqualTo("group_A");
+
+		verify(this.pubSubAdminMock).createSubscription("group_A", "topic_A");
+	}
+
+	@Test
+	public void testProvisionConsumerDestination_anonymousGroup() {
+		String subscriptionNameRegex = "anonymous\\.[a-f0-9\\-]{36}";
+
+		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
+				.provisionConsumerDestination("topic_A", null, this.properties);
+
+		assertThat(result.getName()).matches(subscriptionNameRegex);
+
+		verify(this.pubSubAdminMock).createSubscription(matches(subscriptionNameRegex), eq("topic_A"));
+	}
+}


### PR DESCRIPTION
When a group is not provided for the consumer destination, generate a
random anonymous one.

This will make the binder compatible with Spring Cloud Bus and its use
of anonymous groups.

Fixes #1172