### PR TITLE
Update binder sample properties and docs

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/README.adoc
@@ -4,7 +4,9 @@ This code sample demonstrates how to use the Spring Cloud Stream binder for Goog
 The sample app prompts a user for a message and their user name.
 That data is added to a `UserMessage` object, together with the time of message creation, and is sent through Google Cloud Pub/Sub to a sink which simply logs the message.
 
-If the topic and subscription for the sink and source don't exist, the binder will automatically create them in Google Cloud Pub/Sub based on the values in link:src/main/resources/application.properties[application.properties].
+If the topic for the sink and source does not exist, the binder will automatically create them in Google Cloud Pub/Sub based on the values in link:src/main/resources/application.properties[application.properties].
+
+If the group is not specified, an anonymous subscription with the name `anonymous.<topicName>.<randomUUID>` will be generated.
 
 == Running the code sample
 
@@ -14,11 +16,10 @@ Alternatively, if you have the https://cloud.google.com/sdk/[Google Cloud SDK] i
 
 2. Set your project ID using the `spring.cloud.gcp.project-id` property in link:src/main/resources/application.properties[application.properties] or use the `gcloud config set project [PROJECT_ID]` Cloud SDK command.
 
-3. Set the topic and subscription name in the link:src/main/resources/application.properties[application.properties] file.
+3. Set the topic and, optionally, group name in the link:src/main/resources/application.properties[application.properties] file.
 +
-If you're relying on the binder automatically creating the topic and subscription for you, they need to have the same name so that the messages are properly routed.
-+
-Alternatively, you can manually create the topic and subscription from the https://console.cloud.google.com/cloudpubsub[Google Cloud Console].
+You can rely on the binder to create the topic and subscription, or you can create them manually from the https://console.cloud.google.com/cloudpubsub[Google Cloud Console].
+If you create the subscription manually, make sure it follows the naming convention of `<topicName>.<consumerGroup>`.
 
 4. Run the `mvn clean spring-boot:run` in the root of the code sample to get the app running.
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/application.properties
@@ -1,5 +1,8 @@
-spring.cloud.stream.bindings.input.destination=[PUBSUB_SUBSCRIPTION_NAME]
+spring.cloud.stream.bindings.input.destination=[PUBSUB_TOPIC_NAME]
 spring.cloud.stream.bindings.output.destination=[PUBSUB_TOPIC_NAME]
+
+# If group is specified, the Pub/Sub subscription name will be [PUBSUB_TOPIC_NAME].[PUBSUB_GROUP_NAME]
+#spring.cloud.stream.bindings.input.group=[PUBSUB_GROUP_NAME]
 
 #spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
 #spring.cloud.gcp.credentials.location=file:[LOCAL_PATH_TO_CREDENTIALS]


### PR DESCRIPTION
After consumer groups were integrated, the binder sample direction became misleading. It used to be that you would specify the **topic** name for output destination, and a **subscription** name for input destination. But with consumer group support, if `input.group` is missing, then an anonymous subscription will be created, with `input.destination` assumed to be the topic name. That leads to a mismatch where messages are published to TOPIC but retrieved from `anonymous.<supposed-subscription-name-which-is-actually-a-topic>.<randomUUID>`.