### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 = Spring Framework on Google Cloud Platform
 
 This project makes it easy for Spring users to run their applications on Google Cloud Platform.
-You can check our project website http://cloud.spring.io/spring-cloud-gcp[here].
+You can check our project website https://cloud.spring.io/spring-cloud-gcp[here].
 
 For a deep dive into the project, refer to the https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.1.0.RELEASE/single/spring-cloud-gcp.html[Spring Cloud GCP 1.1 Reference Document].
 
@@ -97,6 +97,6 @@ spring.cloud.gcp.credentials.scopes=[SCOPE_1],[SCOPE_2],[SCOPE_3]
 ----
 
 These properties are optional and, if not specified, Spring Boot will attempt to automatically find them for you.
-For details on how Spring Boot finds these properties, refer to the http://cloud.spring.io/spring-cloud-gcp[documentation].
+For details on how Spring Boot finds these properties, refer to the https://cloud.spring.io/spring-cloud-gcp[documentation].
 
 NOTE: If your app is running on Google App Engine or Google Compute Engine, in most cases, you should omit the `spring.cloud.gcp.credentials.location` property and, instead, let the Spring Cloud GCP Core Starter find the correct credentials for those environments.

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -1,7 +1,7 @@
 = Spring Framework on Google Cloud Platform
 
 This project makes it easy for Spring users to run their applications on Google Cloud Platform.
-You can check our project website http://cloud.spring.io/spring-cloud-gcp[here].
+You can check our project website https://cloud.spring.io/spring-cloud-gcp[here].
 
 For a deep dive into the project, refer to the https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.1.0.RELEASE/single/spring-cloud-gcp.html[Spring Cloud GCP 1.1 Reference Document].
 
@@ -116,6 +116,6 @@ spring.cloud.gcp.credentials.scopes=[SCOPE_1],[SCOPE_2],[SCOPE_3]
 ----
 
 These properties are optional and, if not specified, Spring Boot will attempt to automatically find them for you.
-For details on how Spring Boot finds these properties, refer to the http://cloud.spring.io/spring-cloud-gcp[documentation].
+For details on how Spring Boot finds these properties, refer to the https://cloud.spring.io/spring-cloud-gcp[documentation].
 
 NOTE: If your app is running on Google App Engine or Google Compute Engine, in most cases, you should omit the `spring.cloud.gcp.credentials.location` property and, instead, let the Spring Cloud GCP Core Starter find the correct credentials for those environments.

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -43,7 +43,7 @@ Timeout in milliseconds for connecting to the Google Runtime Configuration API |
 | `spring.cloud.gcp.config.credentials.scopes` | https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Cloud GCP Config credentials | No | https://www.googleapis.com/auth/cloudruntimeconfig
 |===
 
-NOTE: These properties should be specified in a http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context[`bootstrap.yml`/`bootstrap.properties`] file, rather than the usual `applications.yml`/`application.properties`.
+NOTE: These properties should be specified in a https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context[`bootstrap.yml`/`bootstrap.properties`] file, rather than the usual `applications.yml`/`application.properties`.
 
 NOTE: Core properties, as described in <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>>, do not apply to Spring Cloud GCP Config.
 
@@ -92,7 +92,7 @@ When your Spring application starts, the `queueSize` field value will be set to 
 
 === Refreshing the configuration at runtime
 
-http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints[Spring Cloud] provides support to have configuration parameters be reloadable with the POST request to `/actuator/refresh` endpoint.
+https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints[Spring Cloud] provides support to have configuration parameters be reloadable with the POST request to `/actuator/refresh` endpoint.
 
 1.  Add the Spring Boot Actuator dependency:
 +
@@ -126,7 +126,7 @@ $ gcloud beta runtime-config configs variables set \
 5.  Send a POST request to the refresh endpoint:
 +
 ....
-$ curl -XPOST http://myapp.host.com/actuator/refresh
+$ curl -XPOST https://myapp.host.com/actuator/refresh
 ....
 
 === Sample

--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -135,4 +135,4 @@ public interface GcpEnvironmentProvider {
 
 === Spring Initializr
 
-This starter is available from http://start.spring.io/[Spring Initializr] through the `GCP Support` entry.
+This starter is available from https://start.spring.io/[Spring Initializr] through the `GCP Support` entry.

--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -2,8 +2,8 @@
 
 == Spring Data Cloud Datastore
 
-http://projects.spring.io/spring-data/[Spring Data] is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for http://cloud.google.com/datastore/[Google Cloud Datastore].
+https://projects.spring.io/spring-data/[Spring Data] is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for https://cloud.google.com/datastore/[Google Cloud Datastore].
 
 Maven coordinates for this module only, using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
 

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -106,7 +106,7 @@ A summary of these artifacts are provided below.
 
 ==== Spring Initializr
 
-http://start.spring.io/[Spring Initializr] is a tool which generates the scaffolding code for a new Spring Boot project.
+https://start.spring.io/[Spring Initializr] is a tool which generates the scaffolding code for a new Spring Boot project.
 It handles the work of generating the Maven or Gradle build file so you do not have to manually add the dependencies yourself.
 
 Spring Initializr offers three modules from Spring Cloud GCP that you can use to generate your project.

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -28,7 +28,7 @@ This allows grouping of log messages by request, for example, in the https://con
 
 NOTE: Due to the way logging is set up, the GCP project ID and credentials defined in `application.properties` are ignored.
 Instead, you should set the `GOOGLE_CLOUD_PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS` environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you're using the http://cloud.google.com/sdk[Google Cloud SDK], using the `gcloud config set project [YOUR_PROJECT_ID]` and `gcloud auth application-default login` commands, respectively.
+You can do this easily if you're using the https://cloud.google.com/sdk[Google Cloud SDK], using the `gcloud config set project [YOUR_PROJECT_ID]` and `gcloud auth application-default login` commands, respectively.
 
 === Web MVC Interceptor
 

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -225,7 +225,7 @@ Here is an example of how to create a Google Cloud Pub/Sub subscription:
 [source,java]
 ----
 public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }
 ----
 

--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -2,8 +2,8 @@
 
 == Spring Data Cloud Spanner
 
-http://projects.spring.io/spring-data/[Spring Data] is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for http://cloud.google.com/spanner/[Google Cloud Spanner].
+https://projects.spring.io/spring-data/[Spring Data] is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for https://cloud.google.com/spanner/[Google Cloud Spanner].
 
 Maven coordinates for this module only, using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
 

--- a/docs/src/main/asciidoc/vision.adoc
+++ b/docs/src/main/asciidoc/vision.adoc
@@ -54,7 +54,7 @@ A full list of Cloud Vision Features is provided in the https://cloud.google.com
 For each feature type that you provide in the request, `AnnotateImageResponse` provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the `LABEL_DETECTION` feature, you would retrieve the results from the response using `annotateImageResponse.getLabelAnnotationsList()`.
 +
-`AnnotateImageResponse` is provided by the Google Cloud Vision libraries; please consult the https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse[RPC reference] or http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html[Javadoc] for more details.
+`AnnotateImageResponse` is provided by the Google Cloud Vision libraries; please consult the https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse[RPC reference] or https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html[Javadoc] for more details.
 Additionally, you may consult the https://cloud.google.com/vision/docs/[Cloud Vision docs] to familiarize yourself with the concepts and features of the API.
 
 === Detect Image Labels Example

--- a/docs/src/main/docbook/xsl/common.xsl
+++ b/docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/docs/src/main/docbook/xsl/epub.xsl
+++ b/docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/docs/src/main/docbook/xsl/html.xsl
+++ b/docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/docs/src/main/docbook/xsl/pdf.xsl
+++ b/docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"

--- a/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/main/resources/templates/registrants.html
+++ b/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/main/resources/templates/registrants.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head>
   <title>Registrants List</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/README.adoc
@@ -8,7 +8,7 @@ This code sample demonstrates how to read and write POJOs from Google Cloud Data
 
 . https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring Boot Starter for Google Cloud Datastore.
 +
-Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
 +
 Then, uncomment the `spring.cloud.gcp.datastore.credentials.location` property in the link:src/main/resources/application.properties[application.properties] file and fill its value with the path to your service account private key on your local file system, prepended with `file:`.
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/README.adoc
@@ -11,7 +11,7 @@ Cloud Datastore to create and store entities.
 . https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring
 Boot Starter for Google Cloud Datastore.
 +
-Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
 +
 Then, uncomment the `spring.cloud.gcp.datastore.credentials.location` property in the link:src/main/resources/application.properties[application.properties] file and fill its value with the path to your service account private key on your local file system, prepended with `file:`.
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/README.adoc
@@ -26,7 +26,7 @@ If you set a root password, add the `spring.datasource.password` property with t
 
 5. https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring Boot Starter for Google Cloud SQL.
 +
-Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
 Then, uncomment the `spring.cloud.gcp.sql.credentials.location` property in the link:src/main/resources/application.properties[application.properties] file and fill its value with the path to your service account private key on your local file system, prepended with `file:`.
 
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/README.adoc
@@ -12,7 +12,7 @@ The example application will create the database and tables if they do not alrea
 . https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring
 Boot Starter for Google Cloud Spanner.
 +
-Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
 +
 Then, uncomment the `spring.cloud.gcp.spanner.credentials.location` property in the link:src/main/resources/application.properties[application.properties] file and fill its value with the path to your service account private key on your local file system, prepended with `file:`.
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/README.adoc
@@ -23,7 +23,7 @@ If you would like to use a different user, set the `spring.datasource.username` 
 
 5. https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring Boot Starter for Google Cloud SQL.
 +
-Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
 Then, uncomment the `spring.cloud.gcp.sql.credentials.location` property in the link:src/main/resources/application.properties[application.properties] file and fill its value with the path to your service account private key on your local file system, prepended with `file:`.
 
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/README.adoc
@@ -28,7 +28,7 @@ If you would like to use a different user, set the `spring.datasource.username` 
 
 5. https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring Boot Starter for Google Cloud SQL.
 +
-Alternatively, http://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
 Then, uncomment the `spring.cloud.gcp.sql.credentials.location` property in the link:src/main/resources/application.properties file and fill its value with the path to your service account private key on your local file system, prepended with `file:`.
 
 == Running the application

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/resources/templates/result.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/resources/templates/result.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head>
   <title>Google Cloud Vision Results</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://my.endpoint/push (UnknownHostException) with 1 occurrences migrated to:  
  https://my.endpoint/push ([https](https://my.endpoint/push) result UnknownHostException).
* [ ] http://myapp.host.com/actuator/refresh (UnknownHostException) with 1 occurrences migrated to:  
  https://myapp.host.com/actuator/refresh ([https](https://myapp.host.com/actuator/refresh) result UnknownHostException).
* [ ] http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html (404) with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.google.com/datastore/ with 1 occurrences migrated to:  
  https://cloud.google.com/datastore/ ([https](https://cloud.google.com/datastore/) result 200).
* [ ] http://cloud.google.com/spanner/ with 1 occurrences migrated to:  
  https://cloud.google.com/spanner/ ([https](https://cloud.google.com/spanner/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-static/spring-cloud.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud-static/spring-cloud.html) result 200).
* [ ] http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html with 1 occurrences migrated to:  
  https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html ([https](https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html) result 200).
* [ ] http://projects.spring.io/spring-data/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data/ ([https](https://projects.spring.io/spring-data/) result 200).
* [ ] http://start.spring.io/ with 2 occurrences migrated to:  
  https://start.spring.io/ ([https](https://start.spring.io/) result 200).
* [ ] http://www.thymeleaf.org with 2 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://cloud.google.com/sdk with 1 occurrences migrated to:  
  https://cloud.google.com/sdk ([https](https://cloud.google.com/sdk) result 301).
* [ ] http://cloud.spring.io/spring-cloud-gcp with 4 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-gcp ([https](https://cloud.spring.io/spring-cloud-gcp) result 301).
* [ ] http://console.cloud.google.com/iam-admin/serviceaccounts with 6 occurrences migrated to:  
  https://console.cloud.google.com/iam-admin/serviceaccounts ([https](https://console.cloud.google.com/iam-admin/serviceaccounts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost with 2 occurrences
* http://localhost:%d/ with 1 occurrences
* http://localhost:%s/log with 1 occurrences
* http://localhost:%s/trades/ with 1 occurrences
* http://localhost:8080 with 5 occurrences
* http://localhost:8080/ with 6 occurrences
* http://localhost:8080/actuator/refresh with 1 occurrences
* http://localhost:8080/getTuples with 2 occurrences
* http://localhost:8080/headers with 1 occurrences
* http://localhost:8080/topsecret with 1 occurrences
* http://localhost:8080/trades with 2 occurrences
* http://localhost:8080/trades/ with 2 occurrences
* http://localhost:8082/postMessage with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences