### PR TITLE
Fix Postgres JDBC URL template

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/DatabaseType.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/DatabaseType.java
@@ -20,11 +20,14 @@ package org.springframework.cloud.gcp.autoconfigure.sql;
  * @author João André Martins
  */
 public enum DatabaseType {
-	MYSQL("com.mysql.jdbc.Driver", "jdbc:mysql://google/%s?cloudSqlInstance=%s&"
-			+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false"),
+	MYSQL("com.mysql.jdbc.Driver", "jdbc:mysql://google/%s?"
+			+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
+			+ "&cloudSqlInstance=%s"
+			+ "&useSSL=false"),
 
 	POSTGRESQL("org.postgresql.Driver", "jdbc:postgresql://google/%s?"
-			+ "socketFactory=com.google.cloud.sql.postgres.SocketFactory&socketFactoryArg=%s"
+			+ "socketFactory=com.google.cloud.sql.postgres.SocketFactory"
+			+ "&cloudSqlInstance=%s"
 			+ "&useSSL=false");
 
 	private final String jdbcDriverName;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfigurationMockTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfigurationMockTests.java
@@ -55,9 +55,10 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 							context.getBean(CloudSqlJdbcInfoProvider.class);
 					assertThat(dataSource.getDriverClassName()).matches("com.mysql.jdbc.Driver");
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
-							"jdbc:mysql://google/test-database?cloudSqlInstance="
-									+ "tubular-bells:singapore:test-instance&socketFactory="
-									+ "com.google.cloud.sql.mysql.SocketFactory&useSSL=false");
+							"jdbc:mysql://google/test-database?"
+									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
+									+ "&cloudSqlInstance=tubular-bells:singapore:test-instance"
+									+ "&useSSL=false");
 					assertThat(dataSource.getUsername()).matches("root");
 					assertThat(dataSource.getPassword()).isNull();
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
@@ -99,9 +100,10 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					CloudSqlJdbcInfoProvider urlProvider =
 							context.getBean(CloudSqlJdbcInfoProvider.class);
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
-							"jdbc:mysql://google/test-database"
-									+ "?cloudSqlInstance=proj:reg:test-instance&socketFactory="
-									+ "com.google.cloud.sql.mysql.SocketFactory&useSSL=false");
+							"jdbc:mysql://google/test-database?"
+									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
+									+ "&cloudSqlInstance=proj:reg:test-instance"
+									+ "&useSSL=false");
 					assertThat(dataSource.getUsername()).matches("watchmaker");
 					assertThat(dataSource.getPassword()).matches("pass");
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
@@ -120,9 +122,10 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					CloudSqlJdbcInfoProvider urlProvider =
 							context.getBean(CloudSqlJdbcInfoProvider.class);
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
-							"jdbc:mysql://google/test-database"
-									+ "?cloudSqlInstance=proj:reg:test-instance&socketFactory="
-									+ "com.google.cloud.sql.mysql.SocketFactory&useSSL=false");
+							"jdbc:mysql://google/test-database?"
+									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
+									+ "&cloudSqlInstance=proj:reg:test-instance"
+									+ "&useSSL=false");
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
 					assertThat(dataSource.getMaximumPoolSize()).isEqualTo(19);
 					assertThat(dataSource.getConnectionTestQuery()).matches("select 1");
@@ -137,9 +140,10 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					CloudSqlJdbcInfoProvider urlProvider =
 							context.getBean(CloudSqlJdbcInfoProvider.class);
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
-							"jdbc:mysql://google/test-database"
-									+ "?cloudSqlInstance=world:asia:japan&socketFactory="
-									+ "com.google.cloud.sql.mysql.SocketFactory&useSSL=false");
+							"jdbc:mysql://google/test-database?"
+									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
+									+ "&cloudSqlInstance=world:asia:japan"
+									+ "&useSSL=false");
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
 				});
 	}
@@ -154,9 +158,10 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					CloudSqlJdbcInfoProvider urlProvider =
 							context.getBean(CloudSqlJdbcInfoProvider.class);
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
-							"jdbc:postgresql://google/test-database?socketFactory=com.google.cloud"
-									+ ".sql.postgres.SocketFactory&socketFactoryArg="
-									+ "tubular-bells:singapore:test-instance&useSSL=false");
+							"jdbc:postgresql://google/test-database?"
+									+ "socketFactory=com.google.cloud.sql.postgres.SocketFactory"
+									+ "&cloudSqlInstance=tubular-bells:singapore:test-instance"
+									+ "&useSSL=false");
 					assertThat(urlProvider.getJdbcDriverClass()).matches("org.postgresql.Driver");
 				});
 	}


### PR DESCRIPTION
This addresses #1267.

The source of the issue stemmed from a change in the [google cloud postgres libraries](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/commit/94331f948406090020d69e51952acf01a474091e#diff-ab45f30d68cf0bb0948f0ac284e90aed):

In the above link, note how the SocketFactory class no longer accepts the “socketFactoryArg” but instead requires the “cloudSqlInstance” property to be set. This change occurred because ‘socketFactoryArg’ was deprecated by https://github.com/pgjdbc/pgjdbc/issues/1293.

The solution I have provided modifies our Postgres JDBC URL template to set the cloudSqlInstance property instead of socketFactoryArg.

I can add an integration test for postgres a separate PR, will discuss what is the best way to do this.
Will close #1267 after test is added.