### PR TITLE
Spanner session leak fix and tests

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplate.java
@@ -447,7 +447,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 				: getReadContext();
 
 		if (options == null) {
-			resultSet = getReadContext().read(tableName, keys, columns);
+			resultSet = readContext.read(tableName, keys, columns);
 		}
 		else if (options.getIndex() != null) {
 			resultSet = readContext.readUsingIndex(tableName, options.getIndex(), keys,

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateTests.java
@@ -252,6 +252,7 @@ public class SpannerTemplateTests {
 		verifyAfterEvents(new AfterReadEvent(Collections.emptyList(), keys, null),
 				() -> assertThat(this.spannerTemplate.read(TestEntity.class, key)).isNull(), x -> {
 				});
+		verify(this.databaseClient, times(1)).singleUse();
 	}
 
 	@Test
@@ -261,6 +262,7 @@ public class SpannerTemplateTests {
 		verifyAfterEvents(new AfterQueryEvent(Collections.emptyList(), query, null),
 				() -> assertThat(this.spannerTemplate.query(TestEntity.class, query, null)).isEmpty(), x -> {
 				});
+		verify(this.databaseClient, times(1)).singleUse();
 	}
 
 	@Test
@@ -280,6 +282,7 @@ public class SpannerTemplateTests {
 		spyTemplate.read(TestEntity.class, Key.of("key"));
 		verify(spyTemplate, times(1)).read(eq(TestEntity.class), eq(Key.of("key")),
 				eq(null));
+		verify(this.databaseClient, times(1)).singleUse();
 	}
 
 	@Test
@@ -289,6 +292,7 @@ public class SpannerTemplateTests {
 				.build();
 		spyTemplate.read(TestEntity.class, keys);
 		verify(spyTemplate, times(1)).read(eq(TestEntity.class), same(keys), eq(null));
+		verify(this.databaseClient, times(1)).singleUse();
 	}
 
 	@Test
@@ -306,6 +310,7 @@ public class SpannerTemplateTests {
 					verify(this.readContext, times(1)).read(eq("custom_test_table"), same(keySet),
 							any(), same(readOption));
 				});
+		verify(this.databaseClient, times(1)).singleUse();
 	}
 
 	@Test
@@ -322,6 +327,7 @@ public class SpannerTemplateTests {
 				eq(TestEntity.class), isNull(), eq(false));
 		verify(this.readContext, times(1)).readUsingIndex(eq("custom_test_table"),
 				eq("index"), same(keySet), any(), same(readOption));
+		verify(this.databaseClient, times(1)).singleUse();
 	}
 
 	@Test
@@ -331,6 +337,7 @@ public class SpannerTemplateTests {
 		spyTemplate.readAll(TestEntity.class, options);
 		verify(spyTemplate, times(1)).read(eq(TestEntity.class), eq(KeySet.all()),
 				same(options));
+		verify(this.databaseClient, times(1)).singleUse();
 	}
 
 	@Test


### PR DESCRIPTION
fixes #1474 
typo fix. removes accidental call to method rather than using existing variable.