### PR TITLE
Spanner Auditing

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -1271,6 +1271,44 @@ Spring Data Cloud Spanner publishes events extending the Spring Framework's `App
 |===
 
 
+=== Auditing
+
+Spring Data Cloud Spanner supports the `@LastModifiedDate` and `@LastModifiedBy` auditing annotations for properties:
+
+[source,java]
+----
+@Table
+public class SimpleEntity {
+    @PrimaryKey
+    String id;
+
+    @LastModifiedBy
+    String lastUser;
+
+    @LastModifiedDate
+    DateTime lastTouched;
+}
+----
+
+Upon insert, update, or save, these properties will be set automatically by the framework before mutations are generated and saved to Cloud Spanner.
+
+To take advantage of these features, add the `@EnableSpannerAuditing` annotation to your configuration class and provide a bean for an `AuditorAware<A>` implementation where the type `A` is the desired property type annotated by `@LastModifiedBy`:
+
+[source,java]
+----
+@Configuration
+@EnableSpannerAuditing
+public class Config {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> Optional.of("YOUR_USERNAME_HERE");
+    }
+}
+----
+
+You can also set a custom provider for properties annotated `@LastModifiedDate` by providing a bean for `DateTimeProvider` and providing the bean name to `@EnableSpannerAuditing(dateTimeProviderRef = "customDateTimeProviderBean")`.
+
 === Sample
 
 

--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -1307,6 +1307,24 @@ public class Config {
 }
 ----
 
+The `AuditorAware` interface contains a single method that supplies the value for fields annotated by `@LastModofiedBy` and can be of any type.
+One alternative is to use Spring Security's `User` type:
+
+[source,java]
+----
+class SpringSecurityAuditorAware implements AuditorAware<User> {
+
+  public Optional<User> getCurrentAuditor() {
+
+    return Optional.ofNullable(SecurityContextHolder.getContext())
+			  .map(SecurityContext::getAuthentication)
+			  .filter(Authentication::isAuthenticated)
+			  .map(Authentication::getPrincipal)
+			  .map(User.class::cast);
+  }
+}
+----
+
 You can also set a custom provider for properties annotated `@LastModifiedDate` by providing a bean for `DateTimeProvider` and providing the bean name to `@EnableSpannerAuditing(dateTimeProviderRef = "customDateTimeProviderBean")`.
 
 === Sample

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/event/BeforeSaveEvent.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/mapping/event/BeforeSaveEvent.java
@@ -16,10 +16,8 @@
 
 package org.springframework.cloud.gcp.data.spanner.core.mapping.event;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Set;
-
-import com.google.cloud.spanner.Mutation;
 
 /**
  * An event that is published just before a save operation is sent to Cloud Spanner.
@@ -29,14 +27,14 @@ import com.google.cloud.spanner.Mutation;
 public class BeforeSaveEvent extends SaveEvent {
 
 	/**
-	 * Constructor.
+	 * Constructor. {@code BeforeSaveEvent} does not hold mutations because this event gives
+	 * the opportunity to modify the entities from which mutations are ultimately generated.
 	 *
-	 * @param source the mutations for the event initially occurred. (never {@code null})
 	 * @param targetEntities the target entities that need to be mutated. This may be
 	 *     {@code null} depending on the original request.
 	 * @param includeProperties the set of properties to include in the save operation.
 	 */
