### PR TITLE
Add section in refdoc about Kotlin

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -1,0 +1,23 @@
+== Kotlin Support
+
+Spring Cloud GCP libraries work out-of-the-box and are fully interoperable with Kotlin Spring boot applications.
+
+=== Prerequisites
+
+Ensure that your Kotlin Spring Boot application is properly set up.
+Based on your build system, you will need to include the correct Kotlin build plugin in your project:
+
+* https://kotlinlang.org/docs/reference/using-maven.html[Kotlin Maven Plugin]
+* https://kotlinlang.org/docs/reference/using-gradle.html[Kotlin Gradle Plugin]
+
+Depending on your application's needs, you may need to augment your build configuration with compiler plugins:
+
+* https://kotlinlang.org/docs/reference/compiler-plugins.html#spring-support[Spring Kotlin Plugin]: Makes your Spring configuration classes/members non-final for convenience.
+* https://kotlinlang.org/docs/reference/compiler-plugins.html#jpa-support[Kotlin Spring JPA Plugin]: Enables using JPA in Kotlin Spring applications.
+
+Once your Kotlin project is properly configured, the Spring Cloud GCP libraries will work within a Kotlin application without any additional setup.
+
+== Sample
+
+A https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample[Kotlin sample application] is provided to demonstrate a working Maven setup and various Spring Cloud GCP integrations from within Kotlin.
+

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -1,6 +1,9 @@
 == Kotlin Support
 
-Spring Cloud GCP libraries work out-of-the-box and are fully interoperable with Kotlin Spring boot applications.
+The latest version of the Spring Framework provides first-class support for Kotlin.
+For Kotlin users of Spring, the Spring Cloud GCP libraries work out-of-the-box and are fully interoperable with Kotlin applications.
+
+For more information on building a Spring Boot application in Kotlin, please consult the https://docs.spring.io/spring/docs/current/spring-framework-reference/languages.html#kotlin[Spring Kotlin documentation].
 
 === Prerequisites
 

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -3,11 +3,11 @@
 The latest version of the Spring Framework provides first-class support for Kotlin.
 For Kotlin users of Spring, the Spring Cloud GCP libraries work out-of-the-box and are fully interoperable with Kotlin applications.
 
-For more information on building a Spring Boot application in Kotlin, please consult the https://docs.spring.io/spring/docs/current/spring-framework-reference/languages.html#kotlin[Spring Kotlin documentation].
+For more information on building a Spring application in Kotlin, please consult the https://docs.spring.io/spring/docs/current/spring-framework-reference/languages.html#kotlin[Spring Kotlin documentation].
 
 === Prerequisites
 
-Ensure that your Kotlin Spring Boot application is properly set up.
+Ensure that your Kotlin application is properly set up.
 Based on your build system, you will need to include the correct Kotlin build plugin in your project:
 
 * https://kotlinlang.org/docs/reference/using-maven.html[Kotlin Maven Plugin]
@@ -15,10 +15,10 @@ Based on your build system, you will need to include the correct Kotlin build pl
 
 Depending on your application's needs, you may need to augment your build configuration with compiler plugins:
 
-* https://kotlinlang.org/docs/reference/compiler-plugins.html#spring-support[Spring Kotlin Plugin]: Makes your Spring configuration classes/members non-final for convenience.
-* https://kotlinlang.org/docs/reference/compiler-plugins.html#jpa-support[Kotlin Spring JPA Plugin]: Enables using JPA in Kotlin Spring applications.
+* https://kotlinlang.org/docs/reference/compiler-plugins.html#spring-support[Kotlin Spring Plugin]: Makes your Spring configuration classes/members non-final for convenience.
+* https://kotlinlang.org/docs/reference/compiler-plugins.html#jpa-support[Kotlin JPA Plugin]: Enables using JPA in Kotlin applications.
 
-Once your Kotlin project is properly configured, the Spring Cloud GCP libraries will work within a Kotlin application without any additional setup.
+Once your Kotlin project is properly configured, the Spring Cloud GCP libraries will work within your application without any additional setup.
 
 == Sample
 

--- a/docs/src/main/asciidoc/spring-cloud-gcp.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gcp.adoc
@@ -58,3 +58,5 @@ include::security-iap.adoc[]
 include::vision.adoc[]
 
 include::cloudfoundry.adoc[]
+
+include::kotlin.adoc[]


### PR DESCRIPTION
This adds a section in the refdoc discussing Kotlin support. Spring Cloud GCP libraries should work out-of-the-box so long as the user's Kotlin project setup is correct.

Making kotlin app more discoverable #1323