### PR TITLE
Add support for using emulator with Datastore

### DIFF
--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -64,18 +64,12 @@ The following configuration options are available:
 |===
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.datastore.enabled` | Enables the Cloud Datastore client | No | `true`
-| `spring.cloud.gcp.datastore.project-id` | GCP project ID where the Google Cloud Datastore API is hosted, if different from the one in the <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>>
-| No |
-| `spring.cloud.gcp.datastore.credentials.location` | OAuth2 credentials for authenticating with the
-Google Cloud Datastore API, if different from the ones in the
-<<spring-cloud-gcp-core,Spring Cloud GCP Core Module>> | No |
-| `spring.cloud.gcp.datastore.credentials.encoded-key` | Base64-encoded OAuth2 credentials for authenticating with the
-Google Cloud Datastore API, if different from the ones in the
-<<spring-cloud-gcp-core,Spring Cloud GCP Core Module>> | No |
-| `spring.cloud.gcp.datastore.credentials.scopes` |
-https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Cloud GCP
-Cloud Datastore credentials | No | https://www.googleapis.com/auth/datastore
+| `spring.cloud.gcp.datastore.project-id` | GCP project ID where the Google Cloud Datastore API is hosted, if different from the one in the <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>> | No |
+| `spring.cloud.gcp.datastore.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Datastore API, if different from the ones in the <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>> | No |
+| `spring.cloud.gcp.datastore.credentials.encoded-key` | Base64-encoded OAuth2 credentials for authenticating with the Google Cloud Datastore API, if different from the ones in the <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>> | No |
+| `spring.cloud.gcp.datastore.credentials.scopes` | https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Cloud GCP Cloud Datastore credentials | No | https://www.googleapis.com/auth/datastore
 | `spring.cloud.gcp.datastore.namespace` | The Cloud Datastore namespace to use | No | the Default namespace of Cloud Datastore in your GCP project
+| `spring.cloud.gcp.datastore.emulator-host` | The `hostname:port` of the https://cloud.google.com/datastore/docs/tools/datastore-emulator[Datastore Emulator] to connect to | No |
 |===
 
 ==== Repository settings

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 
@@ -70,13 +71,22 @@ public class GcpDatastoreAutoConfiguration {
 	GcpDatastoreAutoConfiguration(GcpDatastoreProperties gcpDatastoreProperties,
 			GcpProjectIdProvider projectIdProvider,
 			CredentialsProvider credentialsProvider) throws IOException {
-		this.credentials = (gcpDatastoreProperties.getCredentials().hasKey()
-				? new DefaultCredentialsProvider(gcpDatastoreProperties)
-				: credentialsProvider).getCredentials();
+
 		this.projectId = (gcpDatastoreProperties.getProjectId() != null)
 				? gcpDatastoreProperties.getProjectId()
 				: projectIdProvider.getProjectId();
 		this.namespace = gcpDatastoreProperties.getNamespace();
+
+		if (gcpDatastoreProperties.getEmulatorHost() == null) {
+			this.credentials = (gcpDatastoreProperties.getCredentials().hasKey()
+					? new DefaultCredentialsProvider(gcpDatastoreProperties)
+					: credentialsProvider).getCredentials();
+		}
+		else {
+			// Use empty credentials with Datastore Emulator.
+			this.credentials = NoCredentials.getInstance();
+		}
+
 		this.emulatorHost = gcpDatastoreProperties.getEmulatorHost();
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -23,6 +23,7 @@ import com.google.auth.Credentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 
+import java.util.Optional;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -65,6 +66,8 @@ public class GcpDatastoreAutoConfiguration {
 
 	private final Credentials credentials;
 
+	private final Optional<String> emulatorHost;
+
 	GcpDatastoreAutoConfiguration(GcpDatastoreProperties gcpDatastoreProperties,
 			GcpProjectIdProvider projectIdProvider,
 			CredentialsProvider credentialsProvider) throws IOException {
@@ -75,6 +78,7 @@ public class GcpDatastoreAutoConfiguration {
 				? gcpDatastoreProperties.getProjectId()
 				: projectIdProvider.getProjectId();
 		this.namespace = gcpDatastoreProperties.getNamespace();
+		this.emulatorHost = Optional.ofNullable(gcpDatastoreProperties.getEmulatorHost());
 	}
 
 	@Bean
@@ -87,6 +91,11 @@ public class GcpDatastoreAutoConfiguration {
 		if (this.namespace != null) {
 			builder.setNamespace(this.namespace);
 		}
+
+		if (emulatorHost.isPresent()) {
+			builder.setHost(emulatorHost.get());
+		}
+
 		return builder.build().getService();
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -23,7 +23,6 @@ import com.google.auth.Credentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 
-import java.util.Optional;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -66,7 +65,7 @@ public class GcpDatastoreAutoConfiguration {
 
 	private final Credentials credentials;
 
-	private final Optional<String> emulatorHost;
+	private final String emulatorHost;
 
 	GcpDatastoreAutoConfiguration(GcpDatastoreProperties gcpDatastoreProperties,
 			GcpProjectIdProvider projectIdProvider,
@@ -78,7 +77,7 @@ public class GcpDatastoreAutoConfiguration {
 				? gcpDatastoreProperties.getProjectId()
 				: projectIdProvider.getProjectId();
 		this.namespace = gcpDatastoreProperties.getNamespace();
-		this.emulatorHost = Optional.ofNullable(gcpDatastoreProperties.getEmulatorHost());
+		this.emulatorHost = gcpDatastoreProperties.getEmulatorHost();
 	}
 
 	@Bean
@@ -92,8 +91,8 @@ public class GcpDatastoreAutoConfiguration {
 			builder.setNamespace(this.namespace);
 		}
 
-		if (emulatorHost.isPresent()) {
-			builder.setHost(emulatorHost.get());
+		if (emulatorHost != null) {
+			builder.setHost(emulatorHost);
 		}
 
 		return builder.build().getService();

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreProperties.java
@@ -36,6 +36,12 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
 	@NestedConfigurationProperty
 	private final Credentials credentials = new Credentials(GcpScope.DATASTORE.getUrl());
 
+	/**
+	 * The host and port of the local running emulator. If provided, this will setup the
+	 * client to connect against a running pub/sub emulator.
+	 */
+	private String emulatorHost;
+
 	private String projectId;
 
 	private String namespace;
@@ -61,4 +67,11 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
 		this.namespace = namespace;
 	}
 
+	public String getEmulatorHost() {
+		return emulatorHost;
+	}
+
+	public void setEmulatorHost(String emulatorHost) {
+		this.emulatorHost = emulatorHost;
+	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.gcp.autoconfigure.datastore;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
@@ -44,7 +46,18 @@ public class GcpDatastoreAutoConfigurationTests {
 					DatastoreRepositoriesAutoConfiguration.class))
 			.withUserConfiguration(TestConfiguration.class)
 			.withPropertyValues("spring.cloud.gcp.datastore.project-id=test-project",
-					"spring.cloud.gcp.datastore.namespace-id=testNamespace");
+					"spring.cloud.gcp.datastore.namespace=testNamespace",
+					"spring.cloud.gcp.datastore.emulator-host=localhost:8081");
+
+	@Test
+	public void testDatastoreOptionsCorrectlySet() {
+		this.contextRunner.run((context) -> {
+			DatastoreOptions datastoreOptions = context.getBean(Datastore.class).getOptions();
+			assertThat(datastoreOptions.getProjectId()).isEqualTo("test-project");
+			assertThat(datastoreOptions.getNamespace()).isEqualTo("testNamespace");
+			assertThat(datastoreOptions.getHost()).isEqualTo("localhost:8081");
+		});
+	}
 
 	@Test
 	public void testDatastoreOperationsCreated() {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -17,7 +17,9 @@
 package org.springframework.cloud.gcp.autoconfigure.datastore;
 
 import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.auth.Credentials;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import org.junit.Test;
@@ -56,6 +58,17 @@ public class GcpDatastoreAutoConfigurationTests {
 			assertThat(datastoreOptions.getProjectId()).isEqualTo("test-project");
 			assertThat(datastoreOptions.getNamespace()).isEqualTo("testNamespace");
 			assertThat(datastoreOptions.getHost()).isEqualTo("localhost:8081");
+		});
+	}
+
+	@Test
+	public void testDatastoreEmulatorCredentialsConfig() {
+		this.contextRunner.run((context) -> {
+			CredentialsProvider defaultCredentialsProvider = context.getBean(CredentialsProvider.class);
+			assertThat(defaultCredentialsProvider).isNotInstanceOf(NoCredentialsProvider.class);
+
+			DatastoreOptions datastoreOptions = context.getBean(Datastore.class).getOptions();
+			assertThat(datastoreOptions.getCredentials()).isInstanceOf(NoCredentials.class);
 		});
 	}
 


### PR DESCRIPTION
Add support for an application property allowing the user to connect to a Datastore emulator.

Fixes #1430.