### PR TITLE
Migrate Datastore, Pub/Sub, Storage, and Core tests to use AssertJ

### DIFF
--- a/spring-cloud-gcp-core/src/test/java/org/springframework/cloud/gcp/core/DefaultCredentialsProviderTests.java
+++ b/spring-cloud-gcp-core/src/test/java/org/springframework/cloud/gcp/core/DefaultCredentialsProviderTests.java
@@ -22,8 +22,7 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author João André Martins
@@ -34,23 +33,23 @@ public class DefaultCredentialsProviderTests {
 	@Test
 	public void testResolveScopesDefaultScopes() throws IOException {
 		List<String> scopes = DefaultCredentialsProvider.resolveScopes(null);
-		assertTrue(scopes.size() > 1);
-		assertTrue(scopes.contains(GcpScope.PUBSUB.getUrl()));
+		assertThat(scopes.size()).isGreaterThan(1);
+		assertThat(scopes).contains(GcpScope.PUBSUB.getUrl());
 	}
 
 	@Test
 	public void testResolveScopesOverrideScopes() throws IOException {
 		List<String> scopes = DefaultCredentialsProvider.resolveScopes(ImmutableList.of("myscope"));
-		assertEquals(scopes.size(), 1);
-		assertTrue(scopes.contains("myscope"));
+		assertThat(scopes).hasSize(1);
+		assertThat(scopes).contains("myscope");
 	}
 
 	@Test
 	public void testResolveScopesStarterScopesPlaceholder() {
 		List<String> scopes = DefaultCredentialsProvider.resolveScopes(ImmutableList.of("DEFAULT_SCOPES", "myscope"));
-		assertTrue(scopes.size() == GcpScope.values().length + 1);
-		assertTrue(scopes.contains(GcpScope.PUBSUB.getUrl()));
-		assertTrue(scopes.contains("myscope"));
+		assertThat(scopes).hasSize(GcpScope.values().length + 1);
+		assertThat(scopes).contains(GcpScope.PUBSUB.getUrl());
+		assertThat(scopes).contains("myscope");
 	}
 
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplateTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplateTests.java
@@ -344,7 +344,7 @@ public class DatastoreTemplateTests {
 		when(this.datastore.get(eq(this.key1), eq(this.key2)))
 				.thenReturn(ImmutableList.of(this.e1, this.e2).iterator());
 		List<Key> keys = ImmutableList.of(this.key1, this.key2);
-		assertThat(this.datastoreTemplate.findAllById(keys, TestEntity.class)).contains(this.ob1, this.ob2);
+		assertThat(this.datastoreTemplate.findAllById(keys, TestEntity.class)).containsExactly(this.ob1, this.ob2);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplateTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplateTests.java
@@ -62,12 +62,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.util.ClassTypeInformation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.notNull;
@@ -318,32 +313,30 @@ public class DatastoreTemplateTests {
 					return "all done";
 				});
 
-		assertEquals("all done", finalResult);
+		assertThat(finalResult).isEqualTo("all done");
 		verify(transactionContext, times(1)).put((FullEntity<?>) any());
 		verify(transactionContext, times(3)).get((Key[]) any());
 	}
 
 	@Test
 	public void findAllByIdTestNotNull() {
-		assertTrue(this.datastoreTemplate
-				.findAllById(Collections.singletonList(this.badKey), TestEntity.class)
-				.isEmpty());
+		assertThat(
+				this.datastoreTemplate.findAllById(Collections.singletonList(this.badKey), TestEntity.class)).isEmpty();
 	}
 
 	@Test
 	public void findByIdTest() {
 		TestEntity result = this.datastoreTemplate.findById(this.key1, TestEntity.class);
-		assertEquals(this.ob1, result);
-		assertThat(result.childEntities, contains(this.childEntity1));
-		assertEquals(result.singularReference, this.childEntity1);
-		assertThat(result.multipleReference, contains(this.childEntity1));
+		assertThat(result).isEqualTo(this.ob1);
+		assertThat(result.childEntities).contains(this.childEntity1);
+		assertThat(this.childEntity1).isEqualTo(result.singularReference);
+		assertThat(result.multipleReference).contains(this.childEntity1);
 	}
 
 	@Test
 	public void findByIdNotFoundTest() {
 		when(this.datastore.get(ArgumentMatchers.<Key[]>any())).thenReturn(null);
-		assertNull(
-				this.datastoreTemplate.findById(createFakeKey("key0"), TestEntity.class));
+		assertThat(this.datastoreTemplate.findById(createFakeKey("key0"), TestEntity.class)).isNull();
 	}
 
 	@Test
@@ -351,14 +344,13 @@ public class DatastoreTemplateTests {
 		when(this.datastore.get(eq(this.key1), eq(this.key2)))
 				.thenReturn(ImmutableList.of(this.e1, this.e2).iterator());
 		List<Key> keys = ImmutableList.of(this.key1, this.key2);
-		assertThat(this.datastoreTemplate.findAllById(keys, TestEntity.class),
-				contains(this.ob1, this.ob2));
+		assertThat(this.datastoreTemplate.findAllById(keys, TestEntity.class)).contains(this.ob1, this.ob2);
 	}
 
 	@Test
 	public void saveTest() {
 		when(this.datastore.put((FullEntity<?>) any())).thenReturn(this.e1);
-		assertTrue(this.datastoreTemplate.save(this.ob1) instanceof TestEntity);
+		assertThat(this.datastoreTemplate.save(this.ob1) instanceof TestEntity).isTrue();
 
 		Entity writtenEntity = Entity.newBuilder(this.key1)
 				.set("singularReference", this.childKey4)
@@ -396,9 +388,9 @@ public class DatastoreTemplateTests {
 	@Test
 	public void saveTestNullDescendantsAndReferences() {
 		//making sure save works when descendants are null
-		assertNull(this.ob2.childEntities);
-		assertNull(this.ob2.singularReference);
-		assertNull(this.ob2.multipleReference);
+		assertThat(this.ob2.childEntities).isNull();
+		assertThat(this.ob2.singularReference).isNull();
+		assertThat(this.ob2.multipleReference).isNull();
 
 		this.datastoreTemplate.save(this.ob2);
 	}
@@ -431,7 +423,7 @@ public class DatastoreTemplateTests {
 		when(this.objectToKeyFactory.allocateKeyForObject(same(this.ob1), any()))
 				.thenReturn(this.key1);
 		when(this.datastore.put((FullEntity<?>) any())).thenReturn(this.e1);
-		assertTrue(this.datastoreTemplate.save(this.ob1) instanceof TestEntity);
+		assertThat(this.datastoreTemplate.save(this.ob1) instanceof TestEntity).isTrue();
 		Entity writtenEntity1 = Entity.newBuilder(this.key1)
 				.set("singularReference", this.childKey4)
 				.set("multipleReference", Arrays.asList(KeyValue.of(this.childKey5), KeyValue.of(this.childKey6)))
@@ -483,14 +475,13 @@ public class DatastoreTemplateTests {
 	@Test
 	public void findAllTest() {
 		this.datastoreTemplate.findAll(TestEntity.class);
-		assertThat(this.datastoreTemplate.findAll(TestEntity.class),
-				contains(this.ob1, this.ob2));
+		assertThat(this.datastoreTemplate.findAll(TestEntity.class)).contains(this.ob1, this.ob2);
 	}
 
 	@Test
 	public void queryTest() {
-		assertThat(this.datastoreTemplate.query((Query<Entity>) this.testEntityQuery,
-				TestEntity.class), contains(this.ob1, this.ob2));
+		assertThat(this.datastoreTemplate.query((Query<Entity>) this.testEntityQuery, TestEntity.class))
+				.contains(this.ob1, this.ob2);
 	}
 
 	@Test
@@ -512,13 +503,13 @@ public class DatastoreTemplateTests {
 		when(this.datastore
 				.run(eq(Query.newKeyQueryBuilder().setKind("custom_test_kind").build())))
 						.thenReturn(queryResults);
-		assertEquals(2, this.datastoreTemplate.count(TestEntity.class));
+		assertThat(this.datastoreTemplate.count(TestEntity.class)).isEqualTo(2);
 	}
 
 	@Test
 	public void existsByIdTest() {
-		assertTrue(this.datastoreTemplate.existsById(this.key1, TestEntity.class));
-		assertFalse(this.datastoreTemplate.existsById(this.badKey, TestEntity.class));
+		assertThat(this.datastoreTemplate.existsById(this.key1, TestEntity.class)).isTrue();
+		assertThat(this.datastoreTemplate.existsById(this.badKey, TestEntity.class)).isFalse();
 	}
 
 	@Test
@@ -564,7 +555,7 @@ public class DatastoreTemplateTests {
 		when(this.datastore
 				.run(eq(Query.newKeyQueryBuilder().setKind("custom_test_kind").build())))
 						.thenReturn(queryResults);
-		assertEquals(2, this.datastoreTemplate.deleteAll(TestEntity.class));
+		assertThat(this.datastoreTemplate.deleteAll(TestEntity.class)).isEqualTo(2);
 		verify(this.datastore, times(1)).delete(same(this.key1), same(this.key2));
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTransactionManagerTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTransactionManagerTests.java
@@ -32,8 +32,7 @@ import org.springframework.transaction.TransactionSystemException;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -78,19 +77,19 @@ public class DatastoreTransactionManagerTests {
 	public void testDoGetTransactionActive() {
 		when(this.transaction.isActive()).thenReturn(true);
 		this.tx.setTransaction(this.transaction);
-		assertSame(this.manager.doGetTransaction(), this.tx);
+		assertThat(this.manager.doGetTransaction()).isSameAs(this.tx);
 	}
 
 	@Test
 	public void testDoGetTransactionNotActive() {
 		when(this.transaction.isActive()).thenReturn(false);
 		this.tx.setTransaction(this.transaction);
-		assertNotSame(this.tx, this.manager.doGetTransaction());
+		assertThat(this.manager.doGetTransaction()).isNotSameAs(this.tx);
 	}
 
 	@Test
 	public void testDoGetTransactionNoTransaction() {
-		assertNotSame(this.tx, this.manager.doGetTransaction());
+		assertThat(this.manager.doGetTransaction()).isNotSameAs(this.tx);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTransactionTemplateTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTransactionTemplateTests.java
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -112,7 +112,7 @@ public class DatastoreTransactionTemplateTests {
 		catch (Exception e) {
 			exception = e;
 		}
-		assertNotNull(exception);
+		assertThat(exception).isNotNull();
 		verify(this.transaction, times(0)).commit();
 		verify(this.transaction, times(1)).rollback();
 		verify(this.datastore, times(1)).newTransaction();

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
@@ -54,7 +54,7 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 	public void getKeyFromIdKeyTest() {
 		when(this.datastore.newKeyFactory()).thenReturn(new KeyFactory("p").setKind("k"));
 		Key key = new KeyFactory("project").setKind("kind").newKey("key");
-		assertThat(this.datastoreServiceObjectToKeyFactory.getKeyFromId(key, "kind")).isEqualTo(key);
+		assertThat(this.datastoreServiceObjectToKeyFactory.getKeyFromId(key, "kind")).isSameAs(key);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
@@ -29,9 +29,7 @@ import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreDataEx
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
 import org.springframework.data.annotation.Id;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -56,24 +54,21 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 	public void getKeyFromIdKeyTest() {
 		when(this.datastore.newKeyFactory()).thenReturn(new KeyFactory("p").setKind("k"));
 		Key key = new KeyFactory("project").setKind("kind").newKey("key");
-		assertSame(key,
-				this.datastoreServiceObjectToKeyFactory.getKeyFromId(key, "kind"));
+		assertThat(this.datastoreServiceObjectToKeyFactory.getKeyFromId(key, "kind")).isEqualTo(key);
 	}
 
 	@Test
 	public void getKeyFromIdStringTest() {
 		when(this.datastore.newKeyFactory()).thenReturn(new KeyFactory("p").setKind("k"));
-		assertEquals(new KeyFactory("p").setKind("custom_test_kind").newKey("key"),
-				this.datastoreServiceObjectToKeyFactory.getKeyFromId("key",
-						"custom_test_kind"));
+		assertThat(this.datastoreServiceObjectToKeyFactory.getKeyFromId("key", "custom_test_kind"))
+				.isEqualTo(new KeyFactory("p").setKind("custom_test_kind").newKey("key"));
 	}
 
 	@Test
 	public void getKeyFromIdLongTest() {
 		when(this.datastore.newKeyFactory()).thenReturn(new KeyFactory("p").setKind("k"));
-		assertEquals(new KeyFactory("p").setKind("custom_test_kind").newKey(3L),
-				this.datastoreServiceObjectToKeyFactory.getKeyFromId(3L,
-						"custom_test_kind"));
+		assertThat(new KeyFactory("p").setKind("custom_test_kind").newKey(3L))
+				.isEqualTo(this.datastoreServiceObjectToKeyFactory.getKeyFromId(3L, "custom_test_kind"));
 	}
 
 	@Test
@@ -89,10 +84,12 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 		when(this.datastore.newKeyFactory()).thenReturn(new KeyFactory("p").setKind("k"));
 		TestEntityWithId testEntity = new TestEntityWithId();
 		testEntity.id = "testkey";
-		assertEquals(new KeyFactory("p").setKind("custom_test_kind").newKey("testkey"),
-				this.datastoreServiceObjectToKeyFactory.getKeyFromObject(testEntity,
-						this.datastoreMappingContext
-								.getPersistentEntity(TestEntityWithId.class)));
+
+		Key actual = this.datastoreServiceObjectToKeyFactory.getKeyFromObject(
+				testEntity, this.datastoreMappingContext.getPersistentEntity(TestEntityWithId.class));
+		Key expectedKey = new KeyFactory("p").setKind("custom_test_kind").newKey("testkey");
+
+		assertThat(actual).isEqualTo(expectedKey);
 	}
 
 	@Test
@@ -107,9 +104,9 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 
 	@Test
 	public void nullIdTest() {
-		assertNull(this.datastoreServiceObjectToKeyFactory
+		assertThat(this.datastoreServiceObjectToKeyFactory
 				.getKeyFromObject(new TestEntityWithId(), this.datastoreMappingContext
-						.getPersistentEntity(TestEntityWithId.class)));
+						.getPersistentEntity(TestEntityWithId.class))).isNull();
 	}
 
 	@Test
@@ -130,8 +127,8 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 				.allocateKeyForObject(testEntityWithKeyId, this.datastoreMappingContext
 						.getPersistentEntity(testEntityWithKeyId.getClass()));
 		Key key = new KeyFactory("project").setKind("custom_test_kind").newKey(123L);
-		assertEquals(key, allocatedKey);
-		assertEquals(key, testEntityWithKeyId.id);
+		assertThat(allocatedKey).isEqualTo(key);
+		assertThat(testEntityWithKeyId.id).isEqualTo(key);
 
 		Key allocatedKeyWithAncestor = this.datastoreServiceObjectToKeyFactory
 				.allocateKeyForObject(testEntityWithKeyId, this.datastoreMappingContext
@@ -139,8 +136,8 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 		Key keyWithAncestor = new KeyFactory("project").setKind("custom_test_kind")
 				.addAncestor(PathElement.of(key.getKind(), key.getId()))
 				.newKey(456L);
-		assertEquals(keyWithAncestor, allocatedKeyWithAncestor);
-		assertEquals(keyWithAncestor, testEntityWithKeyId.id);
+		assertThat(allocatedKeyWithAncestor).isEqualTo(keyWithAncestor);
+		assertThat(testEntityWithKeyId.id).isEqualTo(keyWithAncestor);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -50,7 +50,6 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Dmitry Solomakha
@@ -601,19 +600,17 @@ public class DefaultDatastoreEntityConverterTests {
 
 		assertThat(((BaseEntity) embeddedMapValuesEmbeddedEntityA.get(0).get())
 				.getString("stringField")).isEqualTo("item 0");
-		assertEquals(1, embeddedMapValuesEmbeddedEntityA.size());
+		assertThat(embeddedMapValuesEmbeddedEntityA.size()).isEqualTo(1);
 
 		assertThat(((BaseEntity) embeddedMapValuesEmbeddedEntityB.get(0).get())
 				.getString("stringField")).isEqualTo("item 1");
-		assertEquals(1, embeddedMapValuesEmbeddedEntityB.size());
+		assertThat(embeddedMapValuesEmbeddedEntityB.size()).isEqualTo(1);
 
 		TestItemWithEmbeddedEntity read = entityConverter
 				.read(TestItemWithEmbeddedEntity.class, entity);
 
-		assertEquals("valueA",
-				read.getNestedEmbeddedMaps().get("outer1").get(1L).get("a"));
-		assertEquals("valueB",
-				read.getNestedEmbeddedMaps().get("outer1").get(1L).get("b"));
+		assertThat(read.getNestedEmbeddedMaps().get("outer1").get(1L).get("a")).isEqualTo("valueA");
+		assertThat(read.getNestedEmbeddedMaps().get("outer1").get(1L).get("b")).isEqualTo("valueB");
 
 		assertThat(read).as("read objects equals the original one").isEqualTo(item);
 	}

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastorePersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastorePersistentEntityImplTests.java
@@ -28,11 +28,7 @@ import org.springframework.data.mapping.SimplePropertyHandler;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.expression.spel.SpelEvaluationException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,8 +44,7 @@ public class DatastorePersistentEntityImplTests {
 	public void testTableName() {
 		DatastorePersistentEntityImpl<TestEntity> entity = new DatastorePersistentEntityImpl<>(
 				ClassTypeInformation.from(TestEntity.class));
-
-		assertThat(entity.kindName(), is("custom_test_kind"));
+		assertThat(entity.kindName()).isEqualTo("custom_test_kind");
 	}
 
 	@Test
@@ -57,7 +52,7 @@ public class DatastorePersistentEntityImplTests {
 		DatastorePersistentEntityImpl<EntityNoCustomName> entity = new DatastorePersistentEntityImpl<>(
 				ClassTypeInformation.from(EntityNoCustomName.class));
 
-		assertThat(entity.kindName(), is("entityNoCustomName"));
+		assertThat(entity.kindName()).isEqualTo("entityNoCustomName");
 	}
 
 	@Test
@@ -65,7 +60,7 @@ public class DatastorePersistentEntityImplTests {
 		DatastorePersistentEntityImpl<EntityEmptyCustomName> entity = new DatastorePersistentEntityImpl<>(
 				ClassTypeInformation.from(EntityEmptyCustomName.class));
 
-		assertThat(entity.kindName(), is("entityEmptyCustomName"));
+		assertThat(entity.kindName()).isEqualTo("entityEmptyCustomName");
 	}
 
 	@Test
@@ -88,19 +83,18 @@ public class DatastorePersistentEntityImplTests {
 		when(applicationContext.containsBean("kindPostfix")).thenReturn(true);
 
 		entity.setApplicationContext(applicationContext);
-		assertThat(entity.kindName(), is("kind_something"));
+		assertThat(entity.kindName()).isEqualTo("kind_something");
 	}
 
 	@Test
 	public void testHasIdProperty() {
-		assertTrue(new DatastoreMappingContext().getPersistentEntity(TestEntity.class)
-				.hasIdProperty());
+		assertThat(new DatastoreMappingContext().getPersistentEntity(TestEntity.class)
+				.hasIdProperty()).isTrue();
 	}
 
 	@Test
 	public void testHasNoIdProperty() {
-		assertFalse(new DatastoreMappingContext()
-				.getPersistentEntity(EntityWithNoId.class).hasIdProperty());
+		assertThat(new DatastoreMappingContext().getPersistentEntity(EntityWithNoId.class).hasIdProperty()).isFalse();
 	}
 
 	@Test
@@ -122,8 +116,9 @@ public class DatastorePersistentEntityImplTests {
 		DatastorePersistentEntity p = new DatastoreMappingContext()
 				.getPersistentEntity(TestEntity.class);
 		PersistentPropertyAccessor accessor = p.getPropertyAccessor(t);
-		p.doWithProperties((SimplePropertyHandler) property -> assertNotEquals("b",
-				accessor.getProperty(property)));
+
+		p.doWithProperties(
+				(SimplePropertyHandler) property -> assertThat(accessor.getProperty(property)).isNotEqualTo("b"));
 	}
 
 	@Entity(name = "custom_test_kind")

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastorePersistentPropertyImplTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastorePersistentPropertyImplTests.java
@@ -27,11 +27,8 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mapping.PropertyHandler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Chengyuan Zhao
@@ -49,35 +46,31 @@ public class DatastorePersistentPropertyImplTests {
 				.doWithProperties(
 						(PropertyHandler<DatastorePersistentProperty>) property -> {
 							if (property.isIdProperty()) {
-								assertEquals("id", property.getFieldName());
+								assertThat(property.getFieldName()).isEqualTo("id");
 							}
 							else if (property.getFieldName().equals("custom_field")) {
-								assertEquals(String.class, property.getType());
+								assertThat(property.getType()).isEqualTo(String.class);
 							}
 							else if (property.getFieldName().equals("other")) {
-								assertEquals(String.class, property.getType());
+								assertThat(property.getType()).isEqualTo(String.class);
 							}
 							else if (property.getFieldName().equals("doubleList")) {
-								assertEquals(Double.class,
-										property.getComponentType());
-								assertTrue(property.isCollectionLike());
+								assertThat(property.getComponentType()).isEqualTo(Double.class);
+								assertThat(property.isCollectionLike()).isTrue();
 							}
 							else if (property.getFieldName().equals("embeddedEntity")) {
-								assertTrue(property
-										.getEmbeddedType() == EmbeddedType.EMBEDDED_ENTITY);
+								assertThat(property.getEmbeddedType()).isEqualTo(EmbeddedType.EMBEDDED_ENTITY);
 							}
 							else if (property.getFieldName().equals("embeddedMap")) {
-								assertTrue(property
-										.getEmbeddedType() == EmbeddedType.EMBEDDED_MAP);
-								assertEquals(String.class,
-										property.getTypeInformation().getTypeArguments()
-												.get(1).getType());
+								assertThat(property.getEmbeddedType()).isEqualTo(EmbeddedType.EMBEDDED_MAP);
+								assertThat(property.getTypeInformation().getTypeArguments().get(1).getType())
+										.isEqualTo(String.class);
 							}
 							else if (property.getFieldName().equals("linkedEntity")) {
-								assertTrue(property.isDescendants());
+								assertThat(property.isDescendants()).isTrue();
 							}
 							else if (property.getFieldName().equals("linkedEntityRef")) {
-								assertTrue(property.isReference());
+								assertThat(property.isReference()).isTrue();
 							}
 							else {
 								fail("All properties of the test entity are expected to match a checked"
@@ -90,10 +83,9 @@ public class DatastorePersistentPropertyImplTests {
 	public void testAssociations() {
 		this.datastoreMappingContext.getPersistentEntity(TestEntity.class)
 				.doWithProperties((PropertyHandler<DatastorePersistentProperty>) prop -> {
-					assertSame(prop, ((DatastorePersistentPropertyImpl) prop)
-							.createAssociation().getInverse());
-					assertNull(((DatastorePersistentPropertyImpl) prop)
-							.createAssociation().getObverse());
+					assertThat(prop).isEqualTo(
+							((DatastorePersistentPropertyImpl) prop).createAssociation().getInverse());
+					assertThat(((DatastorePersistentPropertyImpl) prop).createAssociation().getObverse()).isNull();
 				});
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastorePersistentPropertyImplTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastorePersistentPropertyImplTests.java
@@ -83,7 +83,7 @@ public class DatastorePersistentPropertyImplTests {
 	public void testAssociations() {
 		this.datastoreMappingContext.getPersistentEntity(TestEntity.class)
 				.doWithProperties((PropertyHandler<DatastorePersistentProperty>) prop -> {
-					assertThat(prop).isEqualTo(
+					assertThat(prop).isSameAs(
 							((DatastorePersistentPropertyImpl) prop).createAssociation().getInverse());
 					assertThat(((DatastorePersistentPropertyImpl) prop).createAssociation().getObverse()).isNull();
 				});

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -143,7 +143,7 @@ public class DatastoreIntegrationTests {
 		assertThat(
 				this.testEntityRepository.removeByColor("red").stream()
 						.map(TestEntity::getId).collect(Collectors.toList()))
-								.contains(1L, 3L, 4L);
+								.containsExactlyInAnyOrder(1L, 3L, 4L);
 
 		this.testEntityRepository.saveAll(allTestEntities);
 
@@ -170,10 +170,10 @@ public class DatastoreIntegrationTests {
 		assertThat(
 				this.testEntityRepository.findTop3BySizeAndColor(1, "red").stream()
 						.map(TestEntity::getId).collect(Collectors.toList()))
-								.contains(1L, 3L, 4L);
+								.containsExactlyInAnyOrder(1L, 3L, 4L);
 
 		assertThat(this.testEntityRepository.getKeys().stream().map(Key::getId).collect(Collectors.toList()))
-				.contains(1L, 2L, 3L, 4L);
+				.containsExactlyInAnyOrder(1L, 2L, 3L, 4L);
 
 		assertThat(foundByCustomQuery.size()).isEqualTo(1);
 		assertThat(this.testEntityRepository.countEntitiesWithCustomQuery(1L)).isEqualTo(4);

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -43,17 +43,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.iterableWithSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 /**
@@ -126,26 +117,23 @@ public class DatastoreIntegrationTests {
 				() -> this.testEntityRepository.countBySize(1L) == 4);
 
 		assertThat(this.testEntityRepository.findByShape(Shape.SQUARE).stream()
-				.map(x -> x.getId()).collect(Collectors.toList()), contains(4L));
+				.map(x -> x.getId()).collect(Collectors.toList())).contains(4L);
 
-		assertThat(this.testEntityRepository.findByColor("red",
-				PageRequest.of(0, 1)).hasNext(), is(true));
-		assertThat(this.testEntityRepository.findByColor("red", PageRequest.of(1, 1)).hasNext(),
-				is(true));
-		assertThat(this.testEntityRepository.findByColor("red", PageRequest.of(2, 1)).hasNext(),
-				is(false));
+		assertThat(this.testEntityRepository.findByColor("red", PageRequest.of(0, 1)).hasNext()).isTrue();
+		assertThat(this.testEntityRepository.findByColor("red", PageRequest.of(1, 1)).hasNext()).isTrue();
+		assertThat(
+				this.testEntityRepository.findByColor("red", PageRequest.of(2, 1)).hasNext()).isFalse();
 
 		Page<TestEntity> circles = this.testEntityRepository.findByShape(Shape.CIRCLE, PageRequest.of(0, 2));
-		assertThat(circles.getTotalElements(), equalTo(3L));
-		assertThat(circles.getTotalPages(), equalTo(2));
-		assertThat(circles.get().count(), equalTo(2L));
-		assertThat(circles.get().allMatch(e -> e.getShape().equals(Shape.CIRCLE)), is(true));
-
+		assertThat(circles.getTotalElements()).isEqualTo(3L);
+		assertThat(circles.getTotalPages()).isEqualTo(2);
+		assertThat(circles.get().count()).isEqualTo(2L);
+		assertThat(circles.get().allMatch(e -> e.getShape().equals(Shape.CIRCLE))).isTrue();
 
 		assertThat(this.testEntityRepository.findByEnumQueryParam(Shape.SQUARE).stream()
-				.map(x -> x.getId()).collect(Collectors.toList()), contains(4L));
+				.map(x -> x.getId()).collect(Collectors.toList())).contains(4L);
 
-		assertEquals(4, this.testEntityRepository.deleteBySize(1L));
+		assertThat(this.testEntityRepository.deleteBySize(1L)).isEqualTo(4);
 
 		this.testEntityRepository.saveAll(allTestEntities);
 
@@ -154,19 +142,19 @@ public class DatastoreIntegrationTests {
 
 		assertThat(
 				this.testEntityRepository.removeByColor("red").stream()
-						.map(TestEntity::getId).collect(Collectors.toList()),
-				containsInAnyOrder(1L, 3L, 4L));
+						.map(TestEntity::getId).collect(Collectors.toList()))
+								.contains(1L, 3L, 4L);
 
 		this.testEntityRepository.saveAll(allTestEntities);
 
-		assertNull(this.testEntityRepository.findById(1L).get().getBlobField());
+		assertThat(this.testEntityRepository.findById(1L).get().getBlobField()).isNull();
 
 		testEntityA.setBlobField(Blob.copyFrom("testValueA".getBytes()));
 
 		this.testEntityRepository.save(testEntityA);
 
-		assertEquals(Blob.copyFrom("testValueA".getBytes()),
-				this.testEntityRepository.findById(1L).get().getBlobField());
+		assertThat(this.testEntityRepository.findById(1L).get().getBlobField())
+				.isEqualTo(Blob.copyFrom("testValueA".getBytes()));
 
 		millisWaited = Math.max(millisWaited, waitUntilTrue(
 				() -> this.testEntityRepository.countBySizeAndColor(1L, "red") == 3));
@@ -176,45 +164,42 @@ public class DatastoreIntegrationTests {
 		TestEntity[] foundByCustomProjectionQuery = this.testEntityRepository
 				.findEntitiesWithCustomProjectionQuery(1L);
 
-		assertEquals(1, this.testEntityRepository.countBySizeAndColor(1, "blue"));
-		assertEquals("blue", this.testEntityRepository.getById(2L).getColor());
-		assertEquals(3,
-				this.testEntityRepository.countBySizeAndColor(1, "red"));
+		assertThat(this.testEntityRepository.countBySizeAndColor(1, "blue")).isEqualTo(1);
+		assertThat(this.testEntityRepository.getById(2L).getColor()).isEqualTo("blue");
+		assertThat(this.testEntityRepository.countBySizeAndColor(1, "red")).isEqualTo(3);
 		assertThat(
 				this.testEntityRepository.findTop3BySizeAndColor(1, "red").stream()
-						.map(TestEntity::getId).collect(Collectors.toList()),
-				containsInAnyOrder(1L, 3L, 4L));
+						.map(TestEntity::getId).collect(Collectors.toList()))
+								.contains(1L, 3L, 4L);
 
-		assertThat(this.testEntityRepository.getKeys().stream().map(Key::getId)
-				.collect(Collectors.toList()), containsInAnyOrder(1L, 2L, 3L, 4L));
+		assertThat(this.testEntityRepository.getKeys().stream().map(Key::getId).collect(Collectors.toList()))
+				.contains(1L, 2L, 3L, 4L);
 
-		assertEquals(1, foundByCustomQuery.size());
-		assertEquals(4, this.testEntityRepository.countEntitiesWithCustomQuery(1L));
-		assertTrue(this.testEntityRepository.existsByEntitiesWithCustomQuery(1L));
-		assertEquals(Blob.copyFrom("testValueA".getBytes()),
-				foundByCustomQuery.get(0).getBlobField());
+		assertThat(foundByCustomQuery.size()).isEqualTo(1);
+		assertThat(this.testEntityRepository.countEntitiesWithCustomQuery(1L)).isEqualTo(4);
+		assertThat(this.testEntityRepository.existsByEntitiesWithCustomQuery(1L)).isTrue();
+		assertThat(foundByCustomQuery.get(0).getBlobField()).isEqualTo(Blob.copyFrom("testValueA".getBytes()));
 
-		assertEquals(1, foundByCustomProjectionQuery.length);
-		assertNull(foundByCustomProjectionQuery[0].getBlobField());
-		assertEquals((Long) 1L, foundByCustomProjectionQuery[0].getId());
+		assertThat(foundByCustomProjectionQuery.length).isEqualTo(1);
+		assertThat(foundByCustomProjectionQuery[0].getBlobField()).isNull();
+		assertThat(foundByCustomProjectionQuery[0].getId()).isEqualTo((Long) 1L);
 
 		testEntityA.setBlobField(null);
 
-		assertEquals((Long) 1L, this.testEntityRepository.getKey().getId());
-		assertEquals(1, this.testEntityRepository.getIds(1L).length);
-		assertEquals(1, this.testEntityRepository.getOneId(1L));
-		assertNotNull(this.testEntityRepository.getOneTestEntity(1L));
+		assertThat(this.testEntityRepository.getKey().getId()).isEqualTo((Long) 1L);
+		assertThat(this.testEntityRepository.getIds(1L).length).isEqualTo(1);
+		assertThat(this.testEntityRepository.getOneId(1L)).isEqualTo(1);
+		assertThat(this.testEntityRepository.getOneTestEntity(1L)).isNotNull();
 
 		this.testEntityRepository.save(testEntityA);
 
-		assertNull(this.testEntityRepository.findById(1L).get().getBlobField());
+		assertThat(this.testEntityRepository.findById(1L).get().getBlobField()).isNull();
 
-		assertThat(this.testEntityRepository.findAllById(ImmutableList.of(1L, 2L)),
-				iterableWithSize(2));
+		assertThat(this.testEntityRepository.findAllById(ImmutableList.of(1L, 2L))).hasSize(2);
 
 		this.testEntityRepository.delete(testEntityA);
 
-		assertFalse(this.testEntityRepository.findById(1L).isPresent());
+		assertThat(this.testEntityRepository.findById(1L).isPresent()).isFalse();
 
 		this.testEntityRepository.deleteAll();
 
@@ -238,10 +223,9 @@ public class DatastoreIntegrationTests {
 		// show up if it is unexpectedly successful and committed.
 		Thread.sleep(millisWaited * WAIT_FOR_EVENTUAL_CONSISTENCY_SAFETY_MULTIPLE);
 
-		assertEquals(0, this.testEntityRepository.count());
+		assertThat(this.testEntityRepository.count()).isEqualTo(0);
 
-		assertFalse(this.testEntityRepository.findAllById(ImmutableList.of(1L, 2L))
-				.iterator().hasNext());
+		assertThat(this.testEntityRepository.findAllById(ImmutableList.of(1L, 2L)).iterator().hasNext()).isFalse();
 	}
 
 	@Test
@@ -256,7 +240,7 @@ public class DatastoreIntegrationTests {
 
 		EmbeddableTreeNode loaded = this.datastoreTemplate.findById(7L, EmbeddableTreeNode.class);
 
-		assertEquals(treeNode7, loaded);
+		assertThat(loaded).isEqualTo(treeNode7);
 	}
 
 	@Test
@@ -273,7 +257,7 @@ public class DatastoreIntegrationTests {
 
 		TreeCollection loaded = this.datastoreTemplate.findById(1L, TreeCollection.class);
 
-		assertEquals(treeCollection, loaded);
+		assertThat(loaded).isEqualTo(treeCollection);
 	}
 
 	@Test
@@ -292,7 +276,7 @@ public class DatastoreIntegrationTests {
 		});
 
 		AncestorEntity loadedEntity = this.datastoreTemplate.findById(ancestorEntity.id, AncestorEntity.class);
-		assertEquals(ancestorEntity, loadedEntity);
+		assertThat(loadedEntity).isEqualTo(ancestorEntity);
 
 		ancestorEntity.descendants.forEach(descendatEntry -> descendatEntry.name = descendatEntry.name + " updated");
 		this.datastoreTemplate.save(ancestorEntity);
@@ -302,7 +286,7 @@ public class DatastoreIntegrationTests {
 
 		AncestorEntity loadedEntityAfterUpdate =
 				this.datastoreTemplate.findById(ancestorEntity.id, AncestorEntity.class);
-		assertEquals(ancestorEntity, loadedEntityAfterUpdate);
+		assertThat(loadedEntityAfterUpdate).isEqualTo(ancestorEntity);
 	}
 
 	@Test
@@ -316,7 +300,7 @@ public class DatastoreIntegrationTests {
 		waitUntilTrue(() -> this.datastoreTemplate.findAll(ReferenceEntry.class).size() == 4);
 
 		ReferenceEntry loadedParent = this.datastoreTemplate.findById(parent.id, ReferenceEntry.class);
-		assertEquals(parent, loadedParent);
+		assertThat(loadedParent).isEqualTo(parent);
 
 		parent.name = "parent updated";
 		parent.childeren.forEach(child -> child.name = child.name + " updated");
@@ -329,7 +313,7 @@ public class DatastoreIntegrationTests {
 						.stream().allMatch(entry -> entry.name.contains("updated")));
 
 		ReferenceEntry loadedParentAfterUpdate = this.datastoreTemplate.findById(parent.id, ReferenceEntry.class);
-		assertEquals(parent, loadedParentAfterUpdate);
+		assertThat(loadedParentAfterUpdate).isEqualTo(parent);
 	}
 
 	@Test
@@ -344,7 +328,7 @@ public class DatastoreIntegrationTests {
 		this.datastoreTemplate.writeMap(this.keyForMap, map);
 		Map<String, Long> loadedMap = this.datastoreTemplate.findByIdAsMap(this.keyForMap, Long.class);
 
-		assertEquals(map, loadedMap);
+		assertThat(loadedMap).isEqualTo(map);
 	}
 
 	private long waitUntilTrue(Supplier<Boolean> condition) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TransactionalTemplateService.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TransactionalTemplateService.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * A transactional service used for integration tests.
@@ -39,8 +39,7 @@ public class TransactionalTemplateService {
 			throws InterruptedException {
 
 		for (TestEntity testEntity : testEntities) {
-			assertNull(this.datastoreTemplate.findById(testEntity.getId(),
-					TestEntity.class));
+			assertThat(this.datastoreTemplate.findById(testEntity.getId(), TestEntity.class)).isNull();
 		}
 
 		this.datastoreTemplate.saveAll(testEntities);
@@ -52,8 +51,7 @@ public class TransactionalTemplateService {
 		// Datastore transactions always see the state at the start of the transaction. Even
 		// after waiting these entities should not be found.
 		for (TestEntity testEntity : testEntities) {
-			assertNull(this.datastoreTemplate.findById(testEntity.getId(),
-					TestEntity.class));
+			assertThat(this.datastoreTemplate.findById(testEntity.getId(), TestEntity.class)).isNull();
 		}
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -24,6 +24,7 @@ import com.google.cloud.datastore.DoubleValue;
 import com.google.cloud.datastore.GqlQuery;
 import com.google.cloud.datastore.LongValue;
 import com.google.cloud.datastore.Value;
+import org.assertj.core.data.Offset;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -43,7 +44,7 @@ import org.springframework.data.repository.query.QueryMethodEvaluationContextPro
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -59,6 +60,8 @@ import static org.mockito.Mockito.when;
  * @author Chengyuan Zhao
  */
 public class GqlDatastoreQueryTests {
+
+	private static final Offset<Double> COMPARE_OFFSET = Offset.offset(0.00001);
 
 	private DatastoreTemplate datastoreTemplate;
 
@@ -144,36 +147,32 @@ public class GqlDatastoreQueryTests {
 		doAnswer(invocation -> {
 			GqlQuery statement = invocation.getArgument(0);
 
-			assertEquals(entityResolvedGql, statement.getQueryString());
+			assertThat(statement.getQueryString()).isEqualTo(entityResolvedGql);
 
 			Map<String, Value> paramMap = statement.getNamedBindings();
 
-			assertEquals(params[0], paramMap.get("tag0").get());
-			assertEquals(params[1], paramMap.get("tag1").get());
+			assertThat(paramMap.get("tag0").get()).isEqualTo(params[0]);
+			assertThat(paramMap.get("tag1").get()).isEqualTo(params[1]);
 
 			// custom conversion is expected to have been used in this param
-			assertEquals(1L,
-					(long) ((LongValue) (((List) paramMap.get("tag2").get()).get(0))).get());
-			assertEquals(2L,
-					(long) ((LongValue) (((List) paramMap.get("tag2").get()).get(1))).get());
+			assertThat((long) ((LongValue) (((List) paramMap.get("tag2").get()).get(0))).get()).isEqualTo(1L);
+			assertThat((long) ((LongValue) (((List) paramMap.get("tag2").get()).get(1))).get()).isEqualTo(2L);
 
-			assertEquals(((double[]) params[3])[0],
-					((DoubleValue) (((List) paramMap.get("tag3").get()).get(0))).get(),
-					0.00001);
-			assertEquals(((double[]) params[3])[1],
-					((DoubleValue) (((List) paramMap.get("tag3").get()).get(1))).get(),
-					0.00001);
+			double actual = ((DoubleValue) (((List) paramMap.get("tag3").get()).get(0))).get();
+			assertThat(actual).isEqualTo(((double[]) params[3])[0], COMPARE_OFFSET);
+
+			actual = ((DoubleValue) (((List) paramMap.get("tag3").get()).get(1))).get();
+			assertThat(actual).isEqualTo(((double[]) params[3])[1], COMPARE_OFFSET);
+
 			// 3L is expected even though 3 int was the original param due to custom conversions
-			assertEquals(3L, paramMap.get("tag4").get());
-			assertEquals(params[5], paramMap.get("tag5").get());
-			assertEquals(params[6], paramMap.get("tag6").get());
-			assertEquals(params[7], paramMap.get("tag7").get());
-			assertEquals(-1 * (double) params[6], (double) paramMap.get("SpELtag1").get(),
-					0.00001);
-			assertEquals(-1 * (double) params[6], (double) paramMap.get("SpELtag2").get(),
-					0.00001);
-			assertEquals(-1 * (double) params[7], (double) paramMap.get("SpELtag3").get(),
-					0.00001);
+			assertThat(paramMap.get("tag4").get()).isEqualTo(3L);
+			assertThat(paramMap.get("tag5").get()).isEqualTo(params[5]);
+			assertThat(paramMap.get("tag6").get()).isEqualTo(params[6]);
+			assertThat(paramMap.get("tag7").get()).isEqualTo(params[7]);
+
+			assertThat((double) paramMap.get("SpELtag1").get()).isEqualTo(-1 * (double) params[6], COMPARE_OFFSET);
+			assertThat((double) paramMap.get("SpELtag2").get()).isEqualTo(-1 * (double) params[6], COMPARE_OFFSET);
+			assertThat((double) paramMap.get("SpELtag3").get()).isEqualTo(-1 * (double) params[7], COMPARE_OFFSET);
 
 			return null;
 		}).when(this.datastoreTemplate).queryKeysOrEntities(any(), eq(Trade.class));

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -61,7 +61,8 @@ import static org.mockito.Mockito.when;
  */
 public class GqlDatastoreQueryTests {
 
-	private static final Offset<Double> COMPARE_OFFSET = Offset.offset(0.00001);
+	/** Constant for which if two doubles are within DELTA, they are considered equal. */
+	private static final Offset<Double> DELTA = Offset.offset(0.00001);
 
 	private DatastoreTemplate datastoreTemplate;
 
@@ -159,10 +160,10 @@ public class GqlDatastoreQueryTests {
 			assertThat((long) ((LongValue) (((List) paramMap.get("tag2").get()).get(1))).get()).isEqualTo(2L);
 
 			double actual = ((DoubleValue) (((List) paramMap.get("tag3").get()).get(0))).get();
-			assertThat(actual).isEqualTo(((double[]) params[3])[0], COMPARE_OFFSET);
+			assertThat(actual).isEqualTo(((double[]) params[3])[0], DELTA);
 
 			actual = ((DoubleValue) (((List) paramMap.get("tag3").get()).get(1))).get();
-			assertThat(actual).isEqualTo(((double[]) params[3])[1], COMPARE_OFFSET);
+			assertThat(actual).isEqualTo(((double[]) params[3])[1], DELTA);
 
 			// 3L is expected even though 3 int was the original param due to custom conversions
 			assertThat(paramMap.get("tag4").get()).isEqualTo(3L);
@@ -170,9 +171,12 @@ public class GqlDatastoreQueryTests {
 			assertThat(paramMap.get("tag6").get()).isEqualTo(params[6]);
 			assertThat(paramMap.get("tag7").get()).isEqualTo(params[7]);
 
-			assertThat((double) paramMap.get("SpELtag1").get()).isEqualTo(-1 * (double) params[6], COMPARE_OFFSET);
-			assertThat((double) paramMap.get("SpELtag2").get()).isEqualTo(-1 * (double) params[6], COMPARE_OFFSET);
-			assertThat((double) paramMap.get("SpELtag3").get()).isEqualTo(-1 * (double) params[7], COMPARE_OFFSET);
+			assertThat((double) paramMap.get("SpELtag1").get()).isEqualTo(-1 * (double) params[6],
+					DELTA);
+			assertThat((double) paramMap.get("SpELtag2").get()).isEqualTo(-1 * (double) params[6],
+					DELTA);
+			assertThat((double) paramMap.get("SpELtag3").get()).isEqualTo(-1 * (double) params[7],
+					DELTA);
 
 			return null;
 		}).when(this.datastoreTemplate).queryKeysOrEntities(any(), eq(Trade.class));

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -54,9 +54,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.query.DefaultParameters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
@@ -140,7 +138,7 @@ public class PartTreeDatastoreQueryTests {
 					.setKind("trades")
 					.setOrderBy(OrderBy.desc("id")).setLimit(333).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 
 			return Collections.emptyList();
 		});
@@ -175,7 +173,7 @@ public class PartTreeDatastoreQueryTests {
 					.setLimit(444)
 					.setOrderBy(OrderBy.desc("id"), OrderBy.asc("price")).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 
 			return Collections.emptyList();
 		});
@@ -209,7 +207,7 @@ public class PartTreeDatastoreQueryTests {
 					.setLimit(333)
 					.setOrderBy(OrderBy.desc("id")).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 
 			return Collections.emptyList();
 		});
@@ -242,7 +240,7 @@ public class PartTreeDatastoreQueryTests {
 					.setKind("trades")
 					.setOrderBy(OrderBy.desc("id"), OrderBy.asc("price")).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 
 			return Collections.emptyList();
 		});
@@ -275,7 +273,7 @@ public class PartTreeDatastoreQueryTests {
 					.setKind("trades")
 					.setOrderBy(OrderBy.desc("id")).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 
 			return Collections.emptyList();
 		});
@@ -335,7 +333,7 @@ public class PartTreeDatastoreQueryTests {
 					.setOffset(444)
 					.setOrderBy(OrderBy.desc("id")).setLimit(444).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 
 			return Collections.emptyList();
 		});
@@ -363,9 +361,9 @@ public class PartTreeDatastoreQueryTests {
 		when(this.queryMethod.getCollectionReturnType()).thenReturn(List.class);
 
 		Page result = (Page) this.partTreeDatastoreQuery.execute(params);
-		assertEquals(4, result.getTotalElements());
-		assertEquals(2, result.getTotalPages());
-		assertEquals(2, result.getNumberOfElements());
+		assertThat(result.getTotalElements()).isEqualTo(4);
+		assertThat(result.getTotalPages()).isEqualTo(2);
+		assertThat(result.getNumberOfElements()).isEqualTo(2);
 
 		verify(this.datastoreTemplate, times(1))
 				.queryKeysOrEntities(isA(EntityQuery.class), any());
@@ -389,8 +387,8 @@ public class PartTreeDatastoreQueryTests {
 		when(this.queryMethod.getCollectionReturnType()).thenReturn(List.class);
 
 		Page result = (Page) this.partTreeDatastoreQuery.execute(params);
-		assertEquals(4, result.getTotalElements());
-		assertEquals(1, result.getTotalPages());
+		assertThat(result.getTotalElements()).isEqualTo(4);
+		assertThat(result.getTotalPages()).isEqualTo(1);
 
 		verify(this.datastoreTemplate, times(1))
 				.queryKeysOrEntities(isA(EntityQuery.class), any());
@@ -415,8 +413,8 @@ public class PartTreeDatastoreQueryTests {
 		when(this.queryMethod.getCollectionReturnType()).thenReturn(List.class);
 
 		Slice result = (Slice) this.partTreeDatastoreQuery.execute(params);
-		assertEquals(false, result.hasNext());
-		assertEquals(2, result.getNumberOfElements());
+		assertThat(result.hasNext()).isEqualTo(false);
+		assertThat(result.getNumberOfElements()).isEqualTo(2);
 
 
 		verify(this.datastoreTemplate, times(1))
@@ -441,7 +439,7 @@ public class PartTreeDatastoreQueryTests {
 		when(this.queryMethod.getCollectionReturnType()).thenReturn(List.class);
 
 		Slice result = (Slice) this.partTreeDatastoreQuery.execute(params);
-		assertEquals(false, result.hasNext());
+		assertThat(result.hasNext()).isEqualTo(false);
 
 
 		verify(this.datastoreTemplate, times(1))
@@ -467,8 +465,8 @@ public class PartTreeDatastoreQueryTests {
 		when(this.queryMethod.getCollectionReturnType()).thenReturn(List.class);
 
 		Slice result = (Slice) this.partTreeDatastoreQuery.execute(params);
-		assertEquals(true, result.hasNext());
-		assertEquals(2, result.getNumberOfElements());
+		assertThat(result.hasNext()).isEqualTo(true);
+		assertThat(result.getNumberOfElements()).isEqualTo(2);
 
 
 		verify(this.datastoreTemplate, times(1))
@@ -491,7 +489,7 @@ public class PartTreeDatastoreQueryTests {
 					.setOffset(offset)
 					.setOrderBy(OrderBy.desc("id")).setLimit(limit).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 			return Arrays.asList(3, 4);
 		});
 
@@ -506,7 +504,7 @@ public class PartTreeDatastoreQueryTests {
 					.setKind("trades")
 					.setOrderBy(OrderBy.desc("id")).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 			return Arrays.asList(1, 2, 3, 4);
 		});
 	}
@@ -524,7 +522,7 @@ public class PartTreeDatastoreQueryTests {
 					.setOffset(offset)
 					.setOrderBy(OrderBy.desc("id")).setLimit(queryLimit).build();
 
-			assertEquals(expected, statement);
+			assertThat(statement).isEqualTo(expected);
 			List<Integer> results = Arrays.asList(3, 4, 5);
 			return resultLimit != null && resultLimit < results.size() ? results.subList(0, resultLimit)
 					: results;
@@ -598,7 +596,7 @@ public class PartTreeDatastoreQueryTests {
 		PartTreeDatastoreQuery spyQuery = this.partTreeDatastoreQuery;
 
 		Object[] params = new Object[] { "BUY", };
-		assertEquals(1L, spyQuery.execute(params));
+		assertThat(spyQuery.execute(params)).isEqualTo(1L);
 	}
 
 	@Test
@@ -614,7 +612,7 @@ public class PartTreeDatastoreQueryTests {
 				.processRawObjectForProjection(any());
 
 		Object[] params = new Object[] { "BUY", };
-		assertTrue((boolean) spyQuery.execute(params));
+		assertThat((boolean) spyQuery.execute(params)).isTrue();
 	}
 
 	@Test
@@ -628,7 +626,7 @@ public class PartTreeDatastoreQueryTests {
 				.processRawObjectForProjection(any());
 
 		Object[] params = new Object[] { "BUY", };
-		assertFalse((boolean) spyQuery.execute(params));
+		assertThat((boolean) spyQuery.execute(params)).isFalse();
 	}
 
 	private void queryWithMockResult(String queryName, List results, Method m) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactoryBeanTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactoryBeanTests.java
@@ -24,7 +24,7 @@ import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappin
 import org.springframework.cloud.gcp.data.datastore.repository.DatastoreRepository;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -51,6 +51,6 @@ public class DatastoreRepositoryFactoryBeanTests {
 	public void createRepositoryFactoryTest() {
 		RepositoryFactorySupport factory = this.datastoreRepositoryFactoryBean
 				.createRepositoryFactory();
-		assertEquals(DatastoreRepositoryFactory.class, factory.getClass());
+		assertThat(factory.getClass()).isEqualTo(DatastoreRepositoryFactory.class);
 	}
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactoryTests.java
@@ -31,7 +31,7 @@ import org.springframework.data.mapping.MappingException;
 import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.data.repository.core.RepositoryInformation;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -58,12 +58,12 @@ public class DatastoreRepositoryFactoryTests {
 	public void getEntityInformationTest() {
 		EntityInformation<TestEntity, String> entityInformation = this.datastoreRepositoryFactory
 				.getEntityInformation(TestEntity.class);
-		assertEquals(TestEntity.class, entityInformation.getJavaType());
-		assertEquals(String.class, entityInformation.getIdType());
+		assertThat(entityInformation.getJavaType()).isEqualTo(TestEntity.class);
+		assertThat(entityInformation.getIdType()).isEqualTo(String.class);
 
 		TestEntity t = new TestEntity();
 		t.id = "a";
-		assertEquals("a", entityInformation.getId(t));
+		assertThat(entityInformation.getId(t)).isEqualTo("a");
 	}
 
 	@Test
@@ -84,13 +84,13 @@ public class DatastoreRepositoryFactoryTests {
 				.thenReturn(SimpleDatastoreRepository.class);
 		Mockito.<Class<?>>when(repoInfo.getDomainType()).thenReturn(TestEntity.class);
 		Object repo = this.datastoreRepositoryFactory.getTargetRepository(repoInfo);
-		assertEquals(SimpleDatastoreRepository.class, repo.getClass());
+		assertThat(repo.getClass()).isEqualTo(SimpleDatastoreRepository.class);
 	}
 
 	@Test
 	public void getRepositoryBaseClassTest() {
 		Class baseClass = this.datastoreRepositoryFactory.getRepositoryBaseClass(null);
-		assertEquals(SimpleDatastoreRepository.class, baseClass);
+		assertThat(baseClass).isEqualTo(SimpleDatastoreRepository.class);
 	}
 
 	@Entity(name = "custom_test_kind")

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/support/SimpleDatastoreRepositoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/support/SimpleDatastoreRepositoryTests.java
@@ -28,7 +28,7 @@ import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -127,9 +127,10 @@ public class SimpleDatastoreRepositoryTests {
 			Function<DatastoreOperations, String> f = invocation.getArgument(0);
 			return f.apply(this.datastoreTemplate);
 		});
-		assertEquals("test",
-				new SimpleDatastoreRepository<Object, String>(this.datastoreTemplate,
-						Object.class).performTransaction(repo -> "test"));
+
+		String result = new SimpleDatastoreRepository<Object, String>(this.datastoreTemplate, Object.class)
+				.performTransaction(repo -> "test");
+		assertThat(result).isEqualTo("test");
 	}
 
 	@Test

--- a/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/test/kotlin/com/example/RegistrationApplicationTests.kt
+++ b/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/test/kotlin/com/example/RegistrationApplicationTests.kt
@@ -22,7 +22,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.hamcrest.Matchers.`is`
 import org.junit.Assume.assumeThat
-import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactoryTests.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author João André Martins
@@ -47,10 +47,10 @@ public class DefaultPublisherFactoryTests {
 		factory.setCredentialsProvider(this.credentialsProvider);
 		Publisher publisher = factory.createPublisher("testTopic");
 
-		assertEquals(factory.getCache().size(), 1);
-		assertEquals(publisher, factory.getCache().get("testTopic"));
-		assertEquals("testTopic", ((ProjectTopicName) publisher.getTopicName()).getTopic());
-		assertEquals("projectId", ((ProjectTopicName) publisher.getTopicName()).getProject());
+		assertThat(factory.getCache().size()).isEqualTo(1);
+		assertThat(publisher).isEqualTo(factory.getCache().get("testTopic"));
+		assertThat(((ProjectTopicName) publisher.getTopicName()).getTopic()).isEqualTo("testTopic");
+		assertThat(((ProjectTopicName) publisher.getTopicName()).getProject()).isEqualTo("projectId");
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverterTests.java
@@ -30,7 +30,7 @@ import org.junit.rules.ExpectedException;
 
 import org.springframework.core.convert.converter.Converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Mike Eltsufin
@@ -110,16 +110,24 @@ public class SimplePubSubMessageConverterTests {
 		SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
 		PubsubMessage pubsubMessage = converter.toPubSubMessage(TEST_STRING, null);
 
-		assertEquals(TEST_STRING, pubsubMessage.getData().toString(Charset.defaultCharset()));
-		assertEquals(new HashMap<>(), pubsubMessage.getAttributesMap());
+		assertThat(pubsubMessage.getData().toString(Charset.defaultCharset())).isEqualTo(TEST_STRING);
+		assertThat(pubsubMessage.getAttributesMap()).isEqualTo(new HashMap<>());
 	}
 
 	private <T> void doToTestForType(Class<T> type, Converter<T, String> toString) {
 		SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
 
 		// test extraction from PubsubMessage to T
-		assertEquals(TEST_STRING, toString.convert((T) converter.fromPubSubMessage(PubsubMessage.newBuilder()
-				.setData(ByteString.copyFrom(TEST_STRING.getBytes())).putAllAttributes(TEST_HEADERS).build(), type)));
+
+		String extractedMessage = toString.convert(
+				(T) converter.fromPubSubMessage(
+						PubsubMessage.newBuilder()
+								.setData(ByteString.copyFrom(TEST_STRING.getBytes()))
+								.putAllAttributes(TEST_HEADERS)
+								.build(),
+						type));
+
+		assertThat(extractedMessage).isEqualTo(TEST_STRING);
 	}
 
 	private <T> void doFromTest(T value) {
@@ -127,7 +135,7 @@ public class SimplePubSubMessageConverterTests {
 
 		// test conversion of T to PubsubMessage
 		PubsubMessage convertedPubSubMessage = converter.toPubSubMessage(value, TEST_HEADERS);
-		assertEquals(TEST_STRING, new String(convertedPubSubMessage.getData().toByteArray()));
-		assertEquals(TEST_HEADERS, convertedPubSubMessage.getAttributesMap());
+		assertThat(new String(convertedPubSubMessage.getData().toByteArray())).isEqualTo(TEST_STRING);
+		assertThat(convertedPubSubMessage.getAttributesMap()).isEqualTo(TEST_HEADERS);
 	}
 }

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/it/GoogleStorageIntegrationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/it/GoogleStorageIntegrationTests.java
@@ -46,10 +46,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 /**
@@ -106,24 +104,24 @@ public class GoogleStorageIntegrationTests {
 			os.write(message.getBytes());
 		}
 
-		assertTrue(this.resource.exists());
+		assertThat(this.resource.exists()).isTrue();
 
 		try (InputStream is = this.resource.getInputStream()) {
-			assertEquals(message, StreamUtils.copyToString(is, Charset.defaultCharset()));
+			assertThat(message).isEqualTo(StreamUtils.copyToString(is, Charset.defaultCharset()));
 		}
 
 		GoogleStorageResource childResource = getChildResource();
 
-		assertFalse(childResource.exists());
+		assertThat(childResource.exists()).isFalse();
 
 		try (OutputStream os = childResource.getOutputStream()) {
 			os.write(message.getBytes());
 		}
 
-		assertTrue(childResource.exists());
+		assertThat(childResource.exists()).isTrue();
 
 		try (InputStream is = childResource.getInputStream()) {
-			assertEquals(message, StreamUtils.copyToString(is, Charset.defaultCharset()));
+			assertThat(message).isEqualTo(StreamUtils.copyToString(is, Charset.defaultCharset()));
 		}
 	}
 

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/it/GoogleStorageIntegrationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/it/GoogleStorageIntegrationTests.java
@@ -107,7 +107,7 @@ public class GoogleStorageIntegrationTests {
 		assertThat(this.resource.exists()).isTrue();
 
 		try (InputStream is = this.resource.getInputStream()) {
-			assertThat(message).isEqualTo(StreamUtils.copyToString(is, Charset.defaultCharset()));
+			assertThat(StreamUtils.copyToString(is, Charset.defaultCharset())).isEqualTo(message);
 		}
 
 		GoogleStorageResource childResource = getChildResource();
@@ -121,7 +121,7 @@ public class GoogleStorageIntegrationTests {
 		assertThat(childResource.exists()).isTrue();
 
 		try (InputStream is = childResource.getInputStream()) {
-			assertThat(message).isEqualTo(StreamUtils.copyToString(is, Charset.defaultCharset()));
+			assertThat(StreamUtils.copyToString(is, Charset.defaultCharset())).isEqualTo(message);
 		}
 	}
 


### PR DESCRIPTION
This contributes to the goal of enabling AssertJ checkstyle in #1203.

I will split the migration in to a few PRs since it will touch a lot of files.