### PR TITLE
Fix Pub/Sub extended properties tests errors

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
 import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.Topic;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -83,8 +84,12 @@ public class PubSubExtendedBindingsPropertiesTests {
 		@Bean
 		public PubSubAdmin pubSubAdmin() {
 			PubSubAdmin pubSubAdminMock = Mockito.mock(PubSubAdmin.class);
+			when(pubSubAdminMock.createSubscription(anyString(), anyString())).thenReturn(
+					Subscription.getDefaultInstance());
 			when(pubSubAdminMock.getSubscription(anyString())).thenReturn(
 					Subscription.getDefaultInstance());
+			when(pubSubAdminMock.getTopic(anyString())).thenReturn(
+					Topic.getDefaultInstance());
 			return pubSubAdminMock;
 		}
 


### PR DESCRIPTION
This adds additional mocks in the `PubSubExtendedBindingsPropertiesTests` so the test does not do real checks for the existence for topics/subscriptions (it is only interested in verifying the parsing and setting of the pub/sub extended properties).