### PR TITLE
Spanner support for auto-populated commit timestamp

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -249,6 +249,8 @@ This setting is only used when generating DDL schema statements based on domain 
 This setting is only used when generating DDL schema statements based on domain types.
 - `spannerType` is the Cloud Spanner column type you can optionally specify.
 If this is not specified then a compatible column type is inferred from the Java property type.
+- `spannerCommitTimestamp` is a boolean specifying if this property corresponds to an auto-populated commit timestamp column.
+Any value set in this property will be ignored when writing to Cloud Spanner.
 
 
 ==== Embedded Objects

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerSchemaUtils.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerSchemaUtils.java
@@ -184,7 +184,8 @@ public class SpannerSchemaUtils {
 			}
 			return columnName + getTypeDdlString(spannerColumnType, true,
 					spannerPersistentProperty.getMaxColumnLength(),
-					spannerPersistentProperty.isGenerateSchemaNotNull());
+					spannerPersistentProperty.isGenerateSchemaNotNull(),
+					spannerPersistentProperty.isCommitTimestamp());
 		}
 		spannerJavaType = spannerEntityProcessor
 					.getCorrespondingSpannerJavaType(columnType, false);
@@ -209,7 +210,8 @@ public class SpannerSchemaUtils {
 
 		return columnName + getTypeDdlString(spannerColumnType, spannerJavaType.isArray(),
 				spannerPersistentProperty.getMaxColumnLength(),
-				spannerPersistentProperty.isGenerateSchemaNotNull());
+				spannerPersistentProperty.isGenerateSchemaNotNull(),
+				spannerPersistentProperty.isCommitTimestamp());
 	}
 
 	private <T> void addPrimaryKeyColumnNames(
@@ -282,9 +284,11 @@ public class SpannerSchemaUtils {
 	}
 
 	private String getTypeDdlString(Type.Code type, boolean isArray,
-			OptionalLong dataLength, boolean isNotNull) {
-		return getTypeDdlStringWithLength(type, isArray, dataLength)
-				+ (isNotNull ? " NOT NULL" : "");
+			OptionalLong dataLength, boolean isNotNull, boolean isCommitTimestamp) {
+		return (isCommitTimestamp ? Type.Code.TIMESTAMP.toString()
+				: getTypeDdlStringWithLength(type, isArray, dataLength))
+				+ (isNotNull ? " NOT NULL" : "")
+				+ (isCommitTimestamp ? " OPTIONS (allow_commit_timestamp=true)" : "");
 	}
 
 	private String getTypeDdlStringWithLength(Type.Code type, boolean isArray,

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -30,6 +30,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -277,8 +278,15 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 		}
 		else {
 
+			// if the property is a commit timestamp, then its Spanner column type is always TIMESTAMP
+			// and only the dummy value needs to be written to trigger auto-population of the commit
+			// time
+			if (property.isCommitTimestamp()) {
+				valueSet = attemptSetSingleItemValue(Value.COMMIT_TIMESTAMP, Timestamp.class, valueBinder,
+						Timestamp.class);
+			}
 			// use the user's annotated column type if possible
-			if (property.getAnnotatedColumnItemType() != null) {
+			else if (property.getAnnotatedColumnItemType() != null) {
 				valueSet = attemptSetSingleItemValue(propertyValue, propertyType,
 						valueBinder,
 						SpannerTypeMapper.getSimpleJavaClassFor(property.getAnnotatedColumnItemType()));

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/Column.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/Column.java
@@ -70,4 +70,13 @@ public @interface Column {
 	 * @return The user-specified column item type.
 	 */
 	TypeCode spannerType() default TypeCode.TYPE_CODE_UNSPECIFIED;
+
+	/**
+	 * This setting takes effect when the entity in which it appears is used to generate
+	 * schema DDL. If {@code true}, then the column corresponding to the annotated property
+	 * will be auto-populated with the latest Cloud Spanner TrueTime commit timestamp of the
+	 * row. {@code false} for all other usage and columns.
+	 * @return {@code true} for auto-populating commit timestamp. {@code false} otherwise.
+	 */
+	boolean spannerCommitTimestamp() default false;
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerCompositeKeyProperty.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerCompositeKeyProperty.java
@@ -124,6 +124,11 @@ public class SpannerCompositeKeyProperty implements SpannerPersistentProperty {
 	}
 
 	@Override
+	public boolean isCommitTimestamp() {
+		return false;
+	}
+
+	@Override
 	public Code getAnnotatedColumnItemType() {
 		return null;
 	}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerPersistentProperty.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerPersistentProperty.java
@@ -92,6 +92,15 @@ public interface SpannerPersistentProperty
 	boolean isGenerateSchemaNotNull();
 
 	/**
+	 * If the column is a Cloud Spanner commit timestamp auto-populating column. This property
+	 * is always stored in Cloud Spanner as a Timestamp, and will update based on the latest
+	 * commit.
+	 * @return {@code true} if the property is an auto-populated commit timestamp.
+	 * {@code false} otherwise.
+	 */
+	boolean isCommitTimestamp();
+
+	/**
 	 * Optionally directly specify the column type in Cloud Spanner. For ARRAY columns
 	 * this refers to type of the item the array holds. If this is not specified then it
 	 * is inferred.

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerPersistentPropertyImpl.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/SpannerPersistentPropertyImpl.java
@@ -170,6 +170,12 @@ public class SpannerPersistentPropertyImpl
 	}
 
 	@Override
+	public boolean isCommitTimestamp() {
+		Column annotation = findAnnotation(Column.class);
+		return annotation != null && annotation.spannerCommitTimestamp();
+	}
+
+	@Override
 	public Code getAnnotatedColumnItemType() {
 		Column annotation = findAnnotation(Column.class);
 		if (annotation == null

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerSchemaUtilsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/admin/SpannerSchemaUtilsTests.java
@@ -76,7 +76,8 @@ public class SpannerSchemaUtilsTests {
 				+ "primitiveDoubleField FLOAT64 , bigDoubleField FLOAT64 , bigLongField INT64 , "
 				+ "primitiveIntField INT64 , bigIntField INT64 , bytes BYTES(MAX) , "
 				+ "bytesList ARRAY<BYTES(111)> , integerList ARRAY<INT64> , "
-				+ "doubles ARRAY<FLOAT64> ) PRIMARY KEY ( id , id_2 , id3 )";
+				+ "doubles ARRAY<FLOAT64> , commitTimestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true) ) " +
+				"PRIMARY KEY ( id , id_2 , id3 )";
 
 		assertThat(this.spannerSchemaUtils.getCreateTableDdlString(TestEntity.class))
 				.isEqualTo(ddlResult);
@@ -236,6 +237,11 @@ public class SpannerSchemaUtilsTests {
 		List<Integer> integerList;
 
 		double[] doubles;
+
+		// this is intentionally a double to test that it is forced to be TIMESTAMP on Spanner
+		// anyway
+		@Column(spannerCommitTimestamp = true)
+		double commitTimestamp;
 	}
 
 	private static class EmbeddedColumns {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
@@ -149,7 +149,8 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 				.to(Value.date(Date.fromYearMonthDay(2018, 11, 22))).set("timestampField")
 				.to(Value.timestamp(Timestamp.ofTimeMicroseconds(333))).set("bytes")
 				.to(Value.bytes(ByteArray.copyFrom("string1"))).set("momentsInTime")
-				.to(Value.timestampArray(timestamps)).build();
+				.to(Value.timestampArray(timestamps))
+				.set("commitTimestamp").to(Value.timestamp(Timestamp.ofTimeMicroseconds(1))).build();
 
 		Struct struct2 = Struct.newBuilder().set("id").to(Value.string("key12"))
 				.set("id2").to(Value.string("key22")).set("id3").to(Value.string("key32"))
@@ -170,7 +171,8 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 				.to(Value.date(Date.fromYearMonthDay(2019, 11, 22))).set("timestampField")
 				.to(Value.timestamp(Timestamp.ofTimeMicroseconds(555)))
 				.set("momentsInTime").to(Value.timestampArray(timestamps)).set("bytes")
-				.to(Value.bytes(ByteArray.copyFrom("string2"))).build();
+				.to(Value.bytes(ByteArray.copyFrom("string2")))
+				.set("commitTimestamp").to(Value.timestamp(Timestamp.ofTimeMicroseconds(1))).build();
 
 		MockResults mockResults = new MockResults();
 		mockResults.structs = Arrays.asList(struct1, struct2);
@@ -204,6 +206,7 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 		assertThat(t1.dateField.getYear()).isEqualTo(2018);
 		assertThat(t1.momentsInTime).isEqualTo(instants);
 		assertThat(t1.bytes).isEqualTo(ByteArray.copyFrom("string1"));
+		assertThat(t1.commitTimestamp).isEqualTo(Timestamp.ofTimeMicroseconds(1));
 
 		assertThat(t2.id).isEqualTo("key12");
 		assertThat(t2.testEmbeddedColumns.id2).isEqualTo("key22");
@@ -222,6 +225,7 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 		assertThat(t2.momentsInTime).isEqualTo(instants);
 		assertThat(t2.stringList).containsExactly("string");
 		assertThat(t2.bytes).isEqualTo(ByteArray.copyFrom("string2"));
+		assertThat(t2.commitTimestamp).isEqualTo(Timestamp.ofTimeMicroseconds(1));
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -28,6 +28,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
 import com.google.common.collect.ImmutableSet;
 import com.google.spanner.v1.TypeCode;
@@ -91,6 +92,10 @@ public class ConverterAwareMappingSpannerEntityWriterTests {
 		TestEntity t = new TestEntity();
 		t.id = "key1";
 		t.enumField = TestEntity.Color.WHITE;
+
+		// any positive time value will do.
+		t.commitTimestamp = Timestamp.ofTimeMicroseconds(1000);
+
 		t.booleanField = true;
 		t.intField = 123;
 		t.longField = 3L;
@@ -232,6 +237,10 @@ public class ConverterAwareMappingSpannerEntityWriterTests {
 		when(bytesFieldBinder.to((ByteArray) any())).thenReturn(null);
 		when(writeBuilder.set(eq("bytes"))).thenReturn(bytesFieldBinder);
 
+		ValueBinder<WriteBuilder> commitTimestampBinder = mock(ValueBinder.class);
+		when(commitTimestampBinder.to((Timestamp) any())).thenReturn(null);
+		when(writeBuilder.set(eq("commitTimestamp"))).thenReturn(commitTimestampBinder);
+
 		this.spannerEntityWriter.write(t, writeBuilder::set);
 
 		verify(idBinder, times(1)).to(eq(t.id));
@@ -255,6 +264,11 @@ public class ConverterAwareMappingSpannerEntityWriterTests {
 		verify(timestampFieldBinder, times(1)).to(eq(t.timestampField));
 		verify(bytesFieldBinder, times(1)).to(eq(t.bytes));
 		verify(instantListFieldBinder, times(1)).toTimestampArray(eq(timestamps));
+
+		// the positive value set earlier must not be passed to Spanner. it must be replaced by
+		// the dummy value.
+		verify(commitTimestampBinder, times(1)).to(eq(Value.COMMIT_TIMESTAMP));
+
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/convert/TestEntities.java
@@ -107,6 +107,9 @@ public class TestEntities {
 			WHITE,
 			BLACK
 		}
+
+		@Column(spannerCommitTimestamp = true)
+		Timestamp commitTimestamp;
 	}
 
 	/**

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gcp.data.spanner.repository.it;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Struct;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
@@ -204,12 +205,15 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		SubTradeComponent subTradeComponent11 = new SubTradeComponent(
 				someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade1",
 				"11a", "11b");
+		subTradeComponent11.setCommitTimestamp(Timestamp.ofTimeMicroseconds(11));
 		SubTradeComponent subTradeComponent21 = new SubTradeComponent(
 				someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade2",
 				"21a", "21b");
+		subTradeComponent21.setCommitTimestamp(Timestamp.ofTimeMicroseconds(21));
 		SubTradeComponent subTradeComponent22 = new SubTradeComponent(
 				someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade2",
 				"22a", "22b");
+		subTradeComponent22.setCommitTimestamp(Timestamp.ofTimeMicroseconds(22));
 
 		subTrade1.setSubTradeComponentList(ImmutableList.of(subTradeComponent11));
 		subTrade2.setSubTradeComponentList(
@@ -220,6 +224,14 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 
 		assertThat(this.subTradeRepository.count()).isEqualTo(2);
 		assertThat(this.subTradeComponentRepository.count()).isEqualTo(3);
+
+		List<SubTradeComponent> subTradeComponents = (List) this.subTradeComponentRepository.findAll();
+
+		assertThat(subTradeComponents.get(0).getCommitTimestamp())
+				.isEqualTo(subTradeComponents.get(1).getCommitTimestamp());
+		assertThat(subTradeComponents.get(0).getCommitTimestamp())
+				.isEqualTo(subTradeComponents.get(2).getCommitTimestamp());
+		assertThat(subTradeComponents.get(0).getCommitTimestamp()).isGreaterThan(Timestamp.ofTimeMicroseconds(22));
 
 		this.subTradeRepository.deleteById(this.spannerSchemaUtils.getKey(subTrade1));
 		assertThat(this.subTradeComponentRepository.count()).isEqualTo(2);

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/SubTradeComponent.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/SubTradeComponent.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gcp.data.spanner.test.domain;
 
+import com.google.cloud.Timestamp;
 import com.google.spanner.v1.TypeCode;
 
 import org.springframework.cloud.gcp.data.spanner.core.mapping.Column;
@@ -44,6 +45,9 @@ public class SubTradeComponent {
 	@Column(spannerType = TypeCode.STRING)
 	boolean booleanValue;
 
+	@Column(spannerCommitTimestamp = true)
+	Timestamp commitTimestamp;
+
 	public SubTradeComponent() {
 
 	}
@@ -59,5 +63,13 @@ public class SubTradeComponent {
 		this.subTradeIdentifier = subTradeIdentifier;
 		this.componentIdPartA = componentIdPartA;
 		this.componentIdPartB = componentIdPartB;
+	}
+
+	public Timestamp getCommitTimestamp() {
+		return this.commitTimestamp;
+	}
+
+	public void setCommitTimestamp(Timestamp commitTimestamp) {
+		this.commitTimestamp = commitTimestamp;
 	}
 }


### PR DESCRIPTION
related to #1283
This adds support for Spanner's built-in commit timestamp column feature.