### PR TITLE
Fix adoc warnings

### DIFF
--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -53,6 +53,7 @@ NOTE: Core properties, as described in <<spring-cloud-gcp-core,Spring Cloud GCP 
 In other words, if `spring.application.name` is `myapp` and `spring.profiles.active` is `prod`, the configuration should be called `myapp_prod`.
 +
 In order to do that, you should have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, own a Google Cloud Project and run the following command:
++
 [source]
 ----
 gcloud init # if this is your first Google Cloud SDK run.
@@ -94,16 +95,18 @@ When your Spring application starts, the `queueSize` field value will be set to 
 http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints[Spring Cloud] provides support to have configuration parameters be reloadable with the POST request to `/actuator/refresh` endpoint.
 
 1.  Add the Spring Boot Actuator dependency:
-
++
 Maven coordinates:
++
 ----
 <dependency>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-actuator</artifactId>
 </dependency>
 ----
-
++
 Gradle coordinates:
++
 [source,subs="normal"]
 ----
 dependencies {

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -106,7 +106,7 @@ The following properties are available:
 a| If not set, default value is determined in the following order:
 
 1. `SPRING_CLOUD_GCP_LOGGING_PROJECT_ID` Environmental Variable.
-1. Value of `DefaultGcpProjectIdProvider.getProjectId()`
+2. Value of `DefaultGcpProjectIdProvider.getProjectId()`
 a| This is used to generate fully qualified Stackdriver Trace ID format: `projects/[PROJECT-ID]/traces/[TRACE-ID]`.
 
 This format is required to correlate trace between Stackdriver Trace and Stackdriver Logging.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/README.adoc
@@ -2,7 +2,7 @@
 
 This code sample demonstrates how to read and write POJOs from Google Cloud Datastore using the SpringData Cloud Datastore module link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-datastore[Spring Cloud GCP Cloud Datastore Starter].
 
-= Running the example
+== Running the example
 
 . Create a new Cloud Datastore database in your GCP project if this has not already been done to allow Cloud Datastore to create and store entities.
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/README.adoc
@@ -3,7 +3,7 @@
 This code sample demonstrates how to read and write POJOs from Google Cloud Datastore using the Spring
 Data Cloud Datastore module link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-datastore[Spring Cloud GCP Cloud Datastore Starter].
 
-= Running the example
+== Running the example
 
 . Create a new Cloud Datastore database in your GCP project if this has not already been done to allow
 Cloud Datastore to create and store entities.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/README.adoc
@@ -3,7 +3,7 @@
 This code sample demonstrates how to read and write POJOs from Google Cloud Spanner using the Spring
 Data Cloud Spanner module link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-spanner[Spring Cloud GCP Cloud Spanner Starter].
 
-= Running the example
+== Running the example
 
 
 . Create a new Cloud Spanner instance named "spring-demo".

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/README.adoc
@@ -14,12 +14,12 @@ Alternatively, if you have the https://cloud.google.com/sdk/[Google Cloud SDK] i
 3. Still in the same page, locate the newly created topic, click the button with the three vertical dots at the end of the topic's line and click "New subscription".
 Create a new subscription called `json-payload-sample-subscription` with all default parameters.
 
-3. In a terminal window, move into this directory (spring-cloud-gcp-integration-pubsub-json-sample) and run: `mvn spring-boot:run`.
+4. In a terminal window, move into this directory (spring-cloud-gcp-integration-pubsub-json-sample) and run: `mvn spring-boot:run`.
 
-4. Go to http://localhost:8080 and create a `Person` by filling out `Name` and `Age` and clicking submit.
+5. Go to http://localhost:8080 and create a `Person` by filling out `Name` and `Age` and clicking submit.
 In the backend, a Person object is created then serialized to JSON and sent to the Pub/Sub topic you created.
 The JSON payload is then received by the subscriber in the application which deserializes it and logs a message of the object that was received.
 
-5. Verify that the receiver logged the message you wrote.
+6. Verify that the receiver logged the message you wrote.
 +
 `Message arrived! Payload: Person{name='xxxxx' age=xx}`

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/README.adoc
@@ -21,9 +21,9 @@ Create a new subscription called `exampleSubscription` with all default paramete
 
 1. In separate terminal windows, start the `spring-cloud-gcp-spring-integration-pubsub-sample-sender` and `spring-cloud-gcp-spring-integration-pubsub-sample-receiver` applications with the `$ mvn spring-boot:run` command in the same folder as the apps' `pom.xml` files.
 
-1. Go to http://localhost:8080, write a message in the text box and hit the `Submit` button.
+2. Go to http://localhost:8080, write a message in the text box and hit the `Submit` button.
 
-1. Verify that the receiver logged the message you wrote.
+3. Verify that the receiver logged the message you wrote.
 +
 `Message arrived! Payload: [message-entered]`
 
@@ -34,10 +34,10 @@ There is an alternative receiver application that demonstrates receiving message
 
 1. Start the `spring-cloud-gcp-spring-integration-pubsub-sample-sender` application with the `$ mvn spring-boot:run` command in the same folder as the apps' `pom.xml` files.
 
-1. Start the `spring-cloud-gcp-spring-integration-pubsub-sample-polling-receiver` sample app in a separate terminal window.
+2. Start the `spring-cloud-gcp-spring-integration-pubsub-sample-polling-receiver` sample app in a separate terminal window.
 
-1. Open http://localhost:8080, write a message in the text box,  update the "times" text box if you'd like multiple messages, and hit send.
+3. Open http://localhost:8080, write a message in the text box,  update the "times" text box if you'd like multiple messages, and hit send.
 
-1. Verify that the receiver logged the message(s):
+4. Verify that the receiver logged the message(s):
 +
 `Message arrived by Synchronous Pull! Payload: [message-entered] (0)`

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/README.adoc
@@ -6,8 +6,8 @@ Starter] to store and group logs by trace ID, with the Google Stackdriver Loggin
 
 == Setup & Configuration
 1. Create a Google Cloud Platform Project
-1. Have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, initialized and logged in with https://developers.google.com/identity/protocols/application-default-credentials[application default credentials].
-1. Check that the https://console.cloud.google.com/apis/library/logging.googleapis.com/?q=logging[Stackdriver Logging API is enabled].
+2. Have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, initialized and logged in with https://developers.google.com/identity/protocols/application-default-credentials[application default credentials].
+3. Check that the https://console.cloud.google.com/apis/library/logging.googleapis.com/?q=logging[Stackdriver Logging API is enabled].
 
 == Running the Example
 Run the sample application from Maven:

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
@@ -21,7 +21,7 @@ Prints IAP identity details if authentication passes.
 
 == Setup & Configuration
 1. Create a Google Cloud Platform Project.
-1. Have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, initialized and logged in with https://developers.google.com/identity/protocols/application-default-credentials[application default credentials] (you can run the sample locally without logging in, but you'll need the credentials to deploy).
+2. Have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, initialized and logged in with https://developers.google.com/identity/protocols/application-default-credentials[application default credentials] (you can run the sample locally without logging in, but you'll need the credentials to deploy).
 
 
 == Running the Sample Locally

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/README.adoc
@@ -5,7 +5,7 @@ Google Cloud Storage using the link:../../spring-cloud-gcp-starters/spring-cloud
 
 This content is also available in the https://codelabs.developers.google.com/codelabs/spring-cloud-gcp-gcs/index.html[Reading and Writing Files with Spring Resource Abstraction] codelab.
 
-= Running the example
+== Running the example
 
 1. Make sure that you have the Cloud SDK configured by following https://cloud.google.com/sdk/docs/[these instructions].
 


### PR DESCRIPTION
We had two types of issues:
* Some sample docs had level-0 heading as the first section.
*  Numbering lists  as "1. 1. 1." instead of "1. 2. 3.". I did not realize asciidoc required sequential numbers, since the renderer seemed to handle identical numbers fine, so I've created this problem in the first place.