### PR TITLE
Fix and Cleanup Logging Integration Test

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/it/StackdriverLoggingIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/it/StackdriverLoggingIntegrationTests.java
@@ -17,15 +17,15 @@
 package org.springframework.cloud.gcp.autoconfigure.logging.it;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.BeforeClass;
@@ -33,24 +33,35 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.gcp.autoconfigure.logging.it.StackdriverLoggingIntegrationTests.LoggingApplication;
 import org.springframework.cloud.gcp.autoconfigure.sql.GcpCloudSqlAutoConfiguration;
 import org.springframework.cloud.gcp.autoconfigure.storage.GcpStorageAutoConfiguration;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * @author João André Martins
+ * @author Daniel Zou
  */
 @SpringBootTest(
+		classes = {
+				LoggingApplication.class },
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		properties = {"spring.main.banner-mode=off"}
 )
@@ -65,8 +76,8 @@ public class StackdriverLoggingIntegrationTests {
 	@Autowired
 	private CredentialsProvider credentialsProvider;
 
-	@LocalServerPort
-	private int port;
+	@Autowired
+	private TestRestTemplate testRestTemplate;
 
 	private static final LocalDateTime NOW = LocalDateTime.now();
 
@@ -77,46 +88,48 @@ public class StackdriverLoggingIntegrationTests {
 
 	@Test
 	public void test() throws InterruptedException, IOException {
-		URL url = new URL("http://localhost:" + this.port);
-		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-		connection.setRequestProperty("x-cloud-trace-context", "everything-zen");
-		connection.getResponseMessage();
-		connection.disconnect();
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("x-cloud-trace-context", "everything-zen");
+		ResponseEntity<String> responseEntity = this.testRestTemplate.exchange(
+				"/", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+		assertThat(responseEntity.getStatusCode().is2xxSuccessful()).isTrue();
 
 		CredentialsProvider credentialsProvider = this.credentialsProvider;
 		Logging logClient = LoggingOptions.newBuilder()
 				.setCredentials(credentialsProvider.getCredentials())
 				.build().getService();
-		Page<LogEntry> page;
-		int pageSize = 0;
-		int counter = 0;
-		do {
-			Thread.sleep(100);
-			page = logClient.listLogEntries(
+
+		await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+			Page<LogEntry> page = logClient.listLogEntries(
 					Logging.EntryListOption.filter("textPayload:\"#$%^&" + NOW + "\" AND"
 							+ " logName=\"projects/" + this.projectIdProvider.getProjectId()
 							+ "/logs/spring.log\""));
-			for (LogEntry entry : page.getValues()) {
-				pageSize++;
-			}
-		} while (pageSize == 0 && counter++ < 20);
-		assertThat(pageSize).isEqualTo(1);
-		assertThat(page.getValues().iterator().next().getTrace())
-				.matches("projects/" + this.projectIdProvider.getProjectId()
-						+ "/traces/([a-z0-9]){32}");
+
+			ImmutableList<LogEntry> logEntries = ImmutableList.copyOf(page.getValues());
+			assertThat(logEntries).hasSize(1);
+
+			LogEntry entry = logEntries.get(0);
+			assertThat(entry.getTrace()).matches(
+					"projects/" + this.projectIdProvider.getProjectId() + "/traces/([a-z0-9]){32}");
+		});
 	}
 
 	@RestController
 	@SpringBootApplication(exclude = {
 			GcpCloudSqlAutoConfiguration.class,
 			GcpStorageAutoConfiguration.class,
-			DataSourceAutoConfiguration.class
+			DataSourceAutoConfiguration.class,
+			SecurityAutoConfiguration.class
 	})
 	static class LoggingApplication {
+		public static void main(String[] args) {
+			SpringApplication.run(LoggingApplication.class, args);
+		}
 
-		@GetMapping
-		public void log() {
+		@GetMapping("/")
+		public String log() {
 			LOGGER.error("#$%^&" + NOW);
+			return "Log sent.";
 		}
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/it/StackdriverLoggingIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/it/StackdriverLoggingIntegrationTests.java
@@ -33,13 +33,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.cloud.gcp.autoconfigure.logging.it.StackdriverLoggingIntegrationTests.LoggingApplication;
 import org.springframework.cloud.gcp.autoconfigure.sql.GcpCloudSqlAutoConfiguration;
 import org.springframework.cloud.gcp.autoconfigure.storage.GcpStorageAutoConfiguration;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
@@ -60,8 +58,6 @@ import static org.awaitility.Awaitility.await;
  * @author Daniel Zou
  */
 @SpringBootTest(
-		classes = {
-				LoggingApplication.class },
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		properties = {"spring.main.banner-mode=off"}
 )
@@ -122,9 +118,6 @@ public class StackdriverLoggingIntegrationTests {
 			SecurityAutoConfiguration.class
 	})
 	static class LoggingApplication {
-		public static void main(String[] args) {
-			SpringApplication.run(LoggingApplication.class, args);
-		}
 
 		@GetMapping("/")
 		public String log() {


### PR DESCRIPTION
This fixes the Logging autoconfiguration integration tests.

Turns out the test was actually broken because it picked up the new spring security deps which gated the app's HTTP endpoint behind a login screen. I excluded the autoconfiguration from the test and also did some cleanup.