### PR TITLE
Reorder items in refdoc index and use unnumbered list

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gcp.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gcp.adoc
@@ -14,16 +14,16 @@ The Spring Cloud GCP project makes the Spring Framework a first-class citizen of
 
 Spring Cloud GCP lets you leverage the power and simplicity of the Spring Framework to:
 
-. Analyze your images for text, objects, and other content with Google Cloud Vision
-. Use Spring Security via Google Cloud IAP
-. Map objects, relationships, and collections with Spring Data Cloud Spanner and Spring Data Cloud Datastore
-. Publish and subscribe to Google Cloud Pub/Sub topics
-. Configure Spring JDBC with a few properties to use Google Cloud SQL
-. Write and read from Spring Resources backed up by Google Cloud Storage
-. Exchange messages with Spring Integration using Google Cloud Pub/Sub on the background
-. Trace the execution of your app with Spring Cloud Sleuth and Google Stackdriver Trace
-. Configure your app with Spring Cloud Config, backed up by the Google Runtime Configuration API
-. Consume and produce Google Cloud Storage data via Spring Integration GCS Channel Adapters
+- Publish and subscribe to Google Cloud Pub/Sub topics
+- Configure Spring JDBC with a few properties to use Google Cloud SQL
+- Map objects, relationships, and collections with Spring Data Cloud Spanner and Spring Data Cloud Datastore
+- Write and read from Spring Resources backed up by Google Cloud Storage
+- Exchange messages with Spring Integration using Google Cloud Pub/Sub on the background
+- Trace the execution of your app with Spring Cloud Sleuth and Google Stackdriver Trace
+- Configure your app with Spring Cloud Config, backed up by the Google Runtime Configuration API
+- Consume and produce Google Cloud Storage data via Spring Integration GCS Channel Adapters
+- Use Spring Security via Google Cloud IAP
+- Analyze your images for text, objects, and other content with Google Cloud Vision
 
 include::dependency-management.adoc[]
 


### PR DESCRIPTION
This reorders the items in the refdoc index and changes to use an unnumbered list.
- Reordered the items because didn't seem correct to keep Cloud Vision at the top; the more important/core features of library should be at top
- Use unnumbered list because numbered list seems to imply that is exactly what we have to offer and nothing more; whereas this list conveys an idea of "we support these primary use-cases... and there's more."