### PR TITLE
Increase timeout on Trace Autoconfigure tests

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -124,7 +124,7 @@ public class StackdriverTraceAutoConfigurationTests {
 
 			MultipleReportersConfig.GcpTraceService gcpTraceService
 					= context.getBean(MultipleReportersConfig.GcpTraceService.class);
-			await().atMost(2, TimeUnit.SECONDS)
+			await().atMost(10, TimeUnit.SECONDS)
 					.pollInterval(Duration.ONE_SECOND)
 					.untilAsserted(() -> {
 						assertThat(gcpTraceService.hasTraceFor(traceId)).isTrue();
@@ -141,7 +141,7 @@ public class StackdriverTraceAutoConfigurationTests {
 
 			MultipleReportersConfig.OtherSender sender
 					= (MultipleReportersConfig.OtherSender) context.getBean("otherSender");
-			await().atMost(5, TimeUnit.SECONDS)
+			await().atMost(10, TimeUnit.SECONDS)
 					.untilAsserted(() -> assertThat(sender.isSpanSent()).isTrue());
 		});
 	}


### PR DESCRIPTION
Increase timeout on Trace Autoconfiguration tests to fix CI breakage.

passing run on branch _test_: https://travis-ci.org/spring-cloud/spring-cloud-gcp/builds/485514540