### PR TITLE
Enable Google Cloud IAP authentication through spring security

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,6 +27,7 @@ Currently, this repository provides support for:
 ** link:spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-postgres[Google Cloud SQL PostgreSQL]
 ** link:spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage[Google Cloud Storage]
 ** link:spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace[Stackdriver Trace with Spring Cloud Sleuth]
+** link:spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap[Google Cloud IAP Authentication]
 
 If you have any other ideas, suggestions or bug reports, please use our
 https://github.com/spring-cloud/spring-cloud-gcp/issues[GitHub issue tracker] and let us know!

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -193,6 +193,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>commons-io</groupId>

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -195,8 +195,20 @@
 
         <!-- Security -->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.security;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+
+/**
+ * Configures GCP IAP pre-authentication.
+ * If the property is missing, this auto configuration is skipped.
+ */
+@Configuration
+@ConditionalOnProperty(value = "spring.cloud.gcp.security.iap.enabled", matchIfMissing = false)
+@ConditionalOnClass({NimbusJwtDecoderJwkSupport.class})
+@AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class)
+public class IapAuthenticationAutoConfiguration {
+
+	// TODO: externalize as properties.
+	private static final String PUBLIC_KEY_VERIFICATION_LINK = "https://www.gstatic.com/iap/verify/public_key-jwk";
+
+	private static final String ENCRYPTION_ALGORITHM = "ES256";
+
+	private static final String IAP_HEADER = "x-goog-iap-jwt-assertion";
+
+
+	@Bean
+	@ConditionalOnMissingBean
+	public JwtDecoder iapJwtDecoder() {
+		return new NimbusJwtDecoderJwkSupport(PUBLIC_KEY_VERIFICATION_LINK, ENCRYPTION_ALGORITHM);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public BearerTokenResolver iatTokenResolver() {
+		return r -> r.getHeader(IAP_HEADER);
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.autoconfigure.security;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -54,12 +56,14 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenResolv
 @AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class)
 public class IapAuthenticationAutoConfiguration {
 
-	private static final String PUBLIC_KEY_VERIFICATION_LINK = "https://www.gstatic.com/iap/verify/public_key-jwk";
+	@VisibleForTesting
+	static final String PUBLIC_KEY_VERIFICATION_LINK = "https://www.gstatic.com/iap/verify/public_key-jwk";
 
-	private static final String ENCRYPTION_ALGORITHM = "ES256";
+	@VisibleForTesting
+	static final String ENCRYPTION_ALGORITHM = "ES256";
 
-	private static final String IAP_HEADER = "x-goog-iap-jwt-assertion";
-
+	@VisibleForTesting
+	static final String IAP_HEADER = "x-goog-iap-jwt-assertion";
 
 	@Bean
 	@ConditionalOnMissingBean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
@@ -54,7 +54,6 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenResolv
 @AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class)
 public class IapAuthenticationAutoConfiguration {
 
-	// TODO: externalize as properties.
 	private static final String PUBLIC_KEY_VERIFICATION_LINK = "https://www.gstatic.com/iap/verify/public_key-jwk";
 
 	private static final String ENCRYPTION_ALGORITHM = "ES256";

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.gcp.autoconfigure.security;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -56,14 +54,11 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenResolv
 @AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class)
 public class IapAuthenticationAutoConfiguration {
 
-	@VisibleForTesting
-	static final String PUBLIC_KEY_VERIFICATION_LINK = "https://www.gstatic.com/iap/verify/public_key-jwk";
+	public static final String PUBLIC_KEY_VERIFICATION_LINK = "https://www.gstatic.com/iap/verify/public_key-jwk";
 
-	@VisibleForTesting
-	static final String ENCRYPTION_ALGORITHM = "ES256";
+	public static final String ENCRYPTION_ALGORITHM = "ES256";
 
-	@VisibleForTesting
-	static final String IAP_HEADER = "x-goog-iap-jwt-assertion";
+	public static final String IAP_HEADER = "x-goog-iap-jwt-assertion";
 
 	@Bean
 	@ConditionalOnMissingBean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
@@ -49,7 +49,7 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenResolv
  * @since 1.1
  */
 @Configuration
-@ConditionalOnProperty(value = "spring.cloud.gcp.security.iap.enabled", matchIfMissing = false)
+@ConditionalOnProperty("spring.cloud.gcp.security.iap.enabled")
 @ConditionalOnClass({NimbusJwtDecoderJwkSupport.class})
 @AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class)
 public class IapAuthenticationAutoConfiguration {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
@@ -23,13 +23,30 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 
 /**
- * Configures GCP IAP pre-authentication.
- * If the property is missing, this auto configuration is skipped.
+ * Autoconfiguration for extracting pre-authenticated user identity from Google Cloud IAP header.
+ *
+ * <p>The following conditions must be present for this configuration to take effect:
+ * <ul>
+ *   <li>{@code spring.cloud.gcp.security.iap.enabled} property is true. Note that a missing property is treated as
+ *   {@code false}. Because there is no custom code beyond what Spring Security OAuth provides, no dependency can be
+ *   used as a consistent signal for using IAP authentication, making an explicit property necessary.
+ *   <li>Spring Security OAuth Resource Server 5.0 or higher is present on the classpath.
+ * </ul>
+ * <p>If these conditions are met, a custom {@link BearerTokenResolver} and an ES256 web registry-based JWT token
+ * decoder beans are provided.
+ * <p>If a custom {@link WebSecurityConfigurerAdapter} is present, it must add {@code .oauth2ResourceServer().jwt()}
+ * customization to {@link org.springframework.security.config.annotation.web.builders.HttpSecurity} object. If no
+ * custom {@link WebSecurityConfigurerAdapter} is found,
+ * Spring Boot's default {@code OAuth2ResourceServerWebSecurityConfiguration} will add this customization.
+ *
+ * @author Elena Felder
+ * @since 1.1
  */
 @Configuration
 @ConditionalOnProperty(value = "spring.cloud.gcp.security.iap.enabled", matchIfMissing = false)

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -29,6 +29,12 @@
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud Storage components.",
       "defaultValue": true
+    },
+    {
+      "name": "spring.cloud.gcp.security.iap.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud IAP identity extraction components.",
+      "defaultValue": false
     }
   ]
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -9,7 +9,8 @@ org.springframework.cloud.gcp.autoconfigure.sql.GcpCloudSqlAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.storage.GcpStorageAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.trace.StackdriverTraceAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.datastore.DatastoreRepositoriesAutoConfiguration,\
-org.springframework.cloud.gcp.autoconfigure.spanner.SpannerRepositoriesAutoConfiguration
+org.springframework.cloud.gcp.autoconfigure.spanner.SpannerRepositoriesAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.security.IapAuthenticationAutoConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.gcp.autoconfigure.config.GcpConfigBootstrapConfiguration

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Elena Felder
+ * @since 1.1
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class IapAuthenticationAutoConfigurationTests {
+
+	static final String FAKE_TOKEN = "lol cats forever";
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(IapAuthenticationAutoConfiguration.class));
+
+	@Mock
+	HttpServletRequest mockIapRequest;
+
+	@Mock
+	HttpServletRequest mockNonIapRequest;
+
+	@Mock
+	static Jwt mockJwt;
+
+	@Before
+	public void httpRequestSetup() {
+		when(this.mockIapRequest.getHeader("x-goog-iap-jwt-assertion")).thenReturn("very fake jwt");
+	}
+
+	@Test
+	public void testIapAutoconfiguredBeansExistInContext() {
+		this.contextRunner.withPropertyValues("spring.cloud.gcp.security.iap.enabled=true")
+				.run(this::verifyJwtBeans);
+	}
+
+	@Test (expected = NoSuchBeanDefinitionException.class)
+	public void testAutoconfiguredBeansMissingWhenGatingPropertyFalse() {
+		this.contextRunner
+				.withPropertyValues("spring.cloud.gcp.security.iap.enabled=false")
+				.run(context ->	context.getBean(JwtDecoder.class));
+	}
+
+	@Test (expected = NoSuchBeanDefinitionException.class)
+	public void testAutoconfiguredBeansMissingWhenGatingPropertyMissing() {
+		this.contextRunner
+				.run(context -> context.getBean(JwtDecoder.class));
+	}
+
+	@Test
+	public void testIapBeansReturnedWhenBothIapAndSpringSecurityConfigPresent() {
+		new ApplicationContextRunner()
+				.withPropertyValues("spring.cloud.gcp.security.iap.enabled=true")
+				.withConfiguration(
+						AutoConfigurations.of(IapAuthenticationAutoConfiguration.class,
+						OAuth2ResourceServerAutoConfiguration.class))
+				.run(this::verifyJwtBeans);
+	}
+
+	@Test
+	public void testUserBeansReturnedUserConfigPresent() {
+		this.contextRunner
+				.withPropertyValues("spring.cloud.gcp.security.iap.enabled=true")
+				.withUserConfiguration(UserConfiguration.class)
+				.run(context -> {
+					JwtDecoder jwtDecoder =  context.getBean(JwtDecoder.class);
+					assertThat(jwtDecoder).isNotNull();
+					assertFalse(jwtDecoder instanceof NimbusJwtDecoderJwkSupport);
+					assertThat(jwtDecoder.decode("Ceci n'est pas un Jwt")).isSameAs(mockJwt);
+
+					BearerTokenResolver resolver = context.getBean(BearerTokenResolver.class);
+					assertThat(resolver).isNotNull();
+					assertThat(resolver.resolve(this.mockIapRequest)).isEqualTo(FAKE_TOKEN);
+					assertThat(resolver.resolve(this.mockNonIapRequest)).isEqualTo(FAKE_TOKEN);
+				});
+	}
+
+	private void verifyJwtBeans(AssertableApplicationContext context) {
+		JwtDecoder jwtDecoder =  context.getBean(JwtDecoder.class);
+		assertThat(jwtDecoder).isNotNull();
+		assertTrue(jwtDecoder instanceof NimbusJwtDecoderJwkSupport);
+
+		BearerTokenResolver resolver = context.getBean(BearerTokenResolver.class);
+		assertThat(resolver).isNotNull();
+		assertThat(resolver.resolve(this.mockIapRequest)).isEqualTo("very fake jwt");
+
+		assertThat(resolver.resolve(this.mockNonIapRequest)).isNull();
+	}
+
+	@Configuration
+	static class UserConfiguration {
+		@Bean
+		public JwtDecoder jwtDecoder() {
+			return s -> mockJwt;
+		}
+
+		@Bean
+		public BearerTokenResolver bearerTokenResolver() {
+			return httpServletRequest -> FAKE_TOKEN;
+		}
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
@@ -82,7 +83,8 @@ public class GcpStorageAutoConfigurationTests {
 	@SpringBootApplication(exclude = {
 			GcpContextAutoConfiguration.class,
 			GcpCloudSqlAutoConfiguration.class,
-			DataSourceAutoConfiguration.class
+			DataSourceAutoConfiguration.class,
+			SecurityAutoConfiguration.class
 	})
 	@RestController
 	static class StorageApplication {

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -125,6 +125,11 @@
 				<artifactId>spring-cloud-gcp-starter-logging</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 
 			<!-- spring-cloud-gcp-starter-sql -->
 			<dependency>

--- a/spring-cloud-gcp-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/index.adoc
@@ -49,3 +49,5 @@ include::spanner.adoc[]
 include::cloudfoundry.adoc[]
 
 include::memorystore.adoc[]
+
+include::security-iap.adoc[]

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -5,8 +5,7 @@
 
 https://cloud.google.com/iap/[Cloud Identity-Aware Proxy (IAP)] provides a security layer over applications deployed to Google Cloud.
 
-The IAP starter uses
-{spring-security-ref}#oauth2resourceserver[Spring Security OAuth 2.0 Resource Server] functionality to automatically extract user identity from the proxy-injected `x-goog-iap-jwt-assertion` header.
+The IAP starter uses {spring-security-ref}#oauth2resourceserver[Spring Security OAuth 2.0 Resource Server] functionality to automatically extract user identity from the proxy-injected `x-goog-iap-jwt-assertion` header.
 
 To use IAP authentication, you need to:
 

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -5,7 +5,7 @@
 
 https://cloud.google.com/iap/[Cloud Identity-Aware Proxy (IAP)] provides a security layer over applications deployed to Google Cloud.
 
-The IAP starter uses {spring-security-ref}#oauth2resourceserver[Spring Security OAuth 2.0 Resource Server] functionality to automatically extract user identity from the proxy-injected `x-goog-iap-jwt-assertion` header.
+The IAP starter uses {spring-security-ref}#oauth2resourceserver[Spring Security OAuth 2.0 Resource Server] functionality to automatically extract user identity from the proxy-injected `x-goog-iap-jwt-assertion` HTTP header.
 
 To use IAP authentication, you need to:
 

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -1,0 +1,41 @@
+:spring-security-ref: https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/
+:spring-security-javadoc: https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/
+
+== Google Cloud IAP Authentication
+
+https://cloud.google.com/iap/[Cloud Identity-Aware Proxy (IAP)] provides a security layer over applications deployed to Google Cloud.
+
+The IAP starter uses
+{spring-security-ref}#oauth2resourceserver[Spring Security OAuth 2.0 Resource Server] functionality to automatically extract user identity from the proxy-injected `x-goog-iap-jwt-assertion` header.
+
+To use IAP authentication, you need to:
+
+ * Pull in the `org.springframework.cloud:spring-cloud-gcp-starter-security-iap` dependency.
+ * Set `spring.cloud.gcp.security.iap.enabled` property to `true`.
+ * If you create a custom {spring-security-javadoc}config/annotation/web/configuration/WebSecurityConfigurerAdapter.html[`WebSecurityConfigurerAdapter`], enable extracting user identity by adding `.oauth2ResourceServer().jwt()` configuration to the {spring-security-javadoc}config/annotation/web/builders/HttpSecurity.html[`HttpSecurity`] object.
+ If no custom {spring-security-javadoc}config/annotation/web/configuration/WebSecurityConfigurerAdapter.html[`WebSecurityConfigurerAdapter`] is present, nothing needs to be done because Spring Boot will add this customization by default.
+
+A https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample[sample application] is available.
+
+Starter Maven coordinates, using https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml[Spring Cloud GCP BOM]:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
+</dependency>
+----
+
+Starter Gradle coordinates:
+
+[source]
+----
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-security-iap'
+}
+----
+
+
+
+

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -7,7 +7,7 @@ https://cloud.google.com/iap/[Cloud Identity-Aware Proxy (IAP)] provides a secur
 
 The IAP starter uses {spring-security-ref}#oauth2resourceserver[Spring Security OAuth 2.0 Resource Server] functionality to automatically extract user identity from the proxy-injected `x-goog-iap-jwt-assertion` HTTP header.
 
-To use IAP authentication, you need to:
+To use Cloud IAP authentication, you need to:
 
  * Pull in the `org.springframework.cloud:spring-cloud-gcp-starter-security-iap` dependency.
  * Set `spring.cloud.gcp.security.iap.enabled` property to `true`.

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -32,6 +32,7 @@
 		<module>spring-cloud-gcp-integration-storage-sample</module>
 		<module>spring-cloud-gcp-pubsub-binder-sample</module>
 		<module>spring-cloud-gcp-integration-pubsub-json-sample</module>
+		<module>spring-cloud-gcp-security-iap-sample</module>
 	</modules>
 
 	<build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
@@ -1,0 +1,3 @@
+WIP
+
+If you don't create your own implementation of WebSecurityConfigurerAdapter, Spring Boot will introduce its own, OAuth2ResourceServerWebSecurityConfiguration

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
@@ -1,7 +1,65 @@
-TODO
+= Spring Cloud GCP IAP Authentication Example
 
-Note: this sample should be tested when deployed to AppEngine Flexible or Kubernetes environments.
+This sample application demonstrates using
+link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap[Spring Cloud GCP IAP Authentication
+Starter] to extract user identity from a pre-authenticated header injected by https://cloud.google.com/iap/[Cloud Identity-Aware Proxy (IAP)].
 
-It is possible, in principle, to grab a recent JWK token from a deployed apps' /headers path, and to test locally, but this token will expire, causing authentication to be declined locally.
+If you run the sample locally, the following pages will be available:
 
-If you don't create your own implementation of WebSecurityConfigurerAdapter, Spring Boot will introduce its own, OAuth2ResourceServerWebSecurityConfiguration
+|===
+|URL |Description
+
+|`http://localhost:8080/`
+|Unsecured  page.
+
+|`http://localhost:8080/topsecret`
+|Secured page requiring non-anonymous authentication. Prints IAP identity details if authentication passes.
+
+|`http://localhost:8080/headers`
+|Unsecured page that can be used for troubleshooting or capturing IAP tokens from a deployed application for local testing (please don't give anyone else access to your IAP token or add this functionality to a real production application).
+|===
+
+
+== Setup & Configuration
+1. Create a Google Cloud Platform Project
+1. Have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, initialized and logged in with
+https://developers.google.com/identity/protocols/application-default-credentials[application
+default credentials] (you can run the sample locally without logging in, but you'll need the credentials to deploy.
+
+
+== Running the Sample Locally
+Run with Maven from the root of this code sample:
+
+----
+mvn clean spring-boot:run
+----
+
+You can then try using `curl` against the paths made available in the sample.
+
+This will work, and pring "No secrets here":
+
+----
+curl localhost:8080/
+----
+
+This will not work, returning Access Denied:
+
+----
+curl localhost:8080/topsecret
+----
+
+It is possible, in principle, to grab a recent JWK token from a deployed application's `/headers` path, and to test locally.
+Please take care with your token if you do this.
+
+----
+curl -H "x-goog-iap-jwt-assertion: [JWK TOKEN]" localhost:8080/topsecret
+----
+
+
+== Deploying the Sample to AppEngine Flexible
+
+The following Maven target will deploy this application to the root of your AppEngine Flexible instance:
+----
+mvn appengine:deploy
+----
+

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
@@ -1,3 +1,7 @@
-WIP
+TODO
+
+Note: this sample should be tested when deployed to AppEngine Flexible or Kubernetes environments.
+
+It is possible, in principle, to grab a recent JWK token from a deployed apps' /headers path, and to test locally, but this token will expire, causing authentication to be declined locally.
 
 If you don't create your own implementation of WebSecurityConfigurerAdapter, Spring Boot will introduce its own, OAuth2ResourceServerWebSecurityConfiguration

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
@@ -1,8 +1,6 @@
 = Spring Cloud GCP IAP Authentication Example
 
-This sample application demonstrates using
-link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap[Spring Cloud GCP IAP Authentication
-Starter] to extract user identity from a pre-authenticated header injected by https://cloud.google.com/iap/[Cloud Identity-Aware Proxy (IAP)].
+This sample application demonstrates using link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap[Spring Cloud GCP IAP Authentication Starter] to extract user identity from a pre-authenticated header injected by https://cloud.google.com/iap/[Cloud Identity-Aware Proxy (IAP)].
 
 If you run the sample locally, the following pages will be available:
 
@@ -21,10 +19,8 @@ If you run the sample locally, the following pages will be available:
 
 
 == Setup & Configuration
-1. Create a Google Cloud Platform Project
-1. Have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, initialized and logged in with
-https://developers.google.com/identity/protocols/application-default-credentials[application
-default credentials] (you can run the sample locally without logging in, but you'll need the credentials to deploy.
+1. Create a Google Cloud Platform Project.
+1. Have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, initialized and logged in with https://developers.google.com/identity/protocols/application-default-credentials[application default credentials] (you can run the sample locally without logging in, but you'll need the credentials to deploy).
 
 
 == Running the Sample Locally

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
@@ -30,7 +30,7 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>spring-cloud-gcp-security-iap-sample</artifactId>
+    <name>Spring Cloud GCP Security IAP Sample</name>
+    <description>TODO</description>
+
+    <parent>
+        <artifactId>spring-cloud-gcp-samples</artifactId>
+        <groupId>org.springframework.cloud</groupId>
+        <version>1.1.0.BUILD-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+
+<!--        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
+        </dependency>-->
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+<!--
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+            <version>5.1.1.RELEASE</version>
+        </dependency>
+-->
+
+<!--
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-jwt</artifactId>
+            <version>1.0.9.RELEASE</version>
+        </dependency>
+-->
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>6.3-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>appengine-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
@@ -30,11 +30,6 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
@@ -26,68 +26,17 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-
-<!--        <dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
-        </dependency>-->
+        </dependency>
 
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
-<!--
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-jose</artifactId>
-            <version>5.1.1.RELEASE</version>
-        </dependency>
--->
-
-<!--
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-jwt</artifactId>
-            <version>1.0.9.RELEASE</version>
-        </dependency>
--->
-
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-web</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-gcp-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>6.3-SNAPSHOT</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>
@@ -103,6 +52,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.example</groupId>
     <artifactId>spring-cloud-gcp-security-iap-sample</artifactId>
     <name>Spring Cloud GCP Security IAP Sample</name>
-    <description>TODO</description>
+    <description>Spring Cloud IAP Security Sample</description>
 
     <parent>
         <artifactId>spring-cloud-gcp-samples</artifactId>
@@ -30,8 +30,7 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
         </dependency>
-
-
+        
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/appengine/app.yaml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/appengine/app.yaml
@@ -1,0 +1,15 @@
+runtime: java
+env: flex
+
+handlers:
+- url: /.*
+  script: this field is required, but ignored
+
+manual_scaling:
+  instances: 1
+
+resources:
+  memory_gb: 4
+
+env_variables:
+  JAVA_OPTS: -Djava.security.egd=file:/dev/./urandom

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/DemoApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/DemoApplication.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Sample Spring Boot application
+ *
+ * @author Elena Felder
+ */
+@SpringBootApplication
+public class DemoApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/DemoApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/DemoApplication.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * Sample Spring Boot application
  *
  * @author Elena Felder
+ * @since 1.1
  */
 @SpringBootApplication
 public class DemoApplication {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
@@ -23,9 +23,6 @@ import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -47,8 +44,6 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 public class ExampleController {
-	private static final Log LOGGER = LogFactory.getLog(ExampleController.class);
-
 
 	@RequestMapping("/")
 	public String unsecured() {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
@@ -33,9 +33,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Sample REST Controller to demonstrate IAP security header extraction
+ * Sample REST Controller to demonstrate IAP security header extraction.
+ *
+ * <p>Makes the following pages available:
+ * <ul>
+ *     <li>{@code /} - Unsecured page.
+ *     <li>{@code /topsecret} - Secured page requiring non-anonymous authentication. Prints IAP identity details.
+ *     <li>{@code /headers} - Unsecured page that can be used for troubleshooting.
+ * </ul>
  *
  * @author Elena Felder
+ * @since 1.1
  */
 @RestController
 public class ExampleController {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.example;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Sample REST Controller to demonstrate IAP security header extraction
+ *
+ * @author Elena Felder
+ */
+@RestController
+public class ExampleController {
+	private static final Log LOGGER = LogFactory.getLog(ExampleController.class);
+
+
+	@RequestMapping("/")
+	public String unsecured() {
+		return "No secrets here!";
+	}
+
+	@RequestMapping("/topsecret")
+	public String secured() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		return String.format("You are [%s], as determined by [%s]\n",
+				authentication.getPrincipal(), authentication.getCredentials());
+	}
+
+	@RequestMapping("/headers")
+	public Map<String, String> headers(HttpServletRequest req) {
+		return Collections.list(req.getHeaderNames())
+				.stream()
+				.collect(Collectors.toMap(Function.identity(), req::getHeader));
+	}
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
@@ -55,7 +55,7 @@ public class ExampleController {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		if (authentication != null && authentication.getPrincipal() instanceof Jwt) {
 			Jwt jwt = (Jwt) authentication.getPrincipal();
-			return String.format("You are [%s] with e-mail address [%s].\n",
+			return String.format("You are [%s] with e-mail address [%s].%n",
 					jwt.getSubject(), jwt.getClaimAsString("email"));
 		}
 		else {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/ExampleController.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,14 +44,21 @@ public class ExampleController {
 
 	@RequestMapping("/")
 	public String unsecured() {
-		return "No secrets here!";
+		return "No secrets here!\n";
 	}
 
 	@RequestMapping("/topsecret")
 	public String secured() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		return String.format("You are [%s], as determined by [%s]\n",
-				authentication.getPrincipal(), authentication.getCredentials());
+		if (authentication != null && authentication.getPrincipal() instanceof Jwt) {
+			Jwt jwt = (Jwt) authentication.getPrincipal();
+			return String.format("You are [%s] with e-mail address [%s].\n",
+					jwt.getSubject(), jwt.getClaimAsString("email"));
+		}
+		else {
+			return "Something went wrong; authentication is not provided by IAP/JWT.\n";
+		}
+
 	}
 
 	@RequestMapping("/headers")

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/SecurityConfigurer.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/SecurityConfigurer.java
@@ -20,22 +20,19 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity (debug = true)
 public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
-				.anonymous()
+				.authorizeRequests().antMatchers("/topsecret").authenticated()
 				.and()
-				.authorizeRequests()
-					.antMatchers("/topsecret")	.authenticated().and().anonymous().disable()
 				.oauth2ResourceServer()
-				.bearerTokenResolver(r -> r.getHeader("x-goog-iap-jwt-assertion"))
-
-				.jwt()
-				.decoder(new NimbusJwtDecoderJwkSupport("https://www.gstatic.com/iap/verify/public_key-jwk", "ES256"));
+					.jwt()
+					.and()
+					.authenticationEntryPoint(new Http403ForbiddenEntryPoint());
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/SecurityConfigurer.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/SecurityConfigurer.java
@@ -22,8 +22,18 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 
+/**
+ * Sample custom {@link WebSecurityConfigurerAdapter} that applies OAuth Resource Server pre-authentication, and
+ * rejects unauthenticated requests to a single page, {@code /topsecret}. All other pages are unsecured.
+ *
+ * Because of {@code spring-cloud-gcp-starter-security-iap} dependency, the secure token will be retrieved from Google
+ * Cloud IAP header {@code x-goog-iap-jwt-assertion}, and not from the standard OAuth Bearer header.
+ *
+ * @author Elena Felder
+ * @since 1.1
+ */
 @Configuration
-@EnableWebSecurity (debug = true)
+@EnableWebSecurity
 public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/SecurityConfigurer.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/java/com/example/SecurityConfigurer.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http
+				.anonymous()
+				.and()
+				.authorizeRequests()
+					.antMatchers("/topsecret")	.authenticated().and().anonymous().disable()
+				.oauth2ResourceServer()
+				.bearerTokenResolver(r -> r.getHeader("x-goog-iap-jwt-assertion"))
+
+				.jwt()
+				.decoder(new NimbusJwtDecoderJwkSupport("https://www.gstatic.com/iap/verify/public_key-jwk", "ES256"));
+	}
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/resources/application.properties
@@ -1,5 +1,3 @@
 spring.cloud.gcp.security.iap.enabled=true
 
 logging.level.org.springframework.security=DEBUG
-
-spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://www.gstatic.com/iap/verify/public_key-jwk

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/resources/application.properties
@@ -1,3 +1,1 @@
 spring.cloud.gcp.security.iap.enabled=true
-
-logging.level.org.springframework.security=DEBUG

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.cloud.gcp.security.iap.enabled=true
+
+logging.level.org.springframework.security=DEBUG
+
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://www.gstatic.com/iap/verify/public_key-jwk

--- a/spring-cloud-gcp-starters/pom.xml
+++ b/spring-cloud-gcp-starters/pom.xml
@@ -30,5 +30,6 @@
 		<module>spring-cloud-gcp-starter-logging</module>
 		<module>spring-cloud-gcp-starter-sql-mysql</module>
 		<module>spring-cloud-gcp-starter-sql-postgresql</module>
+		<module>spring-cloud-gcp-starter-security-iap</module>
     </modules>
 </project>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>spring-cloud-gcp-starters</artifactId>
+        <groupId>org.springframework.cloud</groupId>
+        <version>1.1.0.BUILD-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
+    <name>Spring Cloud GCP Security IAP Starter</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap/pom.xml
@@ -20,8 +20,16 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This PR changes/creates 3 projects.

**1. spring-cloud-gcp-autoconfigure.**
New package o.s.c.g.a.security  containing customizations to autoconfigured OAuth Resource Server.

Uses Spring Security OAuth2 Resource Server to parse the IAP header, validate its signature and claims, and provide an authorization object.

There is no additional logic, but two IAP-specific beans are provided through autoconfiguration:
* A version of JwtDecoder that goes against IAP public key and validates the private key using ES256 algorithm. The first part could have been configured with a property, but encryption is not yet property-configurable. When spring-projects/spring-boot#15115 is resolved, this bean can be removed and replaced with the two properties.
* A BearerTokenResolver that parses `x-goog-iap-jwt-assertion `header instead of the standard OAuth `access_token`.

There is one unrelated change in this PR -- bringing spring-security as a transitive dependency made GcpStorageAutoConfigurationTests needlessly secure, so I excluded security autoconfiguration from the test.

**2. spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap**
A new project that brings in autoconfiguration and a dependency on `spring-boot-starter-oauth2-resource-server.` 

**3. spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample**
A new project containing a minimal demo app showing how to configure a secured URL with a custom `WebSecurityConfigurerAdapter`.

Fixes #1016.