### PR TITLE
Suggestion: Make getBlobName return empty string if GoogleStorageResource is a bucket

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -79,6 +79,8 @@ public class GoogleStorageLocation {
 	 *    the location is to the bucket itself.
 	 */
 	public GoogleStorageLocation(String bucketName, String pathToFile) {
+		Assert.notNull(pathToFile, "The GCS path to a file/folder must not be null.");
+
 		try {
 			this.bucketName = bucketName;
 			this.blobName = pathToFile;
@@ -184,7 +186,7 @@ public class GoogleStorageLocation {
 
 	private static String getBlobPathFromUri(URI gcsUri) {
 		String uriPath = gcsUri.getPath();
-		if (uriPath.isEmpty() || uriPath.equals("/")) {
+		if (uriPath == null || uriPath.isEmpty() || uriPath.equals("/")) {
 			// This indicates that the path specifies the root of the bucket
 			return "";
 		}

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.gcp.storage;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -61,7 +60,7 @@ public class GoogleStorageLocation {
 			this.blobName = getBlobPathFromUri(locationUri);
 
 			// ensure that if it's a bucket handle, location ends with a '/'
-			if (this.blobName == null && !gcsLocationUriString.endsWith("/")) {
+			if (this.blobName.isEmpty() && !gcsLocationUriString.endsWith("/")) {
 				locationUri = new URI(gcsLocationUriString + "/");
 			}
 			this.uri = locationUri;
@@ -76,15 +75,13 @@ public class GoogleStorageLocation {
 	 * {@code pathToFile}.
 	 *
 	 * @param bucketName name of the Google Storage bucket
-	 * @param pathToFile path to the file or folder in the bucket; set as null if
+	 * @param pathToFile path to the file or folder in the bucket; set as empty string if
 	 *    the location is to the bucket itself.
 	 */
-	public GoogleStorageLocation(String bucketName, @Nullable String pathToFile) {
+	public GoogleStorageLocation(String bucketName, String pathToFile) {
 		try {
 			this.bucketName = bucketName;
 			this.blobName = pathToFile;
-
-			pathToFile = (pathToFile == null) ? "" : pathToFile;
 			this.uri = new URI(String.format(GCS_URI_FORMAT, bucketName, pathToFile));
 		}
 		catch (URISyntaxException e) {
@@ -99,7 +96,7 @@ public class GoogleStorageLocation {
 	 * @return if the location describes a bucket
 	 */
 	public boolean isBucket() {
-		return this.blobName == null;
+		return this.blobName.isEmpty();
 	}
 
 	/**
@@ -107,7 +104,7 @@ public class GoogleStorageLocation {
 	 * @return true if the location describes a file
 	 */
 	public boolean isFile() {
-		return this.blobName != null && !this.blobName.endsWith("/");
+		return !this.blobName.isEmpty() && !this.blobName.endsWith("/");
 	}
 
 	/**
@@ -120,10 +117,10 @@ public class GoogleStorageLocation {
 	}
 
 	/**
-	 * Returns the path to the blob/folder relative from the bucket root. Returns null
+	 * Returns the path to the blob/folder relative from the bucket root. Returns empty string
 	 * if the {@link GoogleStorageLocation} specifies a bucket itself.
 	 *
-	 * @return a path to the blob or folder; null if the location is to a bucket.
+	 * @return a path to the blob or folder; empty string if the location is to a bucket.
 	 */
 	public String getBlobName() {
 		return blobName;
@@ -144,8 +141,7 @@ public class GoogleStorageLocation {
 	 * @return the URI string of the Google Storage location.
 	 */
 	public String uriString() {
-		String processedBlobName = (blobName == null) ? "" : blobName;
-		return String.format(GCS_URI_FORMAT, bucketName, processedBlobName);
+		return String.format(GCS_URI_FORMAT, bucketName, blobName);
 	}
 
 	/**
@@ -154,7 +150,7 @@ public class GoogleStorageLocation {
 	 * @return the {@link GoogleStorageLocation} to the location.
 	 */
 	public static GoogleStorageLocation forBucket(String bucketName) {
-		return new GoogleStorageLocation(bucketName, null);
+		return new GoogleStorageLocation(bucketName, "");
 	}
 
 	/**
@@ -190,7 +186,7 @@ public class GoogleStorageLocation {
 		String uriPath = gcsUri.getPath();
 		if (uriPath.isEmpty() || uriPath.equals("/")) {
 			// This indicates that the path specifies the root of the bucket
-			return null;
+			return "";
 		}
 		else {
 			return uriPath.substring(1);

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -119,7 +119,7 @@ public class GoogleStorageTests {
 		Assert.assertEquals("gs://test-spring/aaa/bbb", relative);
 		Assert.assertEquals(relative, this.bucketResource.createRelative("/aaa/bbb").getURI().toString());
 
-		Assert.assertNull(((GoogleStorageResource) this.bucketResource).getBlobName());
+		Assert.assertTrue(((GoogleStorageResource) this.bucketResource).getBlobName().isEmpty());
 		Assert.assertTrue(((GoogleStorageResource) this.bucketResource).isBucket());
 
 		Assert.assertTrue(this.bucketResource.exists());
@@ -134,7 +134,7 @@ public class GoogleStorageTests {
 	@Test
 	public void testSpecifyBucketCorrect() {
 		GoogleStorageResource googleStorageResource = new GoogleStorageResource(
-				this.storage, "test-spring", null, false);
+				this.storage, "test-spring", "", false);
 
 		Assert.assertTrue(googleStorageResource.isBucket());
 		Assert.assertEquals("test-spring", googleStorageResource.getBucket().getName());


### PR DESCRIPTION
This is a suggestion PR for when `getBlobName()` is called, GoogleStorageResource should return empty string instead of null.

Followup to discussion in #1478 - Elena suggested possibility of returning empty string instead of null.

On further inspection, I think `getBlobName()` should return an empty string instead of null when the resource is a bucket. This is because the empty string is more useful as a value; the main argument for this is usage of expression that pops up: 

```
blobPath = (blobPath == null) ? "" : pathToFile
```

Within storage module this is done twice and this was also done in my work with vision OCR. I begin to fell that it is inconvenient to have to check for null and then convert to empty string.