### PR TITLE
Disable shallow git clone in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+git:
+  depth: 9999999
 jdk:
   - oraclejdk8
 env:


### PR DESCRIPTION
Travis sets a git clone depth to 50 by default.

This change makes it effectively unlimited.

Resolves a warning in SonarCloud:
"Shallow clone detected during the analysis. Some files will miss SCM
information. This will affect features like auto-assignment of issues.
Please configure your build to disable shallow clone."