### PR TITLE
Upgrade Guava by way of google-cloud-bom

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -176,7 +176,7 @@ public class DefaultDatastoreEntityConverterTests {
 		this.thrown.expectMessage("Unable to read property boolField");
 		this.thrown.expectMessage(
 				"Unable to convert class " +
-				"com.google.common.collect.SingletonImmutableList to class java.lang.Boolean");
+				"com.google.common.collect.RegularImmutableList to class java.lang.Boolean");
 
 		Entity entity = getEntityBuilder()
 				.set("stringField", "string value")

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<google-cloud-bom.version>0.70.0-alpha</google-cloud-bom.version>
+		<google-cloud-bom.version>0.71.0-alpha</google-cloud-bom.version>
 		<google-auth-library-oauth2-http.version>0.11.0</google-auth-library-oauth2-http.version>
 		<mysql-socket-factory.version>1.0.11</mysql-socket-factory.version>
 	</properties>


### PR DESCRIPTION
googleapis/google-cloud-java#3980 upgraded Guava (and gRPC/gax) and released version 0.71.

This should address the bulk of Snyk deserialization vulnerabilities.