### PR TITLE
Fix IAP issuer validation tests

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
@@ -177,7 +177,6 @@ public class IapAuthenticationAutoConfigurationTests {
 				.run(context -> {
 					DelegatingOAuth2TokenValidator validator
 							= context.getBean("iapJwtDelegatingValidator", DelegatingOAuth2TokenValidator.class);
-
 					assertFalse(validator.validate(mockJwt).hasErrors());
 				});
 	}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
@@ -178,8 +178,7 @@ public class IapAuthenticationAutoConfigurationTests {
 					DelegatingOAuth2TokenValidator validator
 							= context.getBean("iapJwtDelegatingValidator", DelegatingOAuth2TokenValidator.class);
 
-					System.out.println(validator.validate(mockJwt).getErrors());
-				//	assertFalse(validator.validate(mockJwt).hasErrors());
+					assertFalse(validator.validate(mockJwt).hasErrors());
 				});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gcp.autoconfigure.security;
 
-import java.net.URL;
 import java.time.Instant;
 
 import javax.servlet.http.HttpServletRequest;
@@ -171,14 +170,16 @@ public class IapAuthenticationAutoConfigurationTests {
 	public void testAudienceValidatorNotAddedWhenNotAvailable() throws Exception {
 		when(mockJwt.getExpiresAt()).thenReturn(Instant.now().plusSeconds(10));
 		when(mockJwt.getNotBefore()).thenReturn(Instant.now().minusSeconds(10));
-		when(mockJwt.getIssuer()).thenReturn(new URL("https://cloud.google.com/iap"));
+		when(mockJwt.getClaimAsString("iss")).thenReturn("https://cloud.google.com/iap");
 		verify(mockJwt, never()).getAudience();
 
 		this.contextRunner
 				.run(context -> {
 					DelegatingOAuth2TokenValidator validator
 							= context.getBean("iapJwtDelegatingValidator", DelegatingOAuth2TokenValidator.class);
-					assertFalse(validator.validate(mockJwt).hasErrors());
+
+					System.out.println(validator.validate(mockJwt).getErrors());
+				//	assertFalse(validator.validate(mockJwt).hasErrors());
 				});
 	}
 
@@ -186,7 +187,7 @@ public class IapAuthenticationAutoConfigurationTests {
 	public void testFixedStringAudienceValidatorAddedWhenAvailable() throws Exception {
 		when(mockJwt.getExpiresAt()).thenReturn(Instant.now().plusSeconds(10));
 		when(mockJwt.getNotBefore()).thenReturn(Instant.now().minusSeconds(10));
-		when(mockJwt.getIssuer()).thenReturn(new URL("https://cloud.google.com/iap"));
+		when(mockJwt.getClaimAsString("iss")).thenReturn("https://cloud.google.com/iap");
 
 		this.contextRunner
 				.withUserConfiguration(FixedAudienceValidatorConfiguration.class)


### PR DESCRIPTION
With spring-security 5.1.2, JwtIssuerValidator no longer uses getIssuer() method.