### PR TITLE
Update Kotlin sample to use Object Serialization

### DIFF
--- a/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/main/kotlin/com/example/app/Controller.kt
+++ b/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/main/kotlin/com/example/app/Controller.kt
@@ -16,6 +16,7 @@
 
 package com.example.app
 
+import com.example.data.Person
 import com.example.data.PersonRepository
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate
 import org.springframework.web.bind.annotation.GetMapping
@@ -43,7 +44,7 @@ class Controller(val pubSubTemplate: PubSubTemplate, val personRepository: Perso
 			@RequestParam("lastName") lastName: String,
 			@RequestParam("email") email: String): RedirectView {
 
-		pubSubTemplate.publish(REGISTRATION_TOPIC, "$firstName:$lastName:$email")
+		pubSubTemplate.publish(REGISTRATION_TOPIC, Person(firstName, lastName, email))
 		return RedirectView("/")
 	}
 


### PR DESCRIPTION
This updates the Kotlin sample to use serialized object Pub/Sub payloads.

It demonstrates a more complex use case and also answers #1305 - the sample shows that setting up the `JacksonPubSubMessageConverter` is sufficient for supporting object serialization with kotlin.

Fixes #1305.