### PR TITLE
Make Pub/Sub thread pools Spring-managed beans

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gcp.autoconfigure.pubsub;
 import java.io.IOException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -111,17 +112,29 @@ public class GcpPubSubAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(name = "pubsubPublisherThreadPool")
+	public ScheduledExecutorService pubsubPublisherThreadPool() {
+		return Executors.newScheduledThreadPool(this.gcpPubSubProperties.getSubscriber().getExecutorThreads());
+	}
+
+	@Bean
 	@ConditionalOnMissingBean(name = "publisherExecutorProvider")
-	public ExecutorProvider publisherExecutorProvider() {
-		return FixedExecutorProvider.create(Executors.newScheduledThreadPool(
-				this.gcpPubSubProperties.getPublisher().getExecutorThreads()));
+	public ExecutorProvider publisherExecutorProvider(
+			@Qualifier("pubsubPublisherThreadPool") ScheduledExecutorService executorService) {
+		return FixedExecutorProvider.create(executorService);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(name = "pubsubSubscriberThreadPool")
+	public ScheduledExecutorService pubsubSubscriberThreadPool() {
+		return Executors.newScheduledThreadPool(this.gcpPubSubProperties.getSubscriber().getExecutorThreads());
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(name = "subscriberExecutorProvider")
-	public ExecutorProvider subscriberExecutorProvider() {
-		return FixedExecutorProvider.create(Executors.newScheduledThreadPool(
-				this.gcpPubSubProperties.getSubscriber().getExecutorThreads()));
+	public ExecutorProvider subscriberExecutorProvider(
+			@Qualifier("pubsubSubscriberThreadPool") ScheduledExecutorService executorService) {
+		return FixedExecutorProvider.create(executorService);
 	}
 
 	@Bean


### PR DESCRIPTION
The two thread pools are hardcoded in autoconfiguration, so they fall through the cracks when a Spring application shuts down:
* Spring does not manage them because they are not context-managed beans.
* gRPC stub does not manage them because `FixedExecutorProvider.shouldAutoClose()` is `false` (also, we don't call `SubscriberStub.shutdown()`, which we arguably should do, as well.

This does not manifest on the publisher side because that thread pool is never started, but the subscriber thread pool _is_ started by way of subscriber stub creation when `PubSubSubscriberTemplate` is instantiated.

Fixes #1503.
Addresses the Pub/Sub part of #1506.