### PR TITLE
Fix typo on CloudVisionException in javadoc

### DIFF
--- a/spring-cloud-gcp-vision/src/main/java/org/springframework/cloud/gcp/vision/CloudVisionTemplate.java
+++ b/spring-cloud-gcp-vision/src/main/java/org/springframework/cloud/gcp/vision/CloudVisionTemplate.java
@@ -56,7 +56,7 @@ public class CloudVisionTemplate {
 	 * Extract the text out of an image and return the result as a String.
 	 * @param imageResource the image one wishes to analyze
 	 * @return the text extracted from the image aggregated to a String
-	 * @throws CloudVisionTemplate if the image could not be read or if text extraction failed
+	 * @throws CloudVisionException if the image could not be read or if text extraction failed
 	 */
 	public String extractTextFromImage(Resource imageResource) {
 		AnnotateImageResponse response = analyzeImage(imageResource, Type.TEXT_DETECTION);
@@ -79,7 +79,7 @@ public class CloudVisionTemplate {
 	 *     image formats described here: https://cloud.google.com/vision/docs/supported-files
 	 * @param featureTypes the types of image analysis to perform on the image
 	 * @return the results of image analyses
-	 * @throws CloudVisionTemplate if the image could not be read or if a malformed response
+	 * @throws CloudVisionException if the image could not be read or if a malformed response
 	 *     is received from the Cloud Vision APIs
 	 */
 	public AnnotateImageResponse analyzeImage(Resource imageResource, Feature.Type... featureTypes) {


### PR DESCRIPTION
Fixes typo in CloudVisionTemplate javadocs regarding the exception thrown.