### PR TITLE
Add IAP issuer claim verifier

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 
@@ -59,7 +60,10 @@ public class IapAuthenticationAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public JwtDecoder iapJwtDecoder(IapAuthenticationProperties properties) {
-		return new NimbusJwtDecoderJwkSupport(properties.getRegistry(), properties.getAlgorithm());
+		NimbusJwtDecoderJwkSupport jwkSupport
+				= new NimbusJwtDecoderJwkSupport(properties.getRegistry(), properties.getAlgorithm());
+		jwkSupport.setJwtValidator(JwtValidators.createDefaultWithIssuer(properties.getIssuer()));
+		return jwkSupport;
 	}
 
 	@Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationProperties.java
@@ -42,6 +42,12 @@ public class IapAuthenticationProperties {
 	 */
 	private String header = "x-goog-iap-jwt-assertion";
 
+
+	/**
+	 * JWK issuer to verify.
+	 */
+	private String issuer = "https://cloud.google.com/iap";
+
 	public String getRegistry() {
 		return this.registry;
 	}
@@ -64,5 +70,13 @@ public class IapAuthenticationProperties {
 
 	public void setHeader(String header) {
 		this.header = header;
+	}
+
+	public String getIssuer() {
+		return this.issuer;
+	}
+
+	public void setIssuer(String issuer) {
+		this.issuer = issuer;
 	}
 }

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -58,4 +58,9 @@ CAUTION: Modifying registry, algorithm, and header properties might be useful fo
 |true
 |`x-goog-iap-jwt-assertion`
 
+|`spring.cloud.gcp.security.iap.issuer`
+|JWK issuer to verify.
+|true
+|`https://cloud.google.com/iap`
+
 |===

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -42,16 +42,20 @@ CAUTION: Modifying registry, algorithm, and header properties might be useful fo
 
 |===
 |Name |Description |Required |Default
+
 |`spring.cloud.gcp.security.iap.registry`
 |Link to JWK public key registry.
 |true
 |`https://www.gstatic.com/iap/verify/public_key-jwk`
+
 |`spring.cloud.gcp.security.iap.algorithm`
 |Encryption algorithm used to sign the JWK token.
 |true
 |`ES256`
+
 |`spring.cloud.gcp.security.iap.header`
 |Header from which to extract the JWK key.
 |true
 |`x-goog-iap-jwt-assertion`
+
 |===

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -42,7 +42,6 @@ CAUTION: Modifying registry, algorithm, and header properties might be useful fo
 
 |===
 |Name |Description |Required |Default
-
 |`spring.cloud.gcp.security.iap.registry`
 |Link to JWK public key registry.
 |true

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -55,5 +55,3 @@ CAUTION: Modifying registry, algorithm, and header properties might be useful fo
 |true
 |`x-goog-iap-jwt-assertion`
 |===
-
-

--- a/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/security-iap.adoc
@@ -46,12 +46,10 @@ CAUTION: Modifying registry, algorithm, and header properties might be useful fo
 |Link to JWK public key registry.
 |true
 |`https://www.gstatic.com/iap/verify/public_key-jwk`
-
 |`spring.cloud.gcp.security.iap.algorithm`
 |Encryption algorithm used to sign the JWK token.
 |true
 |`ES256`
-
 |`spring.cloud.gcp.security.iap.header`
 |Header from which to extract the JWK key.
 |true


### PR DESCRIPTION
Spring-security conveniently already has an issuer verifier implementation.

Right now, if client apps need to skip issuer validation, they can provide an overridden JwtDecoder bean. 

The alternative is to make the issuer bean injectable based on whether the property is non-empty. This is more flexible but less secure (Google Cloud says issuer MUST be set to the specific value).

Fixes #1205.