### PR TITLE
Prefix subscription with destination in binder

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -63,6 +63,8 @@ If the consumer group is not specified, an anonymous one will be created with th
 For example, for the following configuration, a topic named `myEvents` and a subscription called `myEvents.counsumerGroup1` would be created.
 If the consumer group is not specified, a subscription called `anonymous.myEvents.a6d83782-c5a3-4861-ac38-e6e2af15a7be` would be created.
 
+IMPORTANT: If you are manually creating Pub/Sub subscriptions for consumers, make sure that they follow the naming convention of `<destinationName>.<consumerGroup>`.
+
 .application.properties
 ----
 spring.cloud.stream.bindings.events.destination=myEvents

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -57,10 +57,10 @@ spring.cloud.stream.gcp.pubsub.bindings.events.producer.auto-create-resources=tr
 ==== Consumer Destination Configuration
 
 If automatic resource creation is turned ON and the subscription and/or the topic do not exist for a consumer, a subscription and potentially a topic will be created.
-The topic name will be the same as the destination name, and the subscription name will be the same as the consumer group name.
+The topic name will be the same as the destination name, and the subscription name will be the destination name followed by the consumer group name.
 If the consumer group is not specified, an anonymous one will be created with the name `anonymous.<destinationName>.<randomUUID>`.
 
-For example, for the following configuration, a topic named `myEvents` and a subscription called `counsumerGroup1` would be created.
+For example, for the following configuration, a topic named `myEvents` and a subscription called `myEvents.counsumerGroup1` would be created.
 If the consumer group is not specified, a subscription called `anonymous.myEvents.a6d83782-c5a3-4861-ac38-e6e2af15a7be` would be created.
 
 .application.properties

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -62,7 +62,7 @@ public class PubSubChannelProvisioner
 		// Generate anonymous random group, if one not provided
 		String subscription = !StringUtils.hasText(group) ?
 				"anonymous." + name + "." + UUID.randomUUID().toString()
-				: group;
+				: name + "." + group;
 
 		if (this.pubSubAdmin.getSubscription(subscription) == null) {
 			if (properties.getExtension().isAutoCreateResources()) {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -17,8 +17,6 @@
 package org.springframework.cloud.gcp.stream.binder.pubsub;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
@@ -65,10 +63,4 @@ public class PubSubMessageChannelBinderTests extends
 		// Do nothing. Original test tests for Lifecycle logic that we don't need.
 	}
 
-	@Test
-	@Ignore("Subscriptions with the same name for different topics are not allowed by Pub/Sub.")
-	@Override
-	public void testSendAndReceiveMultipleTopics() throws Exception {
-		super.testSendAndReceiveMultipleTopics();
-	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -70,9 +70,9 @@ public class PubSubChannelProvisionerTests {
 		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
 				.provisionConsumerDestination("topic_A", "group_A", this.properties);
 
-		assertThat(result.getName()).isEqualTo("group_A");
+		assertThat(result.getName()).isEqualTo("topic_A.group_A");
 
-		verify(this.pubSubAdminMock).createSubscription("group_A", "topic_A");
+		verify(this.pubSubAdminMock).createSubscription("topic_A.group_A", "topic_A");
 	}
 
 	@Test


### PR DESCRIPTION
* Fixes handling of multiple topics with the same consumer group name

* Re-enable testSendAndReceiveMultipleTopics

Fixes #1184.