### PR TITLE
Suppress `LineLength` Checkstyle rule

### DIFF
--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 <suppressions>
     <suppress files="[\\/]spring-cloud-gcp-samples[\\/]" checks="HideUtilityClassConstructorCheck" />
     <suppress files="package\-info\.java" checks="RegexpHeader" />
+    <suppress files=".*" checks="LineLength" />
 </suppressions>


### PR DESCRIPTION
Looks like this rule doesn't work well to calculate a proper line length