### PR TITLE
Spanner Spring Data special instantiator null check

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/StructPropertyValueProvider.java
@@ -82,6 +82,9 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
 		if (!this.structAccessor.hasColumn(colName)) {
 			throw new SpannerDataException("Column not found: " + colName);
 		}
+		if (this.structAccessor.isNull(colName)) {
+			return null;
+		}
 		Class propType = spannerPersistentProperty.getType();
 		Object value = ConversionUtils.isIterableNonByteArrayType(propType)
 				? readIterableWithConversion(spannerPersistentProperty)

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/Trade.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/Trade.java
@@ -65,8 +65,17 @@ public class Trade {
 	@Interleaved
 	private List<SubTrade> subTrades;
 
+	/**
+	 * Partial constructor. Intentionally tests a field that is left null sometimes.
+	 * @param symbol the symbol.
+	 */
+	public Trade(String symbol, List<Instant> executionTimes) {
+		this.symbol = symbol;
+		this.executionTimes = executionTimes;
+	}
+
 	public static Trade aTrade() {
-		Trade t = new Trade();
+		Trade t = new Trade("ABCD", new ArrayList<>());
 		String tradeId = UUID.randomUUID().toString();
 		String traderId = UUID.randomUUID().toString();
 
@@ -74,14 +83,12 @@ public class Trade {
 
 		t.tradeDetail.id = tradeId;
 		t.age = 8;
-		t.symbol = "ABCD";
 		t.action = "BUY";
 		t.traderId = traderId;
 		t.tradeTime = Instant.ofEpochSecond(333);
 		t.tradeDate = Date.from(t.tradeTime);
 		t.tradeDetail.price = 100.0;
 		t.tradeDetail.shares = 12345.6;
-		t.executionTimes = new ArrayList<>();
 		for (int i = 1; i <= 5; i++) {
 			t.executionTimes.add(Instant.ofEpochSecond(i));
 		}

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/Trade.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/Trade.java
@@ -68,6 +68,7 @@ public class Trade {
 	/**
 	 * Partial constructor. Intentionally tests a field that is left null sometimes.
 	 * @param symbol the symbol.
+	 * @param executionTimes the list of execution times.
 	 */
 	public Trade(String symbol, List<Instant> executionTimes) {
 		this.symbol = symbol;


### PR DESCRIPTION
fixes #1470
This addresses an issue where Spring Data's built-in support for partial constructors side-steps a check that we do. 