### PR TITLE
Always create subscriptions for anonymous groups

### DIFF
--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -58,10 +58,12 @@ spring.cloud.stream.gcp.pubsub.bindings.events.producer.auto-create-resources=tr
 
 If automatic resource creation is turned ON and the subscription and/or the topic do not exist for a consumer, a subscription and potentially a topic will be created.
 The topic name will be the same as the destination name, and the subscription name will be the destination name followed by the consumer group name.
-If the consumer group is not specified, an anonymous one will be created with the name `anonymous.<destinationName>.<randomUUID>`.
+
+Regardless of the automatic resource creation setting, if the consumer group is not specified, an anonymous one will be created with the name `anonymous.<destinationName>.<randomUUID>`.
+Then when the binder shuts down, all Pub/Sub subscriptions created for anonymous consumer groups will be automatically cleaned up.
 
 For example, for the following configuration, a topic named `myEvents` and a subscription called `myEvents.counsumerGroup1` would be created.
-If the consumer group is not specified, a subscription called `anonymous.myEvents.a6d83782-c5a3-4861-ac38-e6e2af15a7be` would be created.
+If the consumer group is not specified, a subscription called `anonymous.myEvents.a6d83782-c5a3-4861-ac38-e6e2af15a7be` would be created and later cleaned up.
 
 IMPORTANT: If you are manually creating Pub/Sub subscriptions for consumers, make sure that they follow the naming convention of `<destinationName>.<consumerGroup>`.
 

--- a/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/spring-stream.adoc
@@ -59,7 +59,7 @@ spring.cloud.stream.gcp.pubsub.bindings.events.producer.auto-create-resources=tr
 If automatic resource creation is turned ON and the subscription and/or the topic do not exist for a consumer, a subscription and potentially a topic will be created.
 The topic name will be the same as the destination name, and the subscription name will be the destination name followed by the consumer group name.
 
-Regardless of the automatic resource creation setting, if the consumer group is not specified, an anonymous one will be created with the name `anonymous.<destinationName>.<randomUUID>`.
+Regardless of the `auto-create-resources` setting, if the consumer group is not specified, an anonymous one will be created with the name `anonymous.<destinationName>.<randomUUID>`.
 Then when the binder shuts down, all Pub/Sub subscriptions created for anonymous consumer groups will be automatically cleaned up.
 
 For example, for the following configuration, a topic named `myEvents` and a subscription called `myEvents.counsumerGroup1` would be created.

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubCommonProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubCommonProperties.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 original author or authors.
+ *  Copyright 2018 original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,10 +17,19 @@
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
 /**
- * @author João André Martins
- * @author Daniel Zou
+ * Properties commonn to consumers and producers.
+ *
  * @author Mike Eltsufin
+ * @since 1.1
  */
-public class PubSubConsumerProperties extends PubSubCommonProperties {
+public class PubSubCommonProperties {
+	private boolean autoCreateResources = true;
 
+	public boolean isAutoCreateResources() {
+		return this.autoCreateResources;
+	}
+
+	public void setAutoCreateResources(boolean autoCreateResources) {
+		this.autoCreateResources = autoCreateResources;
+	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubCommonProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubCommonProperties.java
@@ -17,12 +17,13 @@
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
 /**
- * Properties commonn to consumers and producers.
+ * Properties common to consumers and producers.
  *
  * @author Mike Eltsufin
  * @since 1.1
  */
 public class PubSubCommonProperties {
+
 	private boolean autoCreateResources = true;
 
 	public boolean isAutoCreateResources() {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
@@ -20,5 +20,5 @@ package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
  * @author João André Martins
  * @author Daniel Zou
  */
-public class PubSubProducerProperties {
+public class PubSubProducerProperties extends PubSubCommonProperties {
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -47,70 +47,77 @@ public class PubSubChannelProvisioner
 
 	private final PubSubAdmin pubSubAdmin;
 
-	private final Set<String> anonymousSubscriptions = new HashSet<>();
+	private final Set<String> anonymousSubscriptionNames = new HashSet<>();
 
 	public PubSubChannelProvisioner(PubSubAdmin pubSubAdmin) {
 		this.pubSubAdmin = pubSubAdmin;
 	}
 
 	@Override
-	public ProducerDestination provisionProducerDestination(String name,
+	public ProducerDestination provisionProducerDestination(String topic,
 			ExtendedProducerProperties<PubSubProducerProperties> properties)
 			throws ProvisioningException {
-		if (this.pubSubAdmin.getTopic(name) == null) {
-			this.pubSubAdmin.createTopic(name);
-		}
+		makeSureTopicExists(topic, properties.getExtension().isAutoCreateResources());
 
-		return new PubSubProducerDestination(name);
+		return new PubSubProducerDestination(topic);
 	}
 
 	@Override
-	public ConsumerDestination provisionConsumerDestination(String name, String group,
+	public ConsumerDestination provisionConsumerDestination(String topic, String group,
 			ExtendedConsumerProperties<PubSubConsumerProperties> properties)
 			throws ProvisioningException {
-		String subscription;
-		// Use <topic>.<groupName> as subscription name
-		// Generate anonymous random group, if one not provided
-		boolean anonymous = false;
+
+		makeSureTopicExists(topic, properties.getExtension().isAutoCreateResources());
+
+		String subscriptionName;
+		Subscription subscription;
 		if (StringUtils.hasText(group)) {
-			subscription = name + "." + group;
+			// Use <topic>.<group> as subscription name
+			subscriptionName = topic + "." + group;
+			subscription = this.pubSubAdmin.getSubscription(subscriptionName);
 		}
 		else {
-			subscription = "anonymous." + name + "." + UUID.randomUUID().toString();
-			anonymous = true;
+			// Generate anonymous random group since one wasn't provided
+			subscriptionName = "anonymous." + topic + "." + UUID.randomUUID().toString();
+			subscription = this.pubSubAdmin.createSubscription(subscriptionName, topic);
+			this.anonymousSubscriptionNames.add(subscriptionName);
 		}
 
-		Subscription pubSubSubscription = this.pubSubAdmin.getSubscription(subscription);
-		if (pubSubSubscription == null) {
+		// make sure subscription exists
+		if (subscription == null) {
 			if (properties.getExtension().isAutoCreateResources()) {
-				if (this.pubSubAdmin.getTopic(name) == null) {
-					this.pubSubAdmin.createTopic(name);
-				}
-
-				this.pubSubAdmin.createSubscription(subscription, name);
-
-				if (anonymous) {
-					this.anonymousSubscriptions.add(subscription);
-				}
+				this.pubSubAdmin.createSubscription(subscriptionName, topic);
 			}
 			else {
-				throw new ProvisioningException("Non-existing '" + subscription + "' subscription.");
+				throw new ProvisioningException("Non-existing '" + subscriptionName + "' subscription.");
 			}
 		}
-		else if (!pubSubSubscription.getTopic().equals(name)) {
-			throw new ProvisioningException("Existing '" + subscription + "' subscription is for a different topic '"
-					+ pubSubSubscription.getTopic() + "'.");
+		else if (!subscription.getTopic().equals(topic)) {
+			throw new ProvisioningException(
+					"Existing '" + subscriptionName + "' subscription is for a different topic '"
+							+ subscription.getTopic() + "'.");
 		}
-		return new PubSubConsumerDestination(subscription);
+		return new PubSubConsumerDestination(subscriptionName);
 	}
 
 	public void afterUnbindConsumer(ConsumerDestination destination) {
-		if (this.anonymousSubscriptions.remove(destination.getName())) {
+		if (this.anonymousSubscriptionNames.remove(destination.getName())) {
 			try {
 				this.pubSubAdmin.deleteSubscription(destination.getName());
 			}
 			catch (Exception ex) {
 				LOGGER.warn("Failed to delete auto-created anonymous subscription '" + destination.getName() + "'.");
+			}
+		}
+	}
+
+	private void makeSureTopicExists(String topic, boolean autoCreate) {
+		if (this.pubSubAdmin.getTopic(topic) == null) {
+			if (autoCreate) {
+				this.pubSubAdmin.createTopic(topic);
+			}
+			else {
+				throw new ProvisioningException("Non-existing '" + topic + "' topic.");
 			}
 		}
 	}

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -47,7 +47,7 @@ public class PubSubChannelProvisioner
 
 	private final PubSubAdmin pubSubAdmin;
 
-	private final Set<String> anonymousSubscriptionNames = new HashSet<>();
+	private final Set<String> anonymousGroupSubscriptionNames = new HashSet<>();
 
 	public PubSubChannelProvisioner(PubSubAdmin pubSubAdmin) {
 		this.pubSubAdmin = pubSubAdmin;
@@ -80,7 +80,7 @@ public class PubSubChannelProvisioner
 			// Generate anonymous random group since one wasn't provided
 			subscriptionName = "anonymous." + topic + "." + UUID.randomUUID().toString();
 			subscription = this.pubSubAdmin.createSubscription(subscriptionName, topic);
-			this.anonymousSubscriptionNames.add(subscriptionName);
+			this.anonymousGroupSubscriptionNames.add(subscriptionName);
 		}
 
 		// make sure subscription exists
@@ -101,7 +101,7 @@ public class PubSubChannelProvisioner
 	}
 
 	public void afterUnbindConsumer(ConsumerDestination destination) {
-		if (this.anonymousSubscriptionNames.remove(destination.getName())) {
+		if (this.anonymousGroupSubscriptionNames.remove(destination.getName())) {
 			try {
 				this.pubSubAdmin.deleteSubscription(destination.getName());
 			}


### PR DESCRIPTION
Previously, the binder would only create Pub/Sub subscriptions for
anonymous consumer groups when resource auto-creation was turned on.
This change ensures that we uncodnitionally create subscriptions for
anonymous consumer groups regardless of the auto-creation setting.

Fixes #1180.