### PR TITLE
fix typo

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -961,7 +961,7 @@ As a result, beware that the state of the database (and the results) might chang
 The `SpannerRepository` extends the `PagingAndSortingRepository`, but adds the read-only and the read-write transaction functionality provided by Spanner.
 These transactions work very similarly to those of `SpannerOperations`, but is specific to the repository's domain type and provides repository functions instead of template functions.
 
-For example, this is a read-write transaction:
+For example, this is a read-only transaction:
 
 [source,java]
 ----


### PR DESCRIPTION
Or would it be better to change the method to `performReadWriteTransaction`?