### PR TITLE
Fix jdk11 compilation/test problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,34 +138,6 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<configuration>
-						<compilerId>javac-with-errorprone</compilerId>
-						<forceJavacCompilerUse>true</forceJavacCompilerUse>
-						<compilerArgs>
-							<!-- Enable all warnings -->
-							<compilerArg>-Xlint:all</compilerArg>
-							<!-- Disable options warning because we will have differences between the compiler and source code level-->
-							<compilerArg>-Xlint:-options</compilerArg>
-							<!-- Disable serialversionuid warnings -->
-							<compilerArg>-Xlint:-serial</compilerArg>
-							<!--compilerArg>-Werror</compilerArg-->
-						</compilerArgs>
-					</configuration>
-					<dependencies>
-						<dependency>
-							<groupId>org.codehaus.plexus</groupId>
-							<artifactId>plexus-compiler-javac-errorprone</artifactId>
-							<version>2.8.4</version>
-						</dependency>
-						<dependency>
-							<groupId>com.google.errorprone</groupId>
-							<artifactId>error_prone_core</artifactId>
-							<version>2.3.1</version>
-						</dependency>
-					</dependencies>
-				</plugin>
-				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration>
@@ -322,7 +294,7 @@
 				</pluginRepository>
 			</pluginRepositories>
 		</profile>
-		
+
 		<!-- Code Coverage -->
 		<profile>
 			<id>codecov</id>

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/core/environment/OnGcpEnvironmentConditionTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/core/environment/OnGcpEnvironmentConditionTests.java
@@ -89,8 +89,7 @@ public class OnGcpEnvironmentConditionTests {
 	public void testExceptionThrownWhenWrongAttributeType() {
 
 		this.expectedException.expect(ClassCastException.class);
-		this.expectedException.expectMessage("java.lang.String cannot be cast to " +
-				"[Lorg.springframework.cloud.gcp.core.GcpEnvironment;");
+		this.expectedException.expectMessage("java.lang.String cannot be cast");
 
 		setUpAnnotationValue("invalid type");
 		OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();


### PR DESCRIPTION
_javac-with-errorprone_ was causing this type of errors: 
```
cannot access java.lang.Object
  bad class file: /modules/java.base/java/lang/Object.class
    class file has wrong version 55.0, should be 53.0
```

The `OnGcpEnvironmentConditionTests` exception messages was too specific; it ended up checking internal java implementation errors.