### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Spring Framework on Google Cloud Platform
 
 This project makes it easy for Spring users to run their applications on Google Cloud Platform.
-You can check our project website http://cloud.spring.io/spring-cloud-gcp[here].
+You can check our project website https://cloud.spring.io/spring-cloud-gcp[here].
 
 For a deep dive into the project, refer to the
 https://docs.spring.io/spring-cloud-gcp/docs/1.0.0.M3/reference/htmlsingle/[Spring
@@ -91,7 +91,7 @@ spring.cloud.gcp.credentials.scopes=[SCOPE_1],[SCOPE_2],[SCOPE_3]
 
 These properties are optional and, if not specified, Spring Boot will attempt to automatically find
 them for you. For details on how Spring Boot finds these properties, refer to
-the http://cloud.spring.io/spring-cloud-gcp[documentation].
+the https://cloud.spring.io/spring-cloud-gcp[documentation].
 
 NOTE: If your app is running on Google App Engine or Google Compute Engine, in most cases, you should omit
 the `spring.cloud.gcp.credentials.location` property and, instead, let the Spring Cloud GCP Core

--- a/spring-cloud-gcp-docs/src/main/asciidoc/core.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/core.adoc
@@ -136,4 +136,4 @@ spring.cloud.gcp.credentials.scopes=DEFAULT_SCOPES,https://www.googleapis.com/au
 
 ==== Spring Initializr
 
-This starter is available from http://start.spring.io/[Spring Initializr] through the `GCP Support` entry.
+This starter is available from https://start.spring.io/[Spring Initializr] through the `GCP Support` entry.

--- a/spring-cloud-gcp-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/getting-started.adoc
@@ -4,7 +4,7 @@ There are many available resources to get you up to speed with our libraries as 
 
 === Spring Initializr
 
-There are three entries in http://start.spring.io/[Spring Initializr] for Spring Cloud GCP:
+There are three entries in https://start.spring.io/[Spring Initializr] for Spring Cloud GCP:
 
 - GCP Support
 - GCP Messaging

--- a/spring-cloud-gcp-docs/src/main/asciidoc/logging.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/logging.adoc
@@ -29,7 +29,7 @@ This allows grouping of log messages by request, for example, in the https://con
 
 NOTE: Due to the way logging is set up, the GCP project ID and credentials defined in `application.properties` are ignored.
 Instead, you should set the `GOOGLE_CLOUD_PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS` environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you're using the http://cloud.google.com/sdk[Google Cloud SDK], using the `gcloud config set project [YOUR_PROJECT_ID]` and `gcloud auth application-default login` commands, respectively.
+You can do this easily if you're using the https://cloud.google.com/sdk[Google Cloud SDK], using the `gcloud config set project [YOUR_PROJECT_ID]` and `gcloud auth application-default login` commands, respectively.
 
 A https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample[sample application] is available.
 

--- a/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
+++ b/spring-cloud-gcp-docs/src/main/asciidoc/pubsub.adoc
@@ -185,7 +185,7 @@ Here is an example of how to create a Google Cloud Pub/Sub subscription:
 [source,java]
 ----
 public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }
 ----
 

--- a/spring-cloud-gcp-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-gcp-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-gcp-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-gcp-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-gcp-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-gcp-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-gcp-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-gcp-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/README.adoc
@@ -29,7 +29,7 @@ If you set a root password, add the `spring.datasource.password` property with t
 you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring
 Boot Starter for Google Cloud SQL.
 +
-Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account
 from the Google Cloud Console] and download its private key.
 Then, uncomment the `spring.cloud.gcp.sql.credentials.location` property in the
 link:src/main/resources/application.properties[application.properties] file and fill its value with

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-sample/README.adoc
@@ -30,7 +30,7 @@ If you would like to use a different user, set the `spring.datasource.username` 
 you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring
 Boot Starter for Google Cloud SQL.
 +
-Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account
 from the Google Cloud Console] and download its private key.
 Then, uncomment the `spring.cloud.gcp.sql.credentials.location` property in the
 link:src/main/resources/application.properties file and fill its value with the path to your service


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://my.endpoint/push (UnknownHostException) with 1 occurrences migrated to:  
  https://my.endpoint/push ([https](https://my.endpoint/push) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://start.spring.io/ with 2 occurrences migrated to:  
  https://start.spring.io/ ([https](https://start.spring.io/) result 200).
* [ ] http://cloud.google.com/sdk with 1 occurrences migrated to:  
  https://cloud.google.com/sdk ([https](https://cloud.google.com/sdk) result 301).
* [ ] http://cloud.spring.io/spring-cloud-gcp with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-gcp ([https](https://cloud.spring.io/spring-cloud-gcp) result 301).
* [ ] http://console.cloud.google.com/iam-admin/serviceaccounts with 2 occurrences migrated to:  
  https://console.cloud.google.com/iam-admin/serviceaccounts ([https](https://console.cloud.google.com/iam-admin/serviceaccounts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost with 2 occurrences
* http://localhost:8080 with 3 occurrences
* http://localhost:8080/ with 2 occurrences
* http://localhost:8080/getTuples with 1 occurrences
* http://localhost:8080/meet with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences