### PR TITLE
Fix Datastore sample integration test

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/health/DatastoreHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/health/DatastoreHealthIndicatorAutoConfiguration.java
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Configuration;
  * @since 1.2
  */
 @Configuration
-@ConditionalOnClass(Datastore.class)
+@ConditionalOnClass({ Datastore.class, HealthIndicator.class })
 @ConditionalOnBean(Datastore.class)
 @ConditionalOnEnabledHealthIndicator("datastore")
 @AutoConfigureBefore(HealthIndicatorAutoConfiguration.class)


### PR DESCRIPTION
Making Datastore health indicator autoconfiguration conditional on the actuator dependency.