### PR TITLE
Cleanup anonymous Pub/Sub subscriptions

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -51,6 +51,8 @@ public class PubSubMessageChannelBinder
 
 	private final PubSubExtendedBindingProperties pubSubExtendedBindingProperties;
 
+	private final PubSubChannelProvisioner pubSubChannelProvisioner;
+
 	public PubSubMessageChannelBinder(String[] headersToEmbed,
 			PubSubChannelProvisioner provisioningProvider, PubSubTemplate pubSubTemplate,
 			PubSubExtendedBindingProperties pubSubExtendedBindingProperties) {
@@ -58,6 +60,7 @@ public class PubSubMessageChannelBinder
 		super(headersToEmbed, provisioningProvider);
 		this.pubSubTemplate = pubSubTemplate;
 		this.pubSubExtendedBindingProperties = pubSubExtendedBindingProperties;
+		this.pubSubChannelProvisioner = provisioningProvider;
 	}
 
 	@Override
@@ -97,4 +100,10 @@ public class PubSubMessageChannelBinder
 		return this.pubSubExtendedBindingProperties.getExtendedPropertiesEntryClass();
 	}
 
+	@Override
+	protected void afterUnbindConsumer(ConsumerDestination destination, String group,
+			ExtendedConsumerProperties<PubSubConsumerProperties> consumerProperties) {
+		super.afterUnbindConsumer(destination, group, consumerProperties);
+		this.pubSubChannelProvisioner.afterUnbindConsumer(destination, group, consumerProperties);
+	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -104,6 +104,6 @@ public class PubSubMessageChannelBinder
 	protected void afterUnbindConsumer(ConsumerDestination destination, String group,
 			ExtendedConsumerProperties<PubSubConsumerProperties> consumerProperties) {
 		super.afterUnbindConsumer(destination, group, consumerProperties);
-		this.pubSubChannelProvisioner.afterUnbindConsumer(destination, group, consumerProperties);
+		this.pubSubChannelProvisioner.afterUnbindConsumer(destination);
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -16,7 +16,13 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.provisioning;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
+
+import com.google.pubsub.v1.Subscription;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
@@ -37,7 +43,11 @@ public class PubSubChannelProvisioner
 		implements ProvisioningProvider<ExtendedConsumerProperties<PubSubConsumerProperties>,
 		ExtendedProducerProperties<PubSubProducerProperties>> {
 
+	private static final Log LOGGER = LogFactory.getLog(PubSubChannelProvisioner.class);
+
 	private final PubSubAdmin pubSubAdmin;
+
+	private final Set<String> anonymousSubscriptions = new HashSet<>();
 
 	public PubSubChannelProvisioner(PubSubAdmin pubSubAdmin) {
 		this.pubSubAdmin = pubSubAdmin;
@@ -58,24 +68,52 @@ public class PubSubChannelProvisioner
 	public ConsumerDestination provisionConsumerDestination(String name, String group,
 			ExtendedConsumerProperties<PubSubConsumerProperties> properties)
 			throws ProvisioningException {
-		// Use group name as subscription name
+		String subscription;
+		// Use <topic>.<groupName> as subscription name
 		// Generate anonymous random group, if one not provided
-		String subscription = !StringUtils.hasText(group) ?
-				"anonymous." + name + "." + UUID.randomUUID().toString()
-				: name + "." + group;
+		boolean anonymous = false;
+		if (StringUtils.hasText(group)) {
+			subscription = name + "." + group;
+		}
+		else {
+			subscription = "anonymous." + name + "." + UUID.randomUUID().toString();
+			anonymous = true;
+		}
 
-		if (this.pubSubAdmin.getSubscription(subscription) == null) {
+		Subscription pubSubSubscription = this.pubSubAdmin.getSubscription(subscription);
+		if (pubSubSubscription == null) {
 			if (properties.getExtension().isAutoCreateResources()) {
 				if (this.pubSubAdmin.getTopic(name) == null) {
 					this.pubSubAdmin.createTopic(name);
 				}
 
 				this.pubSubAdmin.createSubscription(subscription, name);
+
+				if (anonymous) {
+					this.anonymousSubscriptions.add(subscription);
+				}
 			}
 			else {
 				throw new ProvisioningException("Non-existing '" + subscription + "' subscription.");
 			}
 		}
+		else if (!pubSubSubscription.getTopic().equals(name)) {
+			throw new ProvisioningException("Existing '" + subscription + "' subscription is for a different topic '"
+					+ pubSubSubscription.getTopic() + "'.");
+		}
 		return new PubSubConsumerDestination(subscription);
+	}
+
+	public void afterUnbindConsumer(ConsumerDestination destination, String group,
+			ExtendedConsumerProperties<PubSubConsumerProperties> properties) {
+		if (this.anonymousSubscriptions.contains(destination.getName())) {
+			try {
+				this.pubSubAdmin.deleteSubscription(destination.getName());
+			}
+			catch (Exception ex) {
+				LOGGER.warn("Failed to delete auto-created anonymous subscription '" + destination.getName() + "'.");
+			}
+			this.anonymousSubscriptions.remove(destination.getName());
+		}
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -104,8 +104,7 @@ public class PubSubChannelProvisioner
 		return new PubSubConsumerDestination(subscription);
 	}
 
-	public void afterUnbindConsumer(ConsumerDestination destination, String group,
-			ExtendedConsumerProperties<PubSubConsumerProperties> properties) {
+	public void afterUnbindConsumer(ConsumerDestination destination) {
 		if (this.anonymousSubscriptions.contains(destination.getName())) {
 			try {
 				this.pubSubAdmin.deleteSubscription(destination.getName());

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -105,14 +105,13 @@ public class PubSubChannelProvisioner
 	}
 
 	public void afterUnbindConsumer(ConsumerDestination destination) {
-		if (this.anonymousSubscriptions.contains(destination.getName())) {
+		if (this.anonymousSubscriptions.remove(destination.getName())) {
 			try {
 				this.pubSubAdmin.deleteSubscription(destination.getName());
 			}
 			catch (Exception ex) {
 				LOGGER.warn("Failed to delete auto-created anonymous subscription '" + destination.getName() + "'.");
 			}
-			this.anonymousSubscriptions.remove(destination.getName());
 		}
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorTests.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.stream.binder.pubsub;
+
+import org.junit.ClassRule;
+
+import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
+import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
+import org.springframework.cloud.stream.binder.AbstractBinderTests;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.binder.Spy;
+
+/**
+ * Integration tests that require the Pub/Sub emulator to be installed.
+ *
+ * @author João André Martins
+ * @author Elena Felder
+ */
+public class PubSubMessageChannelBinderEmulatorTests extends
+		AbstractBinderTests<PubSubTestBinder, ExtendedConsumerProperties<PubSubConsumerProperties>,
+				ExtendedProducerProperties<PubSubProducerProperties>> {
+
+	@ClassRule
+	public static PubSubEmulator emulator = new PubSubEmulator();
+
+	@Override
+	protected PubSubTestBinder getBinder() {
+		return new PubSubTestBinder(emulator.getEmulatorHostPort());
+	}
+
+	@Override
+	protected ExtendedConsumerProperties<PubSubConsumerProperties> createConsumerProperties() {
+		return new ExtendedConsumerProperties<>(new PubSubConsumerProperties());
+	}
+
+	@Override
+	protected ExtendedProducerProperties<PubSubProducerProperties> createProducerProperties() {
+		return new ExtendedProducerProperties<>(new PubSubProducerProperties());
+	}
+
+	@Override
+	public Spy spyOn(String name) {
+		return null;
+	}
+
+	@Override
+	public void testClean() {
+		// Do nothing. Original test tests for Lifecycle logic that we don't need.
+	}
+
+}

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -66,8 +66,7 @@ public class PubSubMessageChannelBinderTests {
 	public void testAfterUnbindConsumer() {
 		this.binder.afterUnbindConsumer(this.consumerDestination, "group1", this.consumerProperties);
 
-		verify(this.channelProvisioner).afterUnbindConsumer(this.consumerDestination, "group1",
-				this.consumerProperties);
+		verify(this.channelProvisioner).afterUnbindConsumer(this.consumerDestination);
 	}
 
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -16,51 +16,58 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub;
 
-import org.junit.ClassRule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubConsumerProperties;
-import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubProducerProperties;
-import org.springframework.cloud.stream.binder.AbstractBinderTests;
+import org.springframework.cloud.gcp.stream.binder.pubsub.properties.PubSubExtendedBindingProperties;
+import org.springframework.cloud.gcp.stream.binder.pubsub.provisioning.PubSubChannelProvisioner;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
-import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
-import org.springframework.cloud.stream.binder.Spy;
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+
+import static org.mockito.Mockito.verify;
 
 /**
- * Integration tests that require the Pub/Sub emulator to be installed.
+ * @author Mike Eltsufin
  *
- * @author João André Martins
- * @author Elena Felder
+ * @since 1.1
  */
-public class PubSubMessageChannelBinderTests extends
-		AbstractBinderTests<PubSubTestBinder, ExtendedConsumerProperties<PubSubConsumerProperties>,
-				ExtendedProducerProperties<PubSubProducerProperties>> {
+@RunWith(MockitoJUnitRunner.class)
+public class PubSubMessageChannelBinderTests {
 
-	@ClassRule
-	public static PubSubEmulator emulator = new PubSubEmulator();
+	PubSubMessageChannelBinder binder;
 
-	@Override
-	protected PubSubTestBinder getBinder() {
-		return new PubSubTestBinder(emulator.getEmulatorHostPort());
+	@Mock
+	PubSubChannelProvisioner channelProvisioner;
+
+	@Mock
+	PubSubTemplate pubSubTemplate;
+
+	@Mock
+	PubSubExtendedBindingProperties properties;
+
+	@Mock
+	ConsumerDestination consumerDestination;
+
+	@Mock
+	ExtendedConsumerProperties<PubSubConsumerProperties> consumerProperties;
+
+	@Before
+	public void before() {
+		this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate,
+				this.properties);
 	}
 
-	@Override
-	protected ExtendedConsumerProperties<PubSubConsumerProperties> createConsumerProperties() {
-		return new ExtendedConsumerProperties<>(new PubSubConsumerProperties());
-	}
+	@Test
+	public void testAfterUnbindConsumer() {
+		this.binder.afterUnbindConsumer(this.consumerDestination, "group1", this.consumerProperties);
 
-	@Override
-	protected ExtendedProducerProperties<PubSubProducerProperties> createProducerProperties() {
-		return new ExtendedProducerProperties<>(new PubSubProducerProperties());
-	}
-
-	@Override
-	public Spy spyOn(String name) {
-		return null;
-	}
-
-	@Override
-	public void testClean() {
-		// Do nothing. Original test tests for Lifecycle logic that we don't need.
+		verify(this.channelProvisioner).afterUnbindConsumer(this.consumerDestination, "group1",
+				this.consumerProperties);
 	}
 
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -31,6 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -85,5 +87,36 @@ public class PubSubChannelProvisionerTests {
 		assertThat(result.getName()).matches(subscriptionNameRegex);
 
 		verify(this.pubSubAdminMock).createSubscription(matches(subscriptionNameRegex), eq("topic_A"));
+	}
+
+	@Test
+	public void testAfterUnbindConsumer_anonymousGroup() {
+		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
+				.provisionConsumerDestination("topic_A", null, this.properties);
+
+		this.pubSubChannelProvisioner.afterUnbindConsumer(result, null, this.properties);
+
+		verify(this.pubSubAdminMock).deleteSubscription(result.getName());
+	}
+
+	@Test
+	public void testAfterUnbindConsumer_twice() {
+		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
+				.provisionConsumerDestination("topic_A", null, this.properties);
+
+		this.pubSubChannelProvisioner.afterUnbindConsumer(result, null, this.properties);
+		this.pubSubChannelProvisioner.afterUnbindConsumer(result, null, this.properties);
+
+		verify(this.pubSubAdminMock, times(1)).deleteSubscription(result.getName());
+	}
+
+	@Test
+	public void testAfterUnbindConsumer_nonAnonymous() {
+		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
+				.provisionConsumerDestination("topic_A", "group1", this.properties);
+
+		this.pubSubChannelProvisioner.afterUnbindConsumer(result, "group1", this.properties);
+
+		verify(this.pubSubAdminMock, never()).deleteSubscription(result.getName());
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -94,7 +94,7 @@ public class PubSubChannelProvisionerTests {
 		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
 				.provisionConsumerDestination("topic_A", null, this.properties);
 
-		this.pubSubChannelProvisioner.afterUnbindConsumer(result, null, this.properties);
+		this.pubSubChannelProvisioner.afterUnbindConsumer(result);
 
 		verify(this.pubSubAdminMock).deleteSubscription(result.getName());
 	}
@@ -104,8 +104,8 @@ public class PubSubChannelProvisionerTests {
 		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
 				.provisionConsumerDestination("topic_A", null, this.properties);
 
-		this.pubSubChannelProvisioner.afterUnbindConsumer(result, null, this.properties);
-		this.pubSubChannelProvisioner.afterUnbindConsumer(result, null, this.properties);
+		this.pubSubChannelProvisioner.afterUnbindConsumer(result);
+		this.pubSubChannelProvisioner.afterUnbindConsumer(result);
 
 		verify(this.pubSubAdminMock, times(1)).deleteSubscription(result.getName());
 	}
@@ -115,7 +115,7 @@ public class PubSubChannelProvisionerTests {
 		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
 				.provisionConsumerDestination("topic_A", "group1", this.properties);
 
-		this.pubSubChannelProvisioner.afterUnbindConsumer(result, "group1", this.properties);
+		this.pubSubChannelProvisioner.afterUnbindConsumer(result);
 
 		verify(this.pubSubAdminMock, never()).deleteSubscription(result.getName());
 	}


### PR DESCRIPTION
When a consumer group name is not provided for a consumer destination,
the binder will optionally create anonymous subscriptions. These
anonymous subscriptions will now be deleted when the consumer
destination shuts down and the `afterUnbindConsumer` method is called.

Fixes #1178.