### PR TITLE
Datastore persistent entity discrimination field support

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastoreMappingContext.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastoreMappingContext.java
@@ -57,7 +57,7 @@ public class DatastoreMappingContext extends
 
 	protected <T> DatastorePersistentEntityImpl<T> constructPersistentEntity(
 			TypeInformation<T> typeInformation) {
-		return new DatastorePersistentEntityImpl<>(typeInformation);
+		return new DatastorePersistentEntityImpl<>(typeInformation, this);
 	}
 
 	@Override

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastorePersistentEntity.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DatastorePersistentEntity.java
@@ -33,8 +33,8 @@ public interface DatastorePersistentEntity<T> extends
 		MutablePersistentEntity<T, DatastorePersistentProperty>, ApplicationContextAware {
 
 	/**
-	 * Gets the name of the Datastore Entity.
-	 * @return the name of the Entity.
+	 * Gets the name of the Datastore Kind.
+	 * @return the name of the Datastore Kind that stores these entities.
 	 */
 	String kindName();
 
@@ -44,6 +44,19 @@ public interface DatastorePersistentEntity<T> extends
 	 * @return the ID property.
 	 */
 	DatastorePersistentProperty getIdPropertyOrFail();
+
+	/**
+	 * Get the name of the field for subtype discrimination if there is one.
+	 * @return the name of the discrimination field. {@code null} if this persistent entity
+	 * doesn't have one.
+	 */
+	String getDiscriminationFieldName();
+
+	/**
+	 * Get the discrimination value corresponding to this persistent entity type.
+	 * @return the value or {@code null} if there is no value for this type.
+	 */
+	String getDiscriminationValue();
 
 	/**
 	 * Applies the given {@link PropertyHandler} to all

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DiscriminationField.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DiscriminationField.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.datastore.core.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for entities that are root superclasses of inheritance hierarchies of
+ * subclass entities.
+ *
+ * @author Chengyuan Zhao
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DiscriminationField {
+
+	/**
+	 * The name of the field that holds the value that distinguishes which subclass an entity
+	 * maps to.
+	 * @return the name of the column.
+	 */
+	String field();
+}

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DiscriminationValue.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/mapping/DiscriminationValue.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.datastore.core.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for subclasses in an inheritance hierarchy that matches a value in a
+ * discrimination field in the parent class.
+ *
+ * @author Chengyuan Zhao
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DiscriminationValue {
+
+	/**
+	 * The value that corresponds to entities of the annotated subclass stored in the
+	 * Datastore Kind belonging to the parent class.
+	 * @return the value that corresponds to the annotated subclass.
+	 */
+	String value();
+}


### PR DESCRIPTION
related #1475
Makes the persistent entity impl aware of discriminator fields and values.