### PR TITLE
Fix sample failing when second table does not exist yet

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerDatabaseAdminTemplate.java
@@ -93,7 +93,7 @@ public class SpannerDatabaseAdminTemplate {
 	public void executeDdlStrings(Iterable<String> ddlStrings,
 			boolean createDatabase) {
 		try {
-			if (createDatabase) {
+			if (createDatabase && !this.databaseExists()) {
 				this.databaseAdminClient
 						.createDatabase(getInstanceId(), getDatabase(), ddlStrings)
 						.get();


### PR DESCRIPTION
spring-cloud-gcp-data-spanner sample does not like empty databases. The first table gets created fine, but when the second table tries to get created, it fails because "database already exists".