### PR TITLE
Remove remaining guava presence

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -52,7 +52,7 @@ Here is an example of how to publish a message to a Google Cloud Pub/Sub topic:
 [source,java]
 ----
 public void publishMessage() {
-    this.pubSubTemplate.publish("topic", "your message payload", ImmutableMap.of("key1", "val1"));
+    this.pubSubTemplate.publish("topic", "your message payload", Collections.singletonMap("key1", "val1"));
 }
 ----
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/config/PubSubBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.config;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -59,7 +59,7 @@ public class PubSubBinderConfiguration {
 
 	@Bean
 	public MappingsProvider pubSubExtendedPropertiesDefaultMappingsProvider() {
-		return () -> ImmutableMap.of(
+		return () -> Collections.singletonMap(
 				ConfigurationPropertyName.of("spring.cloud.stream.gcp.pubsub.bindings"),
 				ConfigurationPropertyName.of("spring.cloud.stream.gcp.pubsub.default"));
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.cloud.gcp.pubsub;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.google.api.gax.core.CredentialsProvider;
@@ -26,7 +28,6 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
-import com.google.common.collect.Lists;
 import com.google.pubsub.v1.ProjectName;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
@@ -145,7 +146,9 @@ public class PubSubAdmin implements AutoCloseable {
 		TopicAdminClient.ListTopicsPagedResponse topicListPage =
 				this.topicAdminClient.listTopics(ProjectName.of(this.projectId));
 
-		return Lists.newArrayList(topicListPage.iterateAll());
+		List<Topic> topics = new ArrayList<>();
+		topicListPage.iterateAll().forEach(topics::add);
+		return Collections.unmodifiableList(topics);
 	}
 
 	/**
@@ -264,7 +267,9 @@ public class PubSubAdmin implements AutoCloseable {
 		SubscriptionAdminClient.ListSubscriptionsPagedResponse subscriptionsPage =
 				this.subscriptionAdminClient.listSubscriptions(ProjectName.of(this.projectId));
 
-		return Lists.newArrayList(subscriptionsPage.iterateAll());
+		List<Subscription> subscriptions = new ArrayList<>();
+		subscriptionsPage.iterateAll().forEach(subscriptions::add);
+		return Collections.unmodifiableList(subscriptions);
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.pubsub.v1.ProjectTopicName;
 
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
@@ -165,7 +164,6 @@ public class DefaultPublisherFactory implements PublisherFactory {
 		});
 	}
 
-	@VisibleForTesting
 	Map<String, Publisher> getCache() {
 		return this.publishers;
 	}

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.springframework.cloud.gcp.pubsub.integration.outbound;
 
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.springframework.cloud.gcp.core.util.MapBuilder;
 import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.expression.Expression;
@@ -72,7 +72,10 @@ public class PubSubMessageHandlerTests {
 	@Before
 	public void setUp() {
 		this.message = new GenericMessage<byte[]>("testPayload".getBytes(),
-				ImmutableMap.of("key1", "value1", "key2", "value2"));
+				new MapBuilder<String, Object>()
+						.put("key1", "value1")
+						.put("key2", "value2")
+						.build());
 		SettableListenableFuture<String> future = new SettableListenableFuture<>();
 		future.set("benfica");
 		when(this.pubSubTemplate.publish(eq("testTopic"),
@@ -92,8 +95,11 @@ public class PubSubMessageHandlerTests {
 	@Test
 	public void testPublishDynamicTopic() {
 		Message<?> dynamicMessage = new GenericMessage<byte[]>("testPayload".getBytes(),
-						ImmutableMap.of("key1", "value1", "key2", "value2",
-								GcpPubSubHeaders.TOPIC, "dynamicTopic"));
+				new MapBuilder<String, Object>()
+						.put("key1", "value1")
+						.put("key2", "value2")
+						.put(GcpPubSubHeaders.TOPIC, "dynamicTopic")
+						.build());
 		this.adapter.handleMessage(dynamicMessage);
 		verify(this.pubSubTemplate, times(1))
 			.publish(eq("dynamicTopic"),	eq("testPayload".getBytes()), isA(Map.class));

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/converter/SimplePubSubMessageConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import org.springframework.cloud.gcp.core.util.MapBuilder;
 import org.springframework.core.convert.converter.Converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,9 +42,10 @@ public class SimplePubSubMessageConverterTests {
 
 	private static final String TEST_STRING = "test";
 
-	private static final Map<String, String> TEST_HEADERS = ImmutableMap.of(
-			"key1", "value1",
-			"key2", "value2");
+	private static final Map<String, String> TEST_HEADERS = new MapBuilder<String, String>()
+			.put("key1", "value1")
+			.put("key2", "value2")
+			.build();
 
 	/**
 	 * used to test exception messages and types.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/main/java/com/example/DatastoreBookshelfExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/main/java/com/example/DatastoreBookshelfExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package com.example;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import com.google.common.collect.Lists;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
@@ -50,7 +49,9 @@ public class DatastoreBookshelfExample {
 	@ShellMethod("Loads all books")
 	public String findAllBooks() {
 		Iterable<Book> books = this.bookRepository.findAll();
-		return Lists.newArrayList(books).toString();
+		List<Book> bookList = new ArrayList<>();
+		books.forEach(bookList::add);
+		return books.toString();
 	}
 
 	@ShellMethod("Loads books by author: find-by-author <author>")

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/ConvertersExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/ConvertersExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,6 @@ package com.example;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-
-import com.google.common.collect.ImmutableSet;
 
 import org.springframework.core.convert.converter.Converter;
 
@@ -30,15 +27,6 @@ import org.springframework.core.convert.converter.Converter;
  * @author Dmitry Solomakha
  */
 public class ConvertersExample {
-	//Converter to read ImmutableSet
-	//Note that you don't need a ImmutableSet to List converter
-	static final Converter<List<?>, ImmutableSet<?>> LIST_IMMUTABLE_SET_CONVERTER =
-			new Converter<List<?>, ImmutableSet<?>>() {
-				@Override
-				public ImmutableSet<?> convert(List<?> source) {
-					return ImmutableSet.copyOf(source);
-				}
-			};
 
 	//Converter to write custom Singer.Album type
 	static final Converter<Album, String> ALBUM_STRING_CONVERTER =

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,6 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.HashSet;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -56,15 +53,16 @@ public class DatastoreRepositoryExample {
 			this.singerRepository.deleteAll();
 
 			this.singerRepository
-					.save(new Singer("singer1", "John", "Doe", ImmutableSet.of()));
+					.save(new Singer("singer1", "John", "Doe", new HashSet<Album>()));
 
 			Singer maryJane = new Singer("singer2", "Mary", "Jane",
-					ImmutableSet.of(new Album("a", LocalDate.of(2012, Month.JANUARY, 20)),
-							new Album("b", LocalDate.of(2018, Month.FEBRUARY, 12))));
-			Singer scottSmith = new Singer("singer3", "Scott", "Smith", ImmutableSet
-					.of(new Album("c", LocalDate.of(2000, Month.AUGUST, 31))));
+					new HashSet<>(Arrays.asList(
+							new Album("a", LocalDate.of(2012, Month.JANUARY, 20)),
+							new Album("b", LocalDate.of(2018, Month.FEBRUARY, 12)))));
+			Singer scottSmith = new Singer("singer3", "Scott", "Smith",
+					new HashSet<>(Arrays.asList(new Album("c", LocalDate.of(2000, Month.AUGUST, 31)))));
 
-			this.singerRepository.saveAll(ImmutableList.of(maryJane, scottSmith));
+			this.singerRepository.saveAll(Arrays.asList(maryJane, scottSmith));
 
 			createRelationshipsInTransaction(maryJane, scottSmith);
 
@@ -91,7 +89,7 @@ public class DatastoreRepositoryExample {
 		// Retrieving by keys or querying with a restriction to a single entity group
 		// / family is strongly consistent.
 		this.singerRepository
-				.findAllById(ImmutableList.of("singer1", "singer2", "singer3"))
+				.findAllById(Arrays.asList("singer1", "singer2", "singer3"))
 				.forEach((x) -> System.out.println("retrieved singer: " + x));
 	}
 
@@ -123,10 +121,6 @@ public class DatastoreRepositoryExample {
 	@Bean
 	public DatastoreCustomConversions datastoreCustomConversions() {
 		return new DatastoreCustomConversions(Arrays.asList(
-				// Converter to read ImmutableSet (List to ImmutableSet)
-				// Note that you don't need a ImmutableSet to List converter
-				ConvertersExample.LIST_IMMUTABLE_SET_CONVERTER,
-
 				// Converters to read and write custom Singer.Album type
 				ConvertersExample.ALBUM_STRING_CONVERTER,
 				ConvertersExample.STRING_ALBUM_CONVERTER));

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/test/java/com/example/PubSubJsonPayloadApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/src/test/java/com/example/PubSubJsonPayloadApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package com.example;
 
 import java.util.List;
+import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import org.awaitility.Duration;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.gcp.core.util.MapBuilder;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -60,9 +61,11 @@ public class PubSubJsonPayloadApplicationTests {
 
 	@Test
 	public void testReceivesJsonPayload() {
-		ImmutableMap<String, String> params = ImmutableMap.of(
-				"name", "Bob",
-				"age", "25");
+		Map<String, String> params = new MapBuilder<String, String>()
+				.put("name", "Bob")
+				.put("age", "25")
+				.build();
+
 		this.testRestTemplate.postForObject(
 				"/createPerson?name={name}&age={age}", null, String.class, params);
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/java/com/example/GcsSpringIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/java/com/example/GcsSpringIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -30,7 +31,6 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.common.collect.ImmutableList;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
@@ -110,11 +110,10 @@ public class GcsSpringIntegrationTests {
 					String firstLine = Files.lines(outputFile).findFirst().get();
 					assertThat(firstLine).isEqualTo("Hello World!");
 
-					List<String> blobNamesInOutputBucket = ImmutableList
-							.copyOf(this.storage.list(this.cloudOutputBucket).iterateAll())
-							.stream()
-							.map(Blob::getName)
-							.collect(Collectors.toList());
+					List<String> blobNamesInOutputBucket = new ArrayList<>();
+					this.storage.list(this.cloudOutputBucket).iterateAll()
+							.forEach((b) -> blobNamesInOutputBucket.add(b.getName()));
+
 					assertThat(blobNamesInOutputBucket).contains(TEST_FILE_NAME);
 				});
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.example;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -26,7 +27,6 @@ import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
 import com.google.cloud.logging.Payload.StringPayload;
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -102,7 +102,10 @@ public class LoggingSampleApplicationTests {
 				.untilAsserted(() -> {
 					Page<LogEntry> logEntryPage = this.logClient.listLogEntries(
 							Logging.EntryListOption.filter(logFilter));
-					ImmutableList<LogEntry> logEntries = ImmutableList.copyOf(logEntryPage.iterateAll());
+					List<LogEntry> logEntries = new ArrayList<>();
+					logEntryPage.iterateAll().forEach((le) -> {
+						logEntries.add(le);
+					});
 
 					List<String> logContents = logEntries.stream()
 							.map((logEntry) -> ((StringPayload) logEntry.getPayload()).getData())

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.example;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -27,7 +28,6 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient.ListSubscriptionsPagedResponse;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminClient.ListTopicsPagedResponse;
-import com.google.common.collect.ImmutableList;
 import com.google.pubsub.v1.ProjectName;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
@@ -130,7 +130,7 @@ public class PubSubApplicationTests {
 	@AfterClass
 	public static void cleanupPubsubClients() {
 		if (topicAdminClient != null) {
-			List<String> testTopics = ImmutableList.of(
+			List<String> testTopics = Arrays.asList(
 					SAMPLE_TEST_TOPIC,
 					SAMPLE_TEST_TOPIC2,
 					SAMPLE_TEST_TOPIC_DELETE);
@@ -147,7 +147,7 @@ public class PubSubApplicationTests {
 		}
 
 		if (subscriptionAdminClient != null) {
-			List<String> testSubscriptions = ImmutableList.of(
+			List<String> testSubscriptions = Arrays.asList(
 					SAMPLE_TEST_SUBSCRIPTION1,
 					SAMPLE_TEST_SUBSCRIPTION2,
 					SAMPLE_TEST_SUBSCRIPTION3,

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/ApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/ApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.example;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +28,6 @@ import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
 import com.google.cloud.logging.Payload.StringPayload;
-import com.google.common.collect.ImmutableList;
 import com.google.devtools.cloudtrace.v1.GetTraceRequest;
 import com.google.devtools.cloudtrace.v1.Trace;
 import com.google.devtools.cloudtrace.v1.TraceServiceGrpc;
@@ -139,8 +139,11 @@ public class ApplicationTests {
 			assertThat(trace.getTraceId()).isEqualTo(uuidString);
 			assertThat(trace.getSpansCount()).isEqualTo(8);
 
-			ImmutableList<LogEntry> logEntries = ImmutableList.copyOf(
-					this.logClient.listLogEntries(Logging.EntryListOption.filter(logFilter)).iterateAll());
+			List<LogEntry> logEntries = new ArrayList<>();
+			this.logClient.listLogEntries(Logging.EntryListOption.filter(logFilter)).iterateAll()
+					.forEach((le) -> {
+						logEntries.add(le);
+					});
 
 			List<String> logContents = logEntries.stream()
 					.map((logEntry) -> ((StringPayload) logEntry.getPayload()).getData())

--- a/spring-cloud-gcp-security-iap/pom.xml
+++ b/spring-cloud-gcp-security-iap/pom.xml
@@ -24,10 +24,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.google.cloud</groupId>
-			<artifactId>google-cloud-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-resourcemanager</artifactId>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-security-iap/src/test/java/org/springframework/cloud/gcp/security/iap/AudienceValidatorTests.java
+++ b/spring-cloud-gcp-security-iap/src/test/java/org/springframework/cloud/gcp/security/iap/AudienceValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package org.springframework.cloud.gcp.security.iap;
 
-import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -60,7 +61,7 @@ public class AudienceValidatorTests {
 	@Test
 	public void testCorrectAudienceMatches() {
 		Jwt mockJwt = Mockito.mock(Jwt.class);
-		when(mockJwt.getAudience()).thenReturn(ImmutableList.of("cats"));
+		when(mockJwt.getAudience()).thenReturn(Arrays.asList("cats"));
 
 		this.contextRunner.run((context) -> {
 			AudienceValidator validator = context.getBean(AudienceValidator.class);
@@ -71,7 +72,7 @@ public class AudienceValidatorTests {
 	@Test
 	public void testWrongAudienceDoesNotMatch() {
 		Jwt mockJwt = Mockito.mock(Jwt.class);
-		when(mockJwt.getAudience()).thenReturn(ImmutableList.of("dogs"));
+		when(mockJwt.getAudience()).thenReturn(Arrays.asList("dogs"));
 
 		this.contextRunner.run((context) -> {
 			AudienceValidator validator = context.getBean(AudienceValidator.class);

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -22,13 +22,11 @@
     </module>
 
     <module name="com.puppycrawl.tools.checkstyle.TreeWalker">
-        <!-- TODO: re-enable when ready -->
         <!-- NOTE: previously we also had org.slf4j as illegal -->
-        <!--
-        <module name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck" >
+
+<!--        <module name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck" >
             <property name="illegalPkgs" value="com.google.common"/>
-        </module>
-        -->
+        </module>-->
 
         <!-- TAKEN FROM SPRING BOOT -->
         <!-- Annotations -->

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -24,9 +24,9 @@
     <module name="com.puppycrawl.tools.checkstyle.TreeWalker">
         <!-- NOTE: previously we also had org.slf4j as illegal -->
 
-<!--        <module name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck" >
+        <module name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck" >
             <property name="illegalPkgs" value="com.google.common"/>
-        </module>-->
+        </module>
 
         <!-- TAKEN FROM SPRING BOOT -->
         <!-- Annotations -->


### PR DESCRIPTION
Last part of Guava removal. 

* `ImmutableMap` turned into `Collections.singletonMap()` for a single pair or into `MapBuilder` for multiple pairs.
* `ImmutableSet` turned into a new set created based on a list.
* `ImmutableList` turned into `Arrays.asList()`.
* `ConvertersExample.LIST_IMMUTABLE_SET_CONVERTER` no longer needed because `Set` and `List` are automatically convertable. The custom object converters in the same class are illustrate the concept well already, so no need to replace with a more convoluted data structure.

Fixes #1198 .