### PR TITLE
Remove unused dependencies

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -19,36 +19,6 @@
 		<docs.whitelisted.branches>1.0.x,1.1.x</docs.whitelisted.branches>
 	</properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-autoconfigure</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-data-spanner</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-data-datastore</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-pubsub</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-pubsub-stream-binder</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-storage</artifactId>
-		</dependency>
-	</dependencies>
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
Dependencies from `docs` to functionality providing modules were originally added in #556 to package javadoc together with github pages. But with #1255, the maven plugins that publish javadoc got removed, so these dependencies are not used by anything right now. In the meantime, they are generating false-positive Snyk vulnerabilities.

We still need to figure out the process for releasing javadoc, though, so these dependencies might come back in the future (in which case we should have the full set of `spring-cloud-gcp` modules there, not just a historical subset).