### PR TITLE
Create a GoogleStorageLocation class for Storage module

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -26,6 +26,8 @@ import org.springframework.util.Assert;
  * Represents a Google Cloud Storage location provided by the user.
  *
  * @author Daniel Zou
+ *
+ * @since 1.2
  */
 public class GoogleStorageLocation {
 
@@ -82,12 +84,8 @@ public class GoogleStorageLocation {
 			this.bucketName = bucketName;
 			this.blobName = pathToFile;
 
-			if (pathToFile == null) {
-				this.uri = new URI(String.format(GCS_URI_FORMAT, bucketName, ""));
-			}
-			else {
-				this.uri = new URI(String.format(GCS_URI_FORMAT, bucketName, pathToFile));
-			}
+			pathToFile = (pathToFile == null) ? "" : pathToFile;
+			this.uri = new URI(String.format(GCS_URI_FORMAT, bucketName, pathToFile));
 		}
 		catch (URISyntaxException e) {
 			String errorMessage = String.format(

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.storage;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.springframework.util.Assert;
+
+/**
+ * Represents a Google Cloud Storage location provided by the user.
+ *
+ * @author Daniel Zou
+ */
+public final class GoogleStorageLocation {
+
+	private static final String GCS_URI_FORMAT = "gs://%s/%s";
+
+	private final String bucketName;
+
+	private final String blobName;
+
+	private final URI uri;
+
+	public GoogleStorageLocation(String gcsLocationUriString) {
+		try {
+			URI locationUri = new URI(gcsLocationUriString);
+
+			Assert.isTrue(
+					gcsLocationUriString.startsWith("gs://"),
+					"A Google Storage URI must start with gs://");
+
+			Assert.isTrue(
+					locationUri.getAuthority() != null,
+					"No bucket specified in the location: " + gcsLocationUriString);
+
+			this.bucketName = locationUri.getAuthority();
+			this.blobName = getBlobPathFromUri(locationUri);
+
+			// ensure that if it's a bucket handle, location ends with a '/'
+			if (this.blobName == null && !gcsLocationUriString.endsWith("/")) {
+				locationUri = new URI(gcsLocationUriString + "/");
+			}
+			this.uri = locationUri;
+		}
+		catch (URISyntaxException e) {
+			throw new IllegalArgumentException(
+					"Invalid location: " + gcsLocationUriString);
+		}
+	}
+
+	/**
+	 * Returns the Google Storage bucket name.
+	 */
+	public String getBucketName() {
+		return bucketName;
+	}
+
+	/**
+	 * Returns the path to the blob/folder relative from the bucket root. Returns the empty
+	 * String if the {@link GoogleStorageLocation} specifies a bucket itself.
+	 */
+	public String getBlobName() {
+		return blobName;
+	}
+
+	/**
+	 * Returns the GCS URI of the location.
+	 */
+	public URI uri() {
+		return this.uri;
+	}
+
+	/**
+	 * Returns the Google Storage URI string for the location.
+	 */
+	public String uriString() {
+		String processedBlobName = (blobName == null) ? "" : blobName;
+		return String.format(GCS_URI_FORMAT, bucketName, processedBlobName);
+	}
+
+	/**
+	 * Returns a {@link GoogleStorageLocation} to a bucket.
+	 * @param bucketName name of the GCS bucket
+	 * @return the {@link GoogleStorageLocation} to the location.
+	 */
+	public static GoogleStorageLocation forBucket(String bucketName) {
+		String uri = String.format(GCS_URI_FORMAT, bucketName, "");
+		return new GoogleStorageLocation(uri);
+	}
+
+	/**
+	 * Returns a {@link GoogleStorageLocation} for a file within a bucket.
+	 * @param bucketName name of the GCS bucket
+	 * @param pathToFile path to the file within the bucket
+	 * @return the {@link GoogleStorageLocation} to the location.
+	 */
+	public static GoogleStorageLocation forFile(String bucketName, String pathToFile) {
+		String uri = String.format(GCS_URI_FORMAT, bucketName, pathToFile);
+		return new GoogleStorageLocation(uri);
+	}
+
+	/**
+	 * Returns a {@link GoogleStorageLocation} to a folder whose path is relative to the
+	 * bucket.
+	 * @param bucketName name of the GCS bucket.
+	 * @param pathToFolder path to the folder within the bucket.
+	 * @return the {@link GoogleStorageLocation} to the location.
+	 */
+	public static GoogleStorageLocation forFolder(String bucketName, String pathToFolder) {
+		if (!pathToFolder.endsWith("/")) {
+			pathToFolder += "/";
+		}
+
+		String uri = String.format(GCS_URI_FORMAT, bucketName, pathToFolder);
+		return new GoogleStorageLocation(uri);
+	}
+
+	@Override
+	public String toString() {
+		return uriString();
+	}
+
+	private static String getBlobPathFromUri(URI gcsUri) {
+		String uriPath = gcsUri.getPath();
+		if (uriPath.isEmpty() || uriPath.equals("/")) {
+			// This indicates that the path specifies the root of the bucket
+			return null;
+		}
+		else {
+			return uriPath.substring(1);
+		}
+	}
+}

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -97,11 +97,19 @@ public class GoogleStorageLocation {
 	}
 
 	/**
-	 * Check if this resource references a bucket and not a blob.
-	 * @return if the resource is bucket
+	 * Check if the location references a bucket and not a blob.
+	 * @return if the location describes a bucket
 	 */
 	public boolean isBucket() {
 		return this.blobName == null;
+	}
+
+	/**
+	 * Returns whether this {@link GoogleStorageLocation} represents a file or not.
+	 * @return true if the location describes a file
+	 */
+	public boolean isFile() {
+		return this.blobName != null && !this.blobName.endsWith("/");
 	}
 
 	/**

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -84,11 +84,12 @@ public class GoogleStorageLocation {
 
 			if (pathToFile == null) {
 				this.uri = new URI(String.format(GCS_URI_FORMAT, bucketName, ""));
-			} else {
+			}
+			else {
 				this.uri = new URI(String.format(GCS_URI_FORMAT, bucketName, pathToFile));
 			}
-
-		} catch (URISyntaxException e) {
+		}
+		catch (URISyntaxException e) {
 			String errorMessage = String.format(
 					"Invalid location provided. bucketName: %s, pathToFile: %s", bucketName, pathToFile);
 			throw new IllegalArgumentException(errorMessage, e);
@@ -105,6 +106,8 @@ public class GoogleStorageLocation {
 
 	/**
 	 * Returns the Google Storage bucket name.
+	 *
+	 * @return the name of the Google Storage bucket
 	 */
 	public String getBucketName() {
 		return bucketName;

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -36,6 +36,12 @@ public final class GoogleStorageLocation {
 
 	private final URI uri;
 
+	/**
+	 * Constructs a {@link GoogleStorageLocation} based on the provided Google Storage URI string.
+	 * The URI string is of the form: {@code gs://<BUCKET_NAME>/<PATH_TO_FILE>}
+	 *
+	 * @param gcsLocationUriString a Google Storage URI string to a bucket/folder/file.
+	 */
 	public GoogleStorageLocation(String gcsLocationUriString) {
 		try {
 			URI locationUri = new URI(gcsLocationUriString);

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -99,6 +99,8 @@ public class GoogleStorageResource extends GoogleStorageLocation implements Writ
 	 *     if an operation that depends on its existence is triggered (e.g., getting the
 	 *     output stream of a file)
 	 * @throws IllegalArgumentException if the location is an invalid Google Storage location
+	 *
+	 * @since 1.2
 	 */
 	public GoogleStorageResource(
 			Storage storage,

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageLocationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageLocationTests.java
@@ -20,6 +20,9 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * @author Daniel Zou
+ */
 public class GoogleStorageLocationTests {
 
 	@Test

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageLocationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageLocationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.storage;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GoogleStorageLocationTests {
+
+	@Test
+	public void testCorrectUriForBucket() {
+		GoogleStorageLocation location = GoogleStorageLocation.forBucket("bucketName");
+		assertThat(location.uriString()).isEqualTo("gs://bucketName/");
+	}
+
+	@Test
+	public void testCorrectUriForFolder() {
+		GoogleStorageLocation location = GoogleStorageLocation.forFolder("bucketName", "folderName");
+		assertThat(location.uriString()).isEqualTo("gs://bucketName/folderName/");
+	}
+
+	@Test
+	public void testCorrectUriForFile() {
+		GoogleStorageLocation location = GoogleStorageLocation.forFile("bucketName", "fileName");
+		assertThat(location.uriString()).isEqualTo("gs://bucketName/fileName");
+	}
+}

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -132,6 +132,25 @@ public class GoogleStorageTests {
 	}
 
 	@Test
+	public void testSpecifyBucketCorrect() {
+		GoogleStorageResource googleStorageResource = new GoogleStorageResource(
+				this.storage, "test-spring", null, false);
+
+		Assert.assertTrue(googleStorageResource.isBucket());
+		Assert.assertEquals("test-spring", googleStorageResource.getBucket().getName());
+		Assert.assertTrue(googleStorageResource.exists());
+	}
+
+	@Test
+	public void testSpecifyPathCorrect() {
+		GoogleStorageResource googleStorageResource = new GoogleStorageResource(
+				this.storage, "test-spring", "images/spring.png", false);
+
+		Assert.assertTrue(googleStorageResource.isFile());
+		Assert.assertTrue(googleStorageResource.exists());
+	}
+
+	@Test
 	public void testBucketOutputStream() throws IOException {
 		this.expectedEx.expect(IllegalStateException.class);
 		this.expectedEx.expectMessage("Cannot open an output stream to a bucket: 'gs://test-spring/'");

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Tess for Google Cloud Storage.
+ * Tests for Google Cloud Storage.
  *
  * @author Vinicius Carvalho
  * @author Artem Bilan
@@ -97,7 +97,6 @@ public class GoogleStorageTests {
 		this.expectedEx.expectMessage("No bucket specified in the location: gs:///");
 		new GoogleStorageResource(this.storage, "gs:///", false);
 	}
-
 
 	@Test
 	public void testValidObject() throws Exception {


### PR DESCRIPTION
This creates a `GoogleStorageLocation` class for the Storage module.

I did this because I wanted to reuse the logic to specify and validate URIs/locations of blobs in GCS.

This also offers users an easier way to construct GCS locations (by bucket name + file path). From my research, it looks like people [have trouble finding the documentation for how to construct a GCS URI](https://stackoverflow.com/questions/25373467/how-do-i-identify-the-google-cloud-storage-uri-from-my-google-developers-console).