-	public BeforeSaveEvent(List<Mutation> source, Iterable targetEntities, Set<String> includeProperties) {
-		super(source, targetEntities, includeProperties);
+	public BeforeSaveEvent(Iterable targetEntities, Set<String> includeProperties) {
+		super(Collections.emptyList(), targetEntities, includeProperties);
 	}
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/config/EnableSpannerAuditing.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/config/EnableSpannerAuditing.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.spanner.repository.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.AuditorAware;
+
+/**
+ * The annotation used to activate auditing functionality.
+ *
+ * @author Chengyuan Zhao
+ * @since 1.2
+ */
+@Inherited
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(SpannerAuditingRegistrar.class)
+public @interface EnableSpannerAuditing {
+
+	/**
+	 * Configures a {@link AuditorAware} bean to be used to lookup the current
+	 * principal.
+	 *
+	 * @return the name of a custom auditor provider. If blank then one will be looked up bean type.
+	 */
+	String auditorAwareRef() default "";
+
+	/**
+	 * Configures whether the creation and modification dates are set. Defaults to
+	 * {@literal true}.
+	 *
+	 * @return whether dates are set by the auditing functionality.
+	 */
+	boolean setDates() default true;
+
+	/**
+	 * Configures whether the entity shall be marked as modified on creation. Defaults to
+	 * {@literal true}.
+	 *
+	 * @return whether an entity is marked as modified when it is created.
+	 */
+	boolean modifyOnCreate() default true;
+
+	/**
+	 * Configures a {@link DateTimeProvider} bean name that allows customizing the
+	 * {@link org.joda.time.DateTime} to be used for setting creation and modification dates.
+	 *
+	 * @return the name of the custom time provider. If blank then one will be looked up bean type.
+	 */
+	String dateTimeProviderRef() default "";
+}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/config/SpannerAuditingRegistrar.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/config/SpannerAuditingRegistrar.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.spanner.repository.config;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cloud.gcp.data.spanner.repository.support.SpannerAuditingEventListener;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.auditing.config.AuditingBeanDefinitionRegistrarSupport;
+import org.springframework.data.auditing.config.AuditingConfiguration;
+
+/**
+ * Registers the annotations and classes for providing auditing support in Spring Data
+ * Cloud Spanner.
+ *
+ * @author Chengyuan Zhao
+ * @since 1.2
+ */
+public class SpannerAuditingRegistrar extends AuditingBeanDefinitionRegistrarSupport {
+
+	private static final String AUDITING_HANDLER_BEAN_NAME = "spannerAuditingHandler";
+
+	private static final String MAPPING_CONTEXT_BEAN_NAME = "spannerMappingContext";
+
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableSpannerAuditing.class;
+	}
+
+	@Override
+	protected void registerAuditListenerBeanDefinition(BeanDefinition auditingHandlerDefinition,
+			BeanDefinitionRegistry registry) {
+		Class<?> listenerClass = SpannerAuditingEventListener.class;
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(listenerClass)
+				.addConstructorArgReference(AUDITING_HANDLER_BEAN_NAME);
+
+		registerInfrastructureBeanWithId(builder.getRawBeanDefinition(), listenerClass.getName(), registry);
+	}
+
+	@Override
+	protected BeanDefinitionBuilder getAuditHandlerBeanDefinitionBuilder(AuditingConfiguration configuration) {
+		BeanDefinitionBuilder builder = configureDefaultAuditHandlerAttributes(configuration,
+				BeanDefinitionBuilder.rootBeanDefinition(AuditingHandler.class));
+		return builder.addConstructorArgReference(MAPPING_CONTEXT_BEAN_NAME);
+	}
+
+	@Override
+	protected String getAuditingHandlerBeanName() {
+		return AUDITING_HANDLER_BEAN_NAME;
+	}
+}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerAuditingEventListener.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerAuditingEventListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.spanner.repository.support;
+
+import org.springframework.cloud.gcp.data.spanner.core.mapping.event.BeforeSaveEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.data.auditing.AuditingHandler;
+
+/**
+ * Auditing event listener that listens for {@code BeforeSaveEvent}.
+ *
+ * @author Chengyuan Zhao
+ * @since 1.2
+ */
+public class SpannerAuditingEventListener implements ApplicationListener<BeforeSaveEvent> {
+
+	private final AuditingHandler handler;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param spannerAuditingHandler the auditing handler to set auditing properties.
+	 */
+	public SpannerAuditingEventListener(AuditingHandler spannerAuditingHandler) {
+		this.handler = spannerAuditingHandler;
+	}
+
+	@Override
+	public void onApplicationEvent(BeforeSaveEvent event) {
+		event.getTargetEntities().forEach(x -> this.handler.markModified(x));
+	}
+}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerAuditingEventListener.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerAuditingEventListener.java
@@ -41,6 +41,6 @@ public class SpannerAuditingEventListener implements ApplicationListener<BeforeS
 
 	@Override
 	public void onApplicationEvent(BeforeSaveEvent event) {
-		event.getTargetEntities().forEach(x -> this.handler.markModified(x));
+		event.getTargetEntities().forEach(this.handler::markModified);
 	}
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateAuditingTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateAuditingTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.spanner.core;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Mutation;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gcp.data.spanner.core.admin.SpannerSchemaUtils;
+import org.springframework.cloud.gcp.data.spanner.core.convert.SpannerEntityProcessor;
+import org.springframework.cloud.gcp.data.spanner.core.mapping.PrimaryKey;
+import org.springframework.cloud.gcp.data.spanner.core.mapping.SpannerMappingContext;
+import org.springframework.cloud.gcp.data.spanner.core.mapping.Table;
+import org.springframework.cloud.gcp.data.spanner.repository.config.EnableSpannerAuditing;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the auditing features of the template.
+ *
+ * @author Chengyuan Zhao
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+public class SpannerTemplateAuditingTests {
+
+	private static final List<Mutation> UPSERT_MUTATION = Arrays
+			.asList(Mutation.newInsertOrUpdateBuilder("custom_test_table").build());
+
+	@Autowired
+	SpannerTemplate spannerTemplate;
+
+	@Test
+	public void testModifiedProperties() {
+		TestEntity testEntity = new TestEntity();
+		testEntity.id = "a";
+		// intentionally leaving the other two audit properties untouched.
+
+		this.spannerTemplate.upsert(testEntity);
+	}
+
+	/**
+	 * Spring config for the tests.
+	 */
+	@Configuration
+	@EnableSpannerAuditing
+	static class config {
+
+		@Bean
+		public SpannerMappingContext spannerMappingContext() {
+			return new SpannerMappingContext();
+		}
+
+		@Bean
+		public SpannerTemplate spannerTemplate(SpannerMappingContext spannerMappingContext) {
+			SpannerEntityProcessor objectMapper = mock(SpannerEntityProcessor.class);
+			SpannerMutationFactory mutationFactory = mock(SpannerMutationFactory.class);
+
+			when(mutationFactory.upsert(Mockito.any(TestEntity.class), Mockito.any()))
+					.thenAnswer(invocation -> {
+						TestEntity testEntity = invocation.getArgument(0);
+						assertThat(testEntity.lastTouched).isNotNull();
+						assertThat(testEntity.lastUser).isEqualTo("test_user");
+						return UPSERT_MUTATION;
+					});
+
+			SpannerSchemaUtils schemaUtils = new SpannerSchemaUtils(spannerMappingContext, objectMapper, true);
+
+			return new SpannerTemplate(
+					mock(DatabaseClient.class), spannerMappingContext, objectMapper, mutationFactory, schemaUtils);
+		}
+
+		@Bean
+		public AuditorAware<String> auditorProvider() {
+			return () -> Optional.of("test_user");
+		}
+	}
+
+	@Table(name = "custom_test_table")
+	private static class TestEntity {
+		@PrimaryKey
+		String id;
+
+		@LastModifiedBy
+		String lastUser;
+
+		@LastModifiedDate
+		DateTime lastTouched;
+	}
+}

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateTests.java
@@ -341,7 +341,7 @@ public class SpannerTemplateTests {
 		when(this.mutationFactory.insert(entity))
 				.thenReturn(mutations);
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, Collections.singletonList(entity), null),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), null),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), null),
 				() -> this.spannerTemplate.insert(entity), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -357,7 +357,7 @@ public class SpannerTemplateTests {
 		when(this.mutationFactory.insert(same(entity)))
 				.thenReturn(Collections.singletonList(mutation));
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, entities, null),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(entities, null),
 				new AfterSaveEvent(mutations, entities, null),
 				() -> this.spannerTemplate.insertAll(entities), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -371,7 +371,7 @@ public class SpannerTemplateTests {
 		when(this.mutationFactory.update(entity, null))
 				.thenReturn(mutations);
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, Collections.singletonList(entity), null),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), null),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), null),
 				() -> this.spannerTemplate.update(entity), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -387,7 +387,7 @@ public class SpannerTemplateTests {
 		when(this.mutationFactory.update(same(entity), isNull()))
 				.thenReturn(Collections.singletonList(mutation));
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, entities, null),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(entities, null),
 				new AfterSaveEvent(mutations, entities, null),
 				() -> this.spannerTemplate.updateAll(entities), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -404,7 +404,7 @@ public class SpannerTemplateTests {
 				eq(cols)))
 						.thenReturn(mutations);
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, Collections.singletonList(entity), cols),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), cols),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), cols),
 				() -> this.spannerTemplate.update(entity, "a", "b"), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -420,7 +420,7 @@ public class SpannerTemplateTests {
 		when(this.mutationFactory.update(same(entity), eq(cols)))
 				.thenReturn(mutations);
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, Collections.singletonList(entity), cols),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), cols),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), cols),
 				() -> this.spannerTemplate.update(entity, cols), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -435,7 +435,7 @@ public class SpannerTemplateTests {
 		when(this.mutationFactory.upsert(same(entity), isNull()))
 				.thenReturn(mutations);
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, Collections.singletonList(entity), null),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), null),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), null),
 				() -> this.spannerTemplate.upsert(entity), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -451,7 +451,7 @@ public class SpannerTemplateTests {
 		when(this.mutationFactory.upsert(same(entity), isNull()))
 				.thenReturn(Collections.singletonList(mutation));
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, entities, null),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(entities, null),
 				new AfterSaveEvent(mutations, entities, null),
 				() -> this.spannerTemplate.upsertAll(entities), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -468,7 +468,7 @@ public class SpannerTemplateTests {
 				eq(cols)))
 						.thenReturn(Collections.singletonList(mutation));
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, Collections.singletonList(entity), cols),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), cols),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), cols),
 				() -> this.spannerTemplate.upsert(entity, "a", "b"), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));
@@ -484,7 +484,7 @@ public class SpannerTemplateTests {
 		when(this.mutationFactory.upsert(same(entity), eq(cols)))
 				.thenReturn(Collections.singletonList(mutation));
 
-		verifyBeforeAndAfterEvents(new BeforeSaveEvent(mutations, Collections.singletonList(entity), cols),
+		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), cols),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), cols),
 				() -> this.spannerTemplate.upsert(entity, cols), x -> x.verify(this.databaseClient, times(1))
 						.write(eq(mutations)));


### PR DESCRIPTION
fixes #1283 
adds user and date auditing annotation support. 


We are not supporting the CreatedBy and CreatedDate columns because Spring Data's support for those assumes the existence of hidden-from-the-user versioning columns which we do not support in this module. 