### PR TITLE
ability to provide additional fields to append to json format #1310

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -125,6 +125,8 @@ This setting is only evaluated if `includeFormattedMessage` is `true`
 | `includeContextName` | `true` | Should the logging context be included
 | `includeMessage` | `false` | Should the log message with blank placeholders be included
 | `includeException` | `false` | Should the stacktrace be included as a own field
+| `serviceContext` | none | Define the service context data.
+| `customJson` | none | Defines custom json data. Data will be added to the json output.
 |=======================================================================
 
 This is an example of such an Logback configuration:
@@ -150,6 +152,11 @@ This is an example of such an Logback configuration:
         <!--<includeContextName>true</includeContextName>-->
         <!--<includeMessage>false</includeMessage>-->
         <!--<includeException>false</includeException>-->
+        <!--<serviceContext>
+              <service>service-name</service>
+              <version>service-version</version>
+            </serviceContext>-->
+        <!--<customJson>{"custom-key": "custom-value"}</customJson>-->
       </layout>
     </encoder>
   </appender>

--- a/spring-cloud-gcp-logging/src/main/java/org/springframework/cloud/gcp/logging/StackdriverJsonLayout.java
+++ b/spring-cloud-gcp-logging/src/main/java/org/springframework/cloud/gcp/logging/StackdriverJsonLayout.java
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Andreas Berger
  * @author Chengyuan Zhao
+ * @author Stefan Dieringer
  */
 public class StackdriverJsonLayout extends JsonLayout {
 
@@ -55,6 +56,10 @@ public class StackdriverJsonLayout extends JsonLayout {
 	private boolean includeSpanId;
 
 	private boolean includeExceptionInMessage;
+
+	private StackdriverServiceContext serviceContext;
+
+	private Map<String, Object> customJson;
 
 	/**
 	 * creates a layout for a Logback appender compatible to the Stackdriver log format.
@@ -133,6 +138,24 @@ public class StackdriverJsonLayout extends JsonLayout {
 		this.includeExceptionInMessage = includeExceptionInMessage;
 	}
 
+	/**
+	 * set the service context for stackdriver.
+	 * @param serviceContext the service context
+	 */
+	public void setServiceContext(StackdriverServiceContext serviceContext) {
+		this.serviceContext = serviceContext;
+	}
+
+	/**
+	 * set custom json data to include in log output.
+	 * @param json json string
+	 */
+	public void setCustomJson(String json) {
+		Gson gson = new Gson();
+		this.customJson = gson.fromJson(json, Map.class);
+	}
+
+
 	@Override
 	public void start() {
 		super.start();
@@ -192,6 +215,14 @@ public class StackdriverJsonLayout extends JsonLayout {
 		addTraceId(event, map);
 		add(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, this.includeSpanId,
 				event.getMDCPropertyMap().get(StackdriverTraceConstants.MDC_FIELD_SPAN_ID), map);
+		if (this.serviceContext != null) {
+			map.put(StackdriverTraceConstants.SERVICE_CONTEXT_ATTRIBUTE, this.serviceContext);
+		}
+		if (this.customJson != null && !this.customJson.isEmpty()) {
+			for (Map.Entry<String, Object> entry : this.customJson.entrySet()) {
+				map.putIfAbsent(entry.getKey(), entry.getValue());
+			}
+		}
 		addCustomDataToJsonMap(map, event);
 		return map;
 	}

--- a/spring-cloud-gcp-logging/src/main/java/org/springframework/cloud/gcp/logging/StackdriverServiceContext.java
+++ b/spring-cloud-gcp-logging/src/main/java/org/springframework/cloud/gcp/logging/StackdriverServiceContext.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.logging;
+
+/**
+ * This class provides the service context data for stackdriver error reporting.
+ *
+ * Reference:  https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext
+ *
+ * @author Stefan Dieringer
+ */
+public class StackdriverServiceContext {
+
+	private String service;
+
+	private String version;
+
+	public StackdriverServiceContext() {
+
+	}
+
+	public StackdriverServiceContext(String service, String version) {
+		this.service = service;
+		this.version = version;
+	}
+
+	public String getService() {
+		return this.service;
+	}
+
+	public void setService(String service) {
+		this.service = service;
+	}
+
+	public String getVersion() {
+		return this.version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+}

--- a/spring-cloud-gcp-logging/src/main/java/org/springframework/cloud/gcp/logging/StackdriverTraceConstants.java
+++ b/spring-cloud-gcp-logging/src/main/java/org/springframework/cloud/gcp/logging/StackdriverTraceConstants.java
@@ -67,6 +67,11 @@ public interface StackdriverTraceConstants {
 	String MDC_FIELD_SPAN_EXPORT = "X-Span-Export";
 
 	/**
+	 * The JSON field name for the service context.
+	 */
+	String SERVICE_CONTEXT_ATTRIBUTE = "serviceContext";
+
+	/**
 	 * Composes the full trace name as expected by the Google Developers Console log viewer, to
 	 * enable trace correlation with log entries.
 	 * @param projectId the GCP project ID

--- a/spring-cloud-gcp-logging/src/test/resources/logback-test.xml
+++ b/spring-cloud-gcp-logging/src/test/resources/logback-test.xml
@@ -9,6 +9,27 @@
 		<appender-ref ref="CONSOLE_JSON"/>
 	</logger>
 
+	<appender name="CONSOLE_JSON_SERVICE_CTX" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+			<layout class="org.springframework.cloud.gcp.logging.StackdriverJsonLayout">
+				<projectId>${projectId}</projectId>
+				<serviceContext>
+					<service>service</service>
+					<version>version</version>
+				</serviceContext>
+				<customJson>
+					{
+						"custom-key" : "custom-value"
+					}
+				</customJson>
+			</layout>
+		</encoder>
+	</appender>
+
+	<logger name="StackdriverJsonLayoutServiceCtxLoggerTests" level="WARN">
+		<appender-ref ref="CONSOLE_JSON_SERVICE_CTX"/>
+	</logger>
+
 	<statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
We have the same issue as described in #1310. We need the option to configure serviceContext so we can filter error reports for service-name and version. Additionally it would be helpful to add custom json data to the log if needed.