### PR TITLE
Always include original message

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -124,10 +124,11 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		Map<String, Object> messageHeaders =
 				this.headerMapper.toHeaders(message.getPubsubMessage().getAttributesMap());
 
-		if (this.ackMode == AckMode.MANUAL) {
-			// Send the original message downstream so user decides on when to ack/nack.
-			messageHeaders.put(GcpPubSubHeaders.ORIGINAL_MESSAGE, message);
+		// Send the original message downstream so that the user can decide on when to
+		// ack/nack, or just have access to the original message for any other reason.
+		messageHeaders.put(GcpPubSubHeaders.ORIGINAL_MESSAGE, message);
 
+		if (this.ackMode == AckMode.MANUAL) {
 			// Deprecated mechanism for manual (n)acking.
 			messageHeaders.put(GcpPubSubHeaders.ACKNOWLEDGEMENT, new AckReplyConsumer() {
 				@Override


### PR DESCRIPTION
Changes the Pub/Sub SI channel adapter so that the original Pub/Sub
message is always included in the message headers. Previously, it was
only included if the ack mode was `MANUAL`.

Fixes #1408.