### PR TITLE
Stop hard-coding version in User-Agent for metrics

### DIFF
--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -3,8 +3,6 @@
 The actual release process is triggered by the release admin and happens together with the rest of the Spring Cloud release.
 In order to simplify that process, here is a list of prerequisites to be performed before asking the release admin to run the release scripts.
 
-. Manually change the value of `TRACKING_HEADER_PROJECT_VERSION` in link:spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/UsageTrackingHeaderProvider.java[`UsageTrackingHeaderProvider`] to the version being released from the interim `BUILD-SNAPSHOT` value.
-
 . Ensure that modules that shouldn't be released have the `maven-deploy-plugin` configuration set to `<skip>true</skip>`.
 For GA releases this should be configured under the `central` Maven profile.
 
@@ -22,7 +20,5 @@ For GA releases this should be configured under the `central` Maven profile.
 . Wait for the release scripts to have been run by the release admin.
 
 . Make sure that the release tag was automatically added by the release process.
-
-. Change the `TRACKING_HEADER_PROJECT_VERSION` in link:spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/UsageTrackingHeaderProvider.java[`UsageTrackingHeaderProvider`] back to `BUILD-SNAPSHOT`.
 
 . Make sure that the link:https://github.com/spring-io/initializr/blob/master/initializr-service/src/main/resources/application.yml[Spring Boot Initializr] is updated to support the new version of Spring Cloud GCP.

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigPropertySourceLocator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/config/GoogleConfigPropertySourceLocator.java
@@ -27,7 +27,7 @@ import com.google.auth.Credentials;
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
@@ -107,8 +107,8 @@ public class GoogleConfigPropertySourceLocator implements PropertySourceLocator 
 
 		Assert.isTrue(headers.containsKey(AUTHORIZATION_HEADER), "Authorization header required");
 
-		// Adds usage tracking header.
-		new UsageTrackingHeaderProvider(this.getClass()).getHeaders().forEach(headers::add);
+		// Adds product version header for usage metrics
+		new UserAgentHeaderProvider(this.getClass()).getHeaders().forEach(headers::add);
 
 		return new HttpEntity<>(headers);
 	}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.cloud.gcp.data.datastore.core.DatastoreOperations;
 import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
 import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreCustomConversions;
@@ -82,7 +82,7 @@ public class GcpDatastoreAutoConfiguration {
 	public Datastore datastore() {
 		DatastoreOptions.Builder builder = DatastoreOptions.newBuilder()
 				.setProjectId(this.projectId)
-				.setHeaderProvider(new UsageTrackingHeaderProvider(this.getClass()))
+				.setHeaderProvider(new UserAgentHeaderProvider(this.getClass()))
 				.setCredentials(this.credentials);
 		if (this.namespace != null) {
 			builder.setNamespace(this.namespace);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -50,7 +50,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
 import org.springframework.cloud.gcp.pubsub.core.PubSubException;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
@@ -86,7 +86,7 @@ public class GcpPubSubAutoConfiguration {
 
 	private final CredentialsProvider finalCredentialsProvider;
 
-	private final HeaderProvider headerProvider = new UsageTrackingHeaderProvider(this.getClass());
+	private final HeaderProvider headerProvider = new UserAgentHeaderProvider(this.getClass());
 
 	public GcpPubSubAutoConfiguration(GcpPubSubProperties gcpPubSubProperties,
 			GcpProjectIdProvider gcpProjectIdProvider,

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.cloud.gcp.data.spanner.core.SpannerMutationFactory;
 import org.springframework.cloud.gcp.data.spanner.core.SpannerMutationFactoryImpl;
 import org.springframework.cloud.gcp.data.spanner.core.SpannerOperations;
@@ -119,7 +119,7 @@ public class GcpSpannerAutoConfiguration {
 		public SpannerOptions spannerOptions(SessionPoolOptions sessionPoolOptions) {
 			Builder builder = SpannerOptions.newBuilder()
 					.setProjectId(this.projectId)
-					.setHeaderProvider(new UsageTrackingHeaderProvider(this.getClass()))
+					.setHeaderProvider(new UserAgentHeaderProvider(this.getClass()))
 					.setCredentials(this.credentials);
 			if (this.numRpcChannels >= 0) {
 				builder.setNumChannels(this.numRpcChannels);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/storage/GcpStorageAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.gcp.autoconfigure.core.GcpProperties;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.cloud.gcp.storage.GoogleStorageProtocolResolver;
 import org.springframework.cloud.gcp.storage.GoogleStorageProtocolResolverSettings;
 import org.springframework.context.annotation.Bean;
@@ -65,7 +65,7 @@ public abstract class GcpStorageAutoConfiguration { //NOSONAR squid:S1610 must b
 						? new DefaultCredentialsProvider(gcpStorageProperties).getCredentials()
 						: credentialsProvider.getCredentials())
 				.setHeaderProvider(
-						new UsageTrackingHeaderProvider(GcpStorageAutoConfiguration.class))
+						new UserAgentHeaderProvider(GcpStorageAutoConfiguration.class))
 				.setProjectId(projectIdProvider.getProjectId())
 				.build().getService();
 	}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -50,7 +50,7 @@ import org.springframework.cloud.gcp.autoconfigure.trace.sleuth.StackdriverHttpC
 import org.springframework.cloud.gcp.autoconfigure.trace.sleuth.StackdriverHttpServerParser;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.cloud.sleuth.instrument.web.TraceHttpAutoConfiguration;
@@ -81,7 +81,7 @@ public class StackdriverTraceAutoConfiguration {
 
 	private CredentialsProvider finalCredentialsProvider;
 
-	private UsageTrackingHeaderProvider headerProvider = new UsageTrackingHeaderProvider(this.getClass());
+	private UserAgentHeaderProvider headerProvider = new UserAgentHeaderProvider(this.getClass());
 
 	public StackdriverTraceAutoConfiguration(GcpProjectIdProvider gcpProjectIdProvider,
 			CredentialsProvider credentialsProvider,

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/vision/CloudVisionAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/vision/CloudVisionAutoConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.cloud.gcp.vision.CloudVisionTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -74,7 +74,7 @@ public class CloudVisionAutoConfiguration {
 	public ImageAnnotatorClient imageAnnotatorClient() throws IOException {
 		ImageAnnotatorSettings clientSettings = ImageAnnotatorSettings.newBuilder()
 				.setCredentialsProvider(this.credentialsProvider)
-				.setHeaderProvider(new UsageTrackingHeaderProvider(CloudVisionAutoConfiguration.class))
+				.setHeaderProvider(new UserAgentHeaderProvider(CloudVisionAutoConfiguration.class))
 				.build();
 
 		return ImageAnnotatorClient.create(clientSettings);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
@@ -39,7 +39,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
 import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.integration.AckMode;
@@ -327,7 +327,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 			factory.setExecutorProvider(executorProvider);
 			factory.setCredentialsProvider(credentialsProvider);
 			factory.setHeaderProvider(
-					new UsageTrackingHeaderProvider(GcpPubSubAutoConfiguration.class));
+					new UserAgentHeaderProvider(GcpPubSubAutoConfiguration.class));
 			factory.setChannelProvider(transportChannelProvider);
 
 			return factory;
@@ -348,7 +348,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 			factory.setExecutorProvider(executorProvider);
 			factory.setCredentialsProvider(credentialsProvider);
 			factory.setHeaderProvider(
-					new UsageTrackingHeaderProvider(GcpPubSubAutoConfiguration.class));
+					new UserAgentHeaderProvider(GcpPubSubAutoConfiguration.class));
 			factory.setChannelProvider(transportChannelProvider);
 			return factory;
 		}

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/UserAgentHeaderProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/UserAgentHeaderProvider.java
@@ -29,18 +29,13 @@ import com.google.api.gax.rpc.HeaderProvider;
  * @author Chengyuan Zhao
  * @author Mike Eltsufin
  */
-public class UsageTrackingHeaderProvider implements HeaderProvider {
-
-	/**
-	 * The hard-coded version string reported with usage info.
-	 */
-	public static final String TRACKING_HEADER_PROJECT_VERSION = "1.1.0.BUILD-SNAPSHOT";
+public class UserAgentHeaderProvider implements HeaderProvider {
 
 	private String userAgent;
 
 	private final Map<String, String> headers;
 
-	public UsageTrackingHeaderProvider(Class clazz) {
+	public UserAgentHeaderProvider(Class clazz) {
 		this.userAgent = computeUserAgent(clazz);
 		this.headers = Collections.singletonMap("User-Agent", this.userAgent);
 	}
@@ -67,9 +62,9 @@ public class UsageTrackingHeaderProvider implements HeaderProvider {
 	private String computeUserAgent(Class clazz) {
 		String[] packageTokens = clazz.getPackage().getName().split("\\.");
 		String springLibrary = "spring-cloud-gcp-" + packageTokens[packageTokens.length - 1];
+		String version = this.getClass().getPackage().getImplementationVersion();
 
-		return "Spring/" + TRACKING_HEADER_PROJECT_VERSION
-				+ " " + springLibrary + "/" + TRACKING_HEADER_PROJECT_VERSION;
+		return "Spring/" + version + " " + springLibrary + "/" + version;
 
 	}
 

--- a/spring-cloud-gcp-core/src/test/java/org/springframework/cloud/gcp/core/UserAgentHeaderProviderIT.java
+++ b/spring-cloud-gcp-core/src/test/java/org/springframework/cloud/gcp/core/UserAgentHeaderProviderIT.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.core;
 
+import java.util.regex.Pattern;
+
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,19 +30,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  */
-public class UsageTrackingHeaderProviderIT {
+public class UserAgentHeaderProviderIT {
 
 	/**
-	 * This test is check if the hard-coded version needs to be manually updated.
+	 * This test is check if the generated User-Agent header is in the right format.
 	 */
 	@Test
 	public void testGetHeaders() {
-		UsageTrackingHeaderProvider subject = new UsageTrackingHeaderProvider(this.getClass());
+		UserAgentHeaderProvider subject = new UserAgentHeaderProvider(this.getClass());
 
-		String builtVersion = this.getClass().getPackage().getImplementationVersion();
+		String versionRegex = "\\d+\\.\\d+\\.\\d+\\.[BUILD-SNAPSHOT|M\\d+|RC\\d+|RELEASE]$";
 		assertThat(subject.getHeaders()).containsKey("User-Agent");
-		assertThat(subject.getHeaders().get("User-Agent")).isEqualTo(
-				"Spring/" + builtVersion + " spring-cloud-gcp-core/" + builtVersion);
+		assertThat(subject.getHeaders().get("User-Agent")).matches(
+				Pattern.compile("Spring/" + versionRegex + " spring-cloud-gcp-core/" + versionRegex));
 		assertThat(subject.getHeaders().size()).isEqualTo(1);
 	}
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTestConfiguration.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTestConfiguration.java
@@ -25,7 +25,7 @@ import com.google.cloud.datastore.DatastoreOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
-import org.springframework.cloud.gcp.core.UsageTrackingHeaderProvider;
+import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
 import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
 import org.springframework.cloud.gcp.data.datastore.core.DatastoreTransactionManager;
 import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreEntityConverter;
@@ -75,7 +75,7 @@ public class DatastoreIntegrationTestConfiguration {
 	public Datastore datastore() {
 		DatastoreOptions.Builder builder = DatastoreOptions.newBuilder()
 				.setProjectId(this.projectId)
-				.setHeaderProvider(new UsageTrackingHeaderProvider(this.getClass()))
+				.setHeaderProvider(new UserAgentHeaderProvider(this.getClass()))
 				.setCredentials(this.credentials);
 		if (this.namespacePrefix != null) {
 			builder.setNamespace(this.namespacePrefix + System.currentTimeMillis());


### PR DESCRIPTION
We found the root cause of incorrect versions being reported, and it's
not automatic version detection. So, hard-coding the version is no
longer needed.

This PR also renames the class to `UserAgentHeaderProvider`.