### PR TITLE
Datastore supports only allocating long IDs

### DIFF
--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -181,8 +181,8 @@ public class Trade {
 ----
 
 
-Datastore has automatic ID allocation.
-If a POJO instance is written to Cloud Datastore with `null` as the ID value, then Spring Data Cloud Datastore will obtain a newly allocated ID value from Cloud Datastore and set that in the POJO for saving.
+Datastore can automatically allocate integer ID values.
+If a POJO instance with a `Long` ID property is written to Cloud Datastore with `null` as the ID value, then Spring Data Cloud Datastore will obtain a newly allocated ID value from Cloud Datastore and set that in the POJO for saving.
 Because primitive `long` ID properties cannot be `null` and default to `0`, keys will not be allocated.
 
 ==== Fields

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactory.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactory.java
@@ -95,8 +95,14 @@ public class DatastoreServiceObjectToKeyFactory implements ObjectToKeyFactory {
 		Assert.notNull(datastorePersistentEntity, "Persistent entity must not be null.");
 		PersistentProperty idProp = datastorePersistentEntity.getIdPropertyOrFail();
 
-		KeyFactory keyFactory = getKeyFactory().setKind(datastorePersistentEntity.kindName());
 		Class idPropType = idProp.getType();
+
+		if (!idPropType.equals(Key.class) && !idPropType.equals(Long.class)) {
+			throw new DatastoreDataException("Cloud Datastore can only allocate IDs for Long and Key properties. " +
+					"Cannot allocate for type: " + idPropType);
+		}
+
+		KeyFactory keyFactory = getKeyFactory().setKind(datastorePersistentEntity.kindName());
 		if (ancestors != null && ancestors.length > 0) {
 			if (!idPropType.equals(Key.class)) {
 				throw new DatastoreDataException("Only Key types are allowed for descendants id");

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
@@ -89,11 +89,11 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 	public void getKeyTest() {
 		when(this.datastore.newKeyFactory()).thenReturn(new KeyFactory("p").setKind("k"));
 		TestEntityWithId testEntity = new TestEntityWithId();
-		testEntity.id = "testkey";
+		testEntity.id = 1L;
 
 		Key actual = this.datastoreServiceObjectToKeyFactory.getKeyFromObject(
 				testEntity, this.datastoreMappingContext.getPersistentEntity(TestEntityWithId.class));
-		Key expectedKey = new KeyFactory("p").setKind("custom_test_kind").newKey("testkey");
+		Key expectedKey = new KeyFactory("p").setKind("custom_test_kind").newKey(1L);
 
 		assertThat(actual).isEqualTo(expectedKey);
 	}
@@ -160,8 +160,29 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 						keyFactory.newKey("ancestor"));
 	}
 
+	@Test
+	public void allocateIdForObjectUnsupportedKeyTypeIdTest() {
+		this.expectedEx.expect(DatastoreDataException.class);
+		this.expectedEx.expectMessage("Cloud Datastore can only allocate IDs for Long and Key properties. " +
+				"Cannot allocate for type: class java.lang.String");
+
+		TestEntityWithStringId testEntityWithStringId = new TestEntityWithStringId();
+		KeyFactory keyFactory = new KeyFactory("project").setKind("kind");
+		when(this.datastore.newKeyFactory()).thenReturn(keyFactory);
+		this.datastoreServiceObjectToKeyFactory
+				.allocateKeyForObject(testEntityWithStringId, this.datastoreMappingContext
+						.getPersistentEntity(testEntityWithStringId.getClass()),
+						keyFactory.newKey("key"));
+	}
+
 	@org.springframework.cloud.gcp.data.datastore.core.mapping.Entity(name = "custom_test_kind")
 	private static class TestEntityWithId {
+		@Id
+		Long id;
+	}
+
+	@org.springframework.cloud.gcp.data.datastore.core.mapping.Entity(name = "custom_test_kind")
+	private static class TestEntityWithStringId {
 		@Id
 		String id;
 	}

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -319,6 +319,16 @@ public class DatastoreIntegrationTests {
 	}
 
 	@Test
+	public void allocateIdTest() {
+		// intentionally null ID value
+		TestEntity testEntity = new TestEntity(null, "red", 1L, Shape.CIRCLE, null);
+		assertThat(testEntity.getId()).isNull();
+		this.testEntityRepository.save(testEntity);
+		assertThat(testEntity.getId()).isNotNull();
+		assertThat(this.testEntityRepository.findById(testEntity.getId())).isPresent();
+	}
+
+	@Test
 	public void mapTest() {
 		Map<String, Long> map = new HashMap<>();
 		map.put("field1", 1L);


### PR DESCRIPTION
fixes #1390 
Cloud Datastore can only allocate Long ID values. enforcing this and added tests.