### PR TITLE
Add custom license header with https link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
 						<configuration>
 							<!-- TODO: remove when it matches https://github.com/spring-cloud/spring-cloud-build/blob/master/spring-cloud-build-tools/src/main/resources/checkstyle.xml -->
 							<configLocation>src/checkstyle/checkstyle.xml</configLocation>
+							<headerLocation>src/checkstyle/checkstyle-header.txt</headerLocation>
 							<suppressionsLocation>src/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
 							<includeTestSourceDirectory>true</includeTestSourceDirectory>
 							<consoleOutput>true</consoleOutput>

--- a/src/checkstyle/checkstyle-header.txt
+++ b/src/checkstyle/checkstyle-header.txt
@@ -1,0 +1,17 @@
+^\Q/*\E$
+^\Q * Copyright \E20\d\d\-20\d\d\Q the original author or authors.\E$
+^\Q *\E$
+^\Q * Licensed under the Apache License, Version 2.0 (the "License");\E$
+^\Q * you may not use this file except in compliance with the License.\E$
+^\Q * You may obtain a copy of the License at\E$
+^\Q *\E$
+^\Q *      https://www.apache.org/licenses/LICENSE-2.0\E$
+^\Q *\E$
+^\Q * Unless required by applicable law or agreed to in writing, software\E$
+^\Q * distributed under the License is distributed on an "AS IS" BASIS,\E$
+^\Q * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\E$
+^\Q * See the License for the specific language governing permissions and\E$
+^\Q * limitations under the License.\E$
+^\Q */\E$
+^$
+^.*$


### PR DESCRIPTION
The 1.1.x branch is on an oldish minor version of parent `org.springframework.cloud:spring-cloud-build` project -- version `2.1.3`. 
It cannot be upgraded to newer minor versions because that requires removing Guava from 1.1.x -- it was too invasive of a change to backport.
Creating a project copy of a modern license header with "https" will fix the build, which is currently failing because all java files' license headers got updated to "https" in all branches.
