### PR TITLE
Add dependency on pubsub project to reactive autoconfiguration

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubReactiveAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubReactiveAutoConfiguration.java
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @AutoConfigureAfter(GcpPubSubAutoConfiguration.class)
-@ConditionalOnClass(Flux.class)
+@ConditionalOnClass({Flux.class, PubSubSubscriberTemplate.class})
 @ConditionalOnProperty(value = "spring.cloud.gcp.pubsub.reactive.enabled", matchIfMissing = true)
 public class GcpPubSubReactiveAutoConfiguration {
 


### PR DESCRIPTION
Storage integration test failed because storage had a dependency on spring-integration and, therefore, on reactor, but did not have a dependency on pubsub.

Thank you for writing the integration test :)