### PR TITLE
Increase timeout on logging test

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/it/StackdriverLoggingIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/it/StackdriverLoggingIntegrationTests.java
@@ -95,7 +95,7 @@ public class StackdriverLoggingIntegrationTests {
 				.setCredentials(credentialsProvider.getCredentials())
 				.build().getService();
 
-		await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+		await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> {
 			Page<LogEntry> page = logClient.listLogEntries(
 					Logging.EntryListOption.filter("textPayload:\"#$%^&" + NOW + "\" AND"
 							+ " logName=\"projects/" + this.projectIdProvider.getProjectId()


### PR DESCRIPTION
I noticed another autoconfiguration logging test flake: https://api.travis-ci.org/v3/job/457015991/log.txt

Increase the timeout of the test from 30s to 60s now. This now matches the timeout of the [logging sample](https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java).

passed 20/20 runs locally.