### PR TITLE
Cleanup the constructors in Storage API

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.gcp.storage;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -68,29 +67,6 @@ public class GoogleStorageLocation {
 		}
 		catch (URISyntaxException e) {
 			throw new IllegalArgumentException("Invalid location: " + gcsLocationUriString, e);
-		}
-	}
-
-	/**
-	 * Constructs a {@link GoogleStorageLocation} based on the provided {@code bucketName} and
-	 * {@code pathToFile}.
-	 *
-	 * @param bucketName name of the Google Storage bucket
-	 * @param pathToFile path to the file or folder in the bucket; set as null if
-	 *    the location is to the bucket itself.
-	 */
-	public GoogleStorageLocation(String bucketName, @Nullable String pathToFile) {
-		try {
-			this.bucketName = bucketName;
-			this.blobName = pathToFile;
-
-			pathToFile = (pathToFile == null) ? "" : pathToFile;
-			this.uri = new URI(String.format(GCS_URI_FORMAT, bucketName, pathToFile));
-		}
-		catch (URISyntaxException e) {
-			String errorMessage = String.format(
-					"Invalid location provided. bucketName: %s, pathToFile: %s", bucketName, pathToFile);
-			throw new IllegalArgumentException(errorMessage, e);
 		}
 	}
 
@@ -154,7 +130,7 @@ public class GoogleStorageLocation {
 	 * @return the {@link GoogleStorageLocation} to the location.
 	 */
 	public static GoogleStorageLocation forBucket(String bucketName) {
-		return new GoogleStorageLocation(bucketName, null);
+		return new GoogleStorageLocation(String.format(GCS_URI_FORMAT, bucketName, ""));
 	}
 
 	/**
@@ -164,7 +140,8 @@ public class GoogleStorageLocation {
 	 * @return the {@link GoogleStorageLocation} to the location.
 	 */
 	public static GoogleStorageLocation forFile(String bucketName, String pathToFile) {
-		return new GoogleStorageLocation(bucketName, pathToFile);
+		Assert.notNull(pathToFile, "The path to a Google Storage file must not be null.");
+		return new GoogleStorageLocation(String.format(GCS_URI_FORMAT, bucketName, pathToFile));
 	}
 
 	/**
@@ -175,10 +152,11 @@ public class GoogleStorageLocation {
 	 * @return the {@link GoogleStorageLocation} to the location.
 	 */
 	public static GoogleStorageLocation forFolder(String bucketName, String pathToFolder) {
+		Assert.notNull(pathToFolder, "The path to a Google Storage folder must not be null.");
 		if (!pathToFolder.endsWith("/")) {
 			pathToFolder += "/";
 		}
-		return new GoogleStorageLocation(bucketName, pathToFolder);
+		return new GoogleStorageLocation(String.format(GCS_URI_FORMAT, bucketName, pathToFolder));
 	}
 
 	@Override

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageLocation.java
@@ -87,6 +87,14 @@ public class GoogleStorageLocation {
 	}
 
 	/**
+	 * Returns whether this {@link GoogleStorageLocation} represents a folder.
+	 * @return true if the location describes a folder
+	 */
+	public boolean isFolder() {
+		return this.blobName != null && this.blobName.endsWith("/");
+	}
+
+	/**
 	 * Returns the Google Storage bucket name.
 	 *
 	 * @return the name of the Google Storage bucket

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -72,10 +72,7 @@ public class GoogleStorageResource implements WritableResource {
 	 * @throws IllegalArgumentException if the location URI is invalid
 	 */
 	public GoogleStorageResource(Storage storage, String locationUri, boolean autoCreateFiles) {
-		Assert.notNull(storage, "Storage object can not be null");
-		this.storage = storage;
-		this.location = new GoogleStorageLocation(locationUri);
-		this.autoCreateFiles = autoCreateFiles;
+		this(storage, new GoogleStorageLocation(locationUri), autoCreateFiles);
 	}
 
 	/**

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -256,7 +256,7 @@ public class GoogleStorageResource implements WritableResource {
 	public GoogleStorageResource createRelative(String relativePath) throws IOException {
 		return new GoogleStorageResource(
 				this.storage,
-				this.location.uri().resolve(relativePath).toString(),
+				getURI().resolve(relativePath).toString(),
 				this.autoCreateFiles);
 	}
 

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageLocationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageLocationTests.java
@@ -26,20 +26,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class GoogleStorageLocationTests {
 
 	@Test
-	public void testCorrectUriForBucket() {
+	public void testCorrectLocationForBucket() {
 		GoogleStorageLocation location = GoogleStorageLocation.forBucket("bucketName");
 		assertThat(location.uriString()).isEqualTo("gs://bucketName/");
+		assertThat(location.isBucket()).isTrue();
 	}
 
 	@Test
-	public void testCorrectUriForFolder() {
+	public void testCorrectLocationForFolder() {
 		GoogleStorageLocation location = GoogleStorageLocation.forFolder("bucketName", "folderName");
 		assertThat(location.uriString()).isEqualTo("gs://bucketName/folderName/");
+		assertThat(location.isFolder()).isTrue();
 	}
 
 	@Test
-	public void testCorrectUriForFile() {
+	public void testCorrectLocationForFile() {
 		GoogleStorageLocation location = GoogleStorageLocation.forFile("bucketName", "fileName");
 		assertThat(location.uriString()).isEqualTo("gs://bucketName/fileName");
+		assertThat(location.isFile()).isTrue();
 	}
 }

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -133,8 +133,9 @@ public class GoogleStorageTests {
 
 	@Test
 	public void testSpecifyBucketCorrect() {
+		GoogleStorageLocation location = GoogleStorageLocation.forBucket("test-spring");
 		GoogleStorageResource googleStorageResource = new GoogleStorageResource(
-				this.storage, "test-spring", null, false);
+				this.storage, location, false);
 
 		Assert.assertTrue(googleStorageResource.isBucket());
 		Assert.assertEquals("test-spring", googleStorageResource.getBucket().getName());
@@ -144,9 +145,8 @@ public class GoogleStorageTests {
 	@Test
 	public void testSpecifyPathCorrect() {
 		GoogleStorageResource googleStorageResource = new GoogleStorageResource(
-				this.storage, "test-spring", "images/spring.png", false);
+				this.storage, "gs://test-spring/images/spring.png", false);
 
-		Assert.assertTrue(googleStorageResource.isFile());
 		Assert.assertTrue(googleStorageResource.exists());
 	}
 

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -138,6 +138,7 @@ public class GoogleStorageTests {
 				this.storage, location, false);
 
 		Assert.assertTrue(googleStorageResource.isBucket());
+		Assert.assertEquals("test-spring", googleStorageResource.getBucketName());
 		Assert.assertEquals("test-spring", googleStorageResource.getBucket().getName());
 		Assert.assertTrue(googleStorageResource.exists());
 	}


### PR DESCRIPTION
This cleans up the the constructors in the storage APIs.

- Removed constructor accepting null `pathToBlob`.
- Removed inheritance so GoogleStorageResource can be created from a GoogleStorageLocation