### PR TITLE
New GCP Bom maven surefire works fine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.20</version> <!-- version 2.22.0 brought in by BOMs crashes -->
 					<configuration>
 						<argLine>-Xms512m -Xmx512m</argLine>
 					</configuration>
@@ -321,7 +320,6 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>2.20</version>
 						<configuration>
 							<!-- need for JaCoCo -->
 							<argLine>@{argLine} -Xms512m -Xmx512m</argLine>


### PR DESCRIPTION
fixes #1222 
With the GCP Bom version bump recently it seems this works again. no need to lock down older surefire version