### PR TITLE
Change PubSubMessageSource default ack mode to AUTO

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubMessageSource.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubMessageSource.java
@@ -47,7 +47,7 @@ public class PubSubMessageSource extends AbstractFetchLimitingMessageSource<Obje
 
 	private final PubSubSubscriberOperations pubSubSubscriberOperations;
 
-	private AckMode ackMode = AckMode.MANUAL;
+	private AckMode ackMode = AckMode.AUTO;
 
 	private HeaderMapper<Map<String, String>> headerMapper = new PubSubHeaderMapper();
 

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubMessageSourceTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubMessageSourceTests.java
@@ -216,6 +216,23 @@ public class PubSubMessageSourceTests {
 		verify(this.msg1).ack();
 	}
 
+	@Test
+	public void doReceive_autoAckModeIsDefault() {
+		PubSubMessageSource pubSubMessageSource = new PubSubMessageSource(
+				this.mockPubSubSubscriberOperations, "sub1");
+		pubSubMessageSource.setMaxFetchSize(1);
+		pubSubMessageSource.setPayloadType(String.class);
+
+		MessageSourcePollingTemplate poller = new MessageSourcePollingTemplate(pubSubMessageSource);
+		poller.poll((message) -> {
+			assertThat(message).isNotNull();
+
+			assertThat(message.getPayload()).isEqualTo("msg1");
+			assertThat(message.getHeaders().get(GcpPubSubHeaders.ORIGINAL_MESSAGE)).isEqualTo(this.msg1);
+		});
+
+		verify(this.msg1).ack();
+	}
 
 	@Test
 	public void doReceive_autoModeNacksAutomatically() {
@@ -273,4 +290,5 @@ public class PubSubMessageSourceTests {
 		verify(this.mockPubSubSubscriberOperations)
 				.pullAndConvert("sub1", 1, false, String.class);
 	}
+
 }


### PR DESCRIPTION
I realized while updating cloud stream documentation for #1419 that I had made `PubSubMessageSource` default `AckMode.MANUAL`, which is inconsistent with `PubSubInboundChannelAdapter` and makes no sense for the cloud stream binder.
