### PR TITLE
Revert "Update hard-coded project version to 1.1.0.M3"

### DIFF
--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/UsageTrackingHeaderProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/UsageTrackingHeaderProvider.java
@@ -30,7 +30,7 @@ import com.google.api.gax.rpc.HeaderProvider;
  */
 public class UsageTrackingHeaderProvider implements HeaderProvider {
 
-	public static final String TRACKING_HEADER_PROJECT_VERSION = "1.1.0.M3";
+	public static final String TRACKING_HEADER_PROJECT_VERSION = "1.1.0.BUILD-SNAPSHOT";
 
 	/** Class whose project name and version will be used in the header */
 	private Class clazz;

--- a/spring-cloud-gcp-core/src/test/java/org/springframework/cloud/gcp/core/UsageTrackingHeaderProviderIT.java
+++ b/spring-cloud-gcp-core/src/test/java/org/springframework/cloud/gcp/core/UsageTrackingHeaderProviderIT.java
@@ -34,7 +34,6 @@ public class UsageTrackingHeaderProviderIT {
 	/**
 	 * This test is check if the hard-coded version needs to be manually updated.
 	 */
-	@Ignore
 	@Test
 	public void testGetHeaders() {
 		UsageTrackingHeaderProvider subject = new UsageTrackingHeaderProvider(this.getClass());

--- a/spring-cloud-gcp-core/src/test/java/org/springframework/cloud/gcp/core/UsageTrackingHeaderProviderIT.java
+++ b/spring-cloud-gcp-core/src/test/java/org/springframework/cloud/gcp/core/UsageTrackingHeaderProviderIT.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gcp.core;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Reverts spring-cloud/spring-cloud-gcp#1228

Awaiting actual M3 release, part of the Spring Cloud Greenwich M2.