### PR TITLE
Increase Timeout of Logging Sample Test

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
@@ -92,7 +92,7 @@ public class LoggingSampleApplicationTests {
 
 		String logFilter = String.format(LOG_FILTER_FORMAT, traceHeader);
 
-		await().atMost(40, TimeUnit.SECONDS)
+		await().atMost(60, TimeUnit.SECONDS)
 				.pollInterval(2, TimeUnit.SECONDS)
 				.untilAsserted(() -> {
 					Page<LogEntry> logEntryPage = this.logClient.listLogEntries(
@@ -100,7 +100,6 @@ public class LoggingSampleApplicationTests {
 					ImmutableList<LogEntry> logEntries = ImmutableList.copyOf(logEntryPage.iterateAll());
 
 					List<String> logContents = logEntries.stream()
-							.peek(logEntry -> System.out.println("Found: " + logEntry))
 							.map(logEntry -> ((StringPayload) logEntry.getPayload()).getData())
 							.collect(Collectors.toList());
 


### PR DESCRIPTION
Increase the timeout of the logging sample test due to flaky test failures, such as this: https://travis-ci.org/spring-cloud/spring-cloud-gcp/builds/451517666

Tested on 20 runs with no failures; hopefully this will help.

In reference to #705.