### PR TITLE
Support auto-configuration of the Datastore emulator

### DIFF
--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -71,7 +71,10 @@ The following configuration options are available:
 | `spring.cloud.gcp.datastore.credentials.encoded-key` | Base64-encoded OAuth2 credentials for authenticating with the Google Cloud Datastore API, if different from the ones in the <<spring-cloud-gcp-core,Spring Cloud GCP Core Module>> | No |
 | `spring.cloud.gcp.datastore.credentials.scopes` | https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Cloud GCP Cloud Datastore credentials | No | https://www.googleapis.com/auth/datastore
 | `spring.cloud.gcp.datastore.namespace` | The Cloud Datastore namespace to use | No | the Default namespace of Cloud Datastore in your GCP project
-| `spring.cloud.gcp.datastore.emulator-host` | The `hostname:port` of the https://cloud.google.com/datastore/docs/tools/datastore-emulator[Datastore Emulator] to connect to | No |
+| `spring.cloud.gcp.datastore.host` | The `hostname:port` of the datastore service or emulator to connect to. Can be used to connect to a manually started https://cloud.google.com/datastore/docs/tools/datastore-emulator[Datastore Emulator]. If the autoconfigured emulator is enabled, this property will be ignored and `localhost:<emulator_port>` will be used. | No |
+| `spring.cloud.gcp.datastore.emulator.enabled` | To enable the auto configuration to start a local instance of the Datastore Emulator. | No | `false`
+| `spring.cloud.gcp.datastore.emulator.port` | The local port to use for the Datastore Emulator | No | `8081`
+| `spring.cloud.gcp.datastore.emulator.consistency` | The https://cloud.google.com/sdk/gcloud/reference/beta/emulators/datastore/start?#--consistency[consistency] to use for the Datastore Emulator instance | No | `0.9`
 |===
 
 ==== Repository settings
@@ -88,6 +91,16 @@ Our Spring Boot autoconfiguration creates the following beans available in the S
 - an instance of all user defined repositories extending `CrudRepository`, `PagingAndSortingRepository`, and `DatastoreRepository` (an extension of `PagingAndSortingRepository` with additional Cloud Datastore features) when repositories are enabled
 - an instance of `Datastore` from the Google Cloud Java Client for Datastore, for convenience and lower level API access
 
+==== Datastore Emulator Autoconfiguration
+
+This Spring Boot autoconfiguration can also configure and start a local Datastore Emulator server if enabled by property.
+
+It is useful for integration testing, but not for production.
+
+When enabled, the `spring.cloud.gcp.datastore.host` property will be ignored and the Datastore autoconfiguration itself will be forced to connect to the autoconfigured local emulator instance.
+
+It will create an instance of `LocalDatastoreHelper` as a bean that stores the `DatastoreOptions` to get the `Datastore` client connection to the emulator for convenience and lower level API for local access.
+The emulator will be properly stopped after the Spring application context shutdown.
 
 === Object Mapping
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/EmulatorSettings.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/EmulatorSettings.java
@@ -25,17 +25,17 @@ package org.springframework.cloud.gcp.autoconfigure.datastore;
  */
 public class EmulatorSettings {
 	/**
-	 * Is datastore emulator auto configuration enabled. If enabled the Datastore client
-	 * instance itself will point to the local Datastore instance with the specified
-	 * {@link #port}.
+	 * If enabled the Datastore client will connect to an local datastore emulator.
 	 */
 	private boolean enabled;
 
-	/** Is the datastore emulator port. Default: 8081 */
+	/**
+	 * Is the datastore emulator port. Default: {@code 8081}
+	 */
 	private int port = 8081;
 
 	/**
-	 * Consistency to use creating the Datastore server instance. Default: <code>0.9</code>
+	 * Consistency to use creating the Datastore server instance. Default: {@code 0.9}
 	 */
 	private double consistency = 0.9D;
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/EmulatorSettings.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/EmulatorSettings.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+/**
+ * Properties for configuring Cloud Datastore Emulator.
+ *
+ * @author Lucas Soares
+ *
+ * @since 1.2
+ */
+public class EmulatorSettings {
+	/**
+	 * Is datastore emulator auto configuration enabled. If enabled the Datastore client
+	 * instance itself will point to the local Datastore instance with the specified
+	 * {@link #port}.
+	 */
+	private boolean enabled;
+
+	/** Is the datastore emulator port. Default: 8081 */
+	private int port = 8081;
+
+	/**
+	 * Consistency to use creating the Datastore server instance. Default: <code>0.9</code>
+	 */
+	private double consistency = 0.9D;
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public double getConsistency() {
+		return consistency;
+	}
+
+	public void setConsistency(double consistency) {
+		this.consistency = consistency;
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -23,9 +23,9 @@ import com.google.auth.Credentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -61,6 +61,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass({ DatastoreOperations.class, Datastore.class })
 @EnableConfigurationProperties(GcpDatastoreProperties.class)
 public class GcpDatastoreAutoConfiguration {
+
 	private static final Log LOGGER = LogFactory.getLog(GcpDatastoreEmulatorAutoConfiguration.class);
 
 	private final String projectId;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -24,6 +24,8 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -59,6 +61,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass({ DatastoreOperations.class, Datastore.class })
 @EnableConfigurationProperties(GcpDatastoreProperties.class)
 public class GcpDatastoreAutoConfiguration {
+	private static final Log LOGGER = LogFactory.getLog(GcpDatastoreEmulatorAutoConfiguration.class);
 
 	private final String projectId;
 
@@ -80,6 +83,7 @@ public class GcpDatastoreAutoConfiguration {
 		String hostToConnect = gcpDatastoreProperties.getHost();
 		if (gcpDatastoreProperties.getEmulator().isEnabled()) {
 			hostToConnect = "localhost:" + gcpDatastoreProperties.getEmulator().getPort();
+			LOGGER.info("Connecting to a local datastore emulator.");
 		}
 
 		if (hostToConnect == null) {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -66,7 +66,7 @@ public class GcpDatastoreAutoConfiguration {
 
 	private final Credentials credentials;
 
-	private final String emulatorHost;
+	private final String host;
 
 	GcpDatastoreAutoConfiguration(GcpDatastoreProperties gcpDatastoreProperties,
 			GcpProjectIdProvider projectIdProvider,
@@ -77,7 +77,12 @@ public class GcpDatastoreAutoConfiguration {
 				: projectIdProvider.getProjectId();
 		this.namespace = gcpDatastoreProperties.getNamespace();
 
-		if (gcpDatastoreProperties.getEmulatorHost() == null) {
+		String hostToConnect = gcpDatastoreProperties.getHost();
+		if (gcpDatastoreProperties.getEmulator().isEnabled()) {
+			hostToConnect = "localhost:" + gcpDatastoreProperties.getEmulator().getPort();
+		}
+
+		if (hostToConnect == null) {
 			this.credentials = (gcpDatastoreProperties.getCredentials().hasKey()
 					? new DefaultCredentialsProvider(gcpDatastoreProperties)
 					: credentialsProvider).getCredentials();
@@ -87,7 +92,7 @@ public class GcpDatastoreAutoConfiguration {
 			this.credentials = NoCredentials.getInstance();
 		}
 
-		this.emulatorHost = gcpDatastoreProperties.getEmulatorHost();
+		this.host = hostToConnect;
 	}
 
 	@Bean
@@ -101,8 +106,8 @@ public class GcpDatastoreAutoConfiguration {
 			builder.setNamespace(this.namespace);
 		}
 
-		if (emulatorHost != null) {
-			builder.setHost(emulatorHost);
+		if (this.host != null) {
+			builder.setHost(this.host);
 		}
 
 		return builder.build().getService();

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfiguration.java
@@ -71,11 +71,11 @@ public class GcpDatastoreEmulatorAutoConfiguration implements SmartLifecycle {
 		}
 
 		try {
-			LOGGER.debug("Stopping datastore emulator.");
+			LOGGER.info("Stopping datastore emulator.");
 
 			this.helper.stop();
 
-			LOGGER.debug("Datastore emulator stopped.");
+			LOGGER.info("Datastore emulator stopped.");
 
 			this.running = false;
 		}
@@ -103,11 +103,11 @@ public class GcpDatastoreEmulatorAutoConfiguration implements SmartLifecycle {
 		}
 
 		try {
-			LOGGER.debug("Starting datastore emulator.");
+			LOGGER.info("Starting datastore emulator.");
 
 			this.helper.start();
 
-			LOGGER.debug("Datastore emulator started.");
+			LOGGER.info("Datastore emulator started.");
 
 			this.running = true;
 		}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfiguration.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * If <code>spring.cloud.gcp.datastore.emulator.enabled</code> is set to <code>true</code>
+ * the emulator will be started as a local datastore server using the
+ * {@link com.google.cloud.datastore.testing.LocalDatastoreHelper}.
+ *
+ * @author Lucas Soares
+ *
+ * @since 1.2
+ */
+@Configuration
+@ConditionalOnProperty("spring.cloud.gcp.datastore.emulator.enabled")
+@AutoConfigureBefore(GcpDatastoreAutoConfiguration.class)
+@EnableConfigurationProperties(GcpDatastoreProperties.class)
+@ConditionalOnMissingBean(LocalDatastoreHelper.class)
+public class GcpDatastoreEmulatorAutoConfiguration implements SmartLifecycle {
+
+	private static final Log LOGGER = LogFactory.getLog(GcpDatastoreEmulatorAutoConfiguration.class);
+
+	private LocalDatastoreHelper helper;
+
+	private volatile boolean running;
+
+	@Bean
+	public LocalDatastoreHelper createDatastoreHelper(
+			GcpDatastoreProperties datastoreProperties) {
+		EmulatorSettings settings = datastoreProperties.getEmulator();
+
+		this.helper = LocalDatastoreHelper.create(settings.getConsistency(),
+				settings.getPort());
+
+		return this.helper;
+	}
+
+	/** Stops the instance of the emulator. */
+	@Override
+	public void stop() {
+		if (!isRunning()) {
+			LOGGER.warn("The datastore emulator is not running.");
+
+			return;
+		}
+
+		try {
+			LOGGER.debug("Stopping datastore emulator.");
+
+			this.helper.stop();
+
+			LOGGER.debug("Datastore emulator stopped.");
+
+			this.running = false;
+		}
+		catch (Exception e) {
+			LOGGER.warn("Failed to stop datastore instance.", e);
+		}
+	}
+
+	/**
+	 * Checks if the instance is running. This will be <code>true</code> after a successful
+	 * execution of the method {@link #start()} and <code>false</code> after a successful
+	 * execution of the method {@link #stop()}. method is called.
+	 */
+	@Override
+	public boolean isRunning() {
+		return this.running;
+	}
+
+	/** Starts the instance of the emulator. */
+	@Override
+	public void start() {
+		if (isRunning()) {
+			LOGGER.warn("The datastore emulator is already running.");
+			return;
+		}
+
+		try {
+			LOGGER.debug("Starting datastore emulator.");
+
+			this.helper.start();
+
+			LOGGER.debug("Datastore emulator started.");
+
+			this.running = true;
+		}
+		catch (Exception e) {
+			LOGGER.error("Error constructing datastore instance.");
+		}
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfiguration.java
@@ -29,8 +29,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * If <code>spring.cloud.gcp.datastore.emulator.enabled</code> is set to <code>true</code>
- * the emulator will be started as a local datastore server using the
+ * If spring.cloud.gcp.datastore.emulator.enabled is set to true the emulator will be
+ * started as a local datastore server using the
  * {@link com.google.cloud.datastore.testing.LocalDatastoreHelper}.
  *
  * @author Lucas Soares
@@ -94,7 +94,9 @@ public class GcpDatastoreEmulatorAutoConfiguration implements SmartLifecycle {
 		return this.running;
 	}
 
-	/** Starts the instance of the emulator. */
+	/**
+	 * Starts the instance of the emulator.
+	 */
 	@Override
 	public void start() {
 		if (isRunning()) {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreProperties.java
@@ -37,10 +37,22 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
 	private final Credentials credentials = new Credentials(GcpScope.DATASTORE.getUrl());
 
 	/**
-	 * The host and port of the local running emulator. If provided, this will setup the
-	 * client to connect against a running pub/sub emulator.
+	 * Properties to auto configure a local Datastore Emulator.
 	 */
+	@NestedConfigurationProperty
+	private final EmulatorSettings emulator = new EmulatorSettings();
+
+	/**
+	 * @deprecated use <code>spring.cloud.gcp.datastore.host</code> instead.
+	 * @see #host
+	 */
+	@Deprecated
 	private String emulatorHost;
+
+	/**
+	 * The host and port of a Datastore emulator as the following example: localhost:8081.
+	 */
+	private String host;
 
 	private String projectId;
 
@@ -49,6 +61,10 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
 	@Override
 	public Credentials getCredentials() {
 		return this.credentials;
+	}
+
+	public EmulatorSettings getEmulator() {
+		return this.emulator;
 	}
 
 	public String getProjectId() {
@@ -67,10 +83,28 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
 		this.namespace = namespace;
 	}
 
-	public String getEmulatorHost() {
-		return emulatorHost;
+	public String getHost() {
+		return this.host;
 	}
 
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	/**
+	 * @return the old emulator host parameter
+	 * @deprecated use {@link #getHost()} instead
+	 */
+	@Deprecated
+	public String getEmulatorHost() {
+		return this.emulatorHost;
+	}
+
+	/**
+	 * @param emulatorHost the emulator post
+	 * @deprecated use {@link #setHost(String)} instead
+	 */
+	@Deprecated
 	public void setEmulatorHost(String emulatorHost) {
 		this.emulatorHost = emulatorHost;
 	}

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -13,7 +13,8 @@ org.springframework.cloud.gcp.autoconfigure.trace.StackdriverTraceAutoConfigurat
 org.springframework.cloud.gcp.autoconfigure.datastore.DatastoreRepositoriesAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.spanner.SpannerRepositoriesAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.security.IapAuthenticationAutoConfiguration,\
-org.springframework.cloud.gcp.autoconfigure.vision.CloudVisionAutoConfiguration
+org.springframework.cloud.gcp.autoconfigure.vision.CloudVisionAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.datastore.GcpDatastoreEmulatorAutoConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.gcp.autoconfigure.config.GcpConfigBootstrapConfiguration

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -56,7 +56,7 @@ public class GcpDatastoreAutoConfigurationTests {
 			.withUserConfiguration(TestConfiguration.class)
 			.withPropertyValues("spring.cloud.gcp.datastore.project-id=test-project",
 					"spring.cloud.gcp.datastore.namespace=testNamespace",
-					"spring.cloud.gcp.datastore.emulator-host=localhost:8081",
+					"spring.cloud.gcp.datastore.host=localhost:8081",
 					"management.health.datastore.enabled=false");
 
 	@Test

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfigurationTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore;
+
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import org.junit.Test;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for Datastore Emulator auto-config.
+ *
+ * @author Lucas Soares
+ *
+ * @since 1.2
+ */
+public class GcpDatastoreEmulatorAutoConfigurationTests {
+	@Test
+	public void testDatastoreOptionsCorrectlySet() {
+		new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(
+						GcpDatastoreEmulatorAutoConfiguration.class))
+				.withPropertyValues(
+						"spring.cloud.gcp.datastore.emulator.port=8182",
+						"spring.cloud.gcp.datastore.emulator.enabled=true",
+						"spring.cloud.gcp.datastore.emulator.consistency=0.8")
+				.run((context) -> {
+					LocalDatastoreHelper helper = context.getBean(LocalDatastoreHelper.class);
+					DatastoreOptions datastoreOptions = helper.getOptions();
+					assertThat(datastoreOptions.getHost()).isEqualTo("localhost:8182");
+					assertThat(helper.getConsistency()).isEqualTo(0.8D);
+				});
+	}
+
+	@Test
+	public void testDisabledAutoEmulator() {
+		new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(
+						GcpDatastoreEmulatorAutoConfiguration.class))
+				.run((context) -> assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+						.isThrownBy(() -> context.getBean(LocalDatastoreHelper.class)));
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.datastore.it;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.EntityQuery;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.StructuredQuery;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.cloud.gcp.autoconfigure.datastore.DatastoreRepositoriesAutoConfiguration;
+import org.springframework.cloud.gcp.autoconfigure.datastore.DatastoreTransactionManagerAutoConfiguration;
+import org.springframework.cloud.gcp.autoconfigure.datastore.GcpDatastoreAutoConfiguration;
+import org.springframework.cloud.gcp.autoconfigure.datastore.GcpDatastoreEmulatorAutoConfiguration;
+import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.annotation.Id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for Datastore Emulator integration with the datastore itself.
+ *
+ * @author Lucas Soares
+ *
+ * @since 1.2
+ */
+public class GcpDatastoreEmulatorIntegrationTests {
+	@Test
+	public void testDatastoreEmulatorConfiguration() {
+		DatastoreOptions.Builder builder = DatastoreOptions.newBuilder();
+
+		new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(GcpDatastoreAutoConfiguration.class,
+						GcpContextAutoConfiguration.class,
+						DatastoreTransactionManagerAutoConfiguration.class,
+						DatastoreRepositoriesAutoConfiguration.class,
+						GcpDatastoreEmulatorAutoConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class)
+				.withPropertyValues("spring.cloud.gcp.datastore.project-id=test-project",
+						"spring.cloud.gcp.datastore.namespace=test-namespace",
+						"spring.cloud.gcp.datastore.emulator.port=8181",
+						"spring.cloud.gcp.datastore.emulator.enabled=true",
+						"spring.cloud.gcp.datastore.emulator.consistency=0.9")
+				.run((context) -> {
+					DatastoreTemplate datastore = context.getBean(DatastoreTemplate.class);
+					Datastore datastoreClient = context.getBean(Datastore.class);
+
+					builder.setServiceFactory(datastoreOptions -> datastoreClient);
+
+					EmulatorEntityTest entity = new EmulatorEntityTest();
+					entity.setProperty("property-test");
+
+					datastore.save(entity);
+
+					assertThat(entity.getId()).isNotNull();
+
+					assertThat(datastore.findById(entity.getId(), EmulatorEntityTest.class).getProperty())
+							.isEqualTo("property-test");
+				});
+
+		Datastore datastore = builder.build().getService();
+
+		EntityQuery query = Query.newEntityQueryBuilder().setKind("RandomKind")
+				.setFilter(StructuredQuery.PropertyFilter.eq("key", "value"))
+				.build();
+
+		assertThatExceptionOfType(DatastoreException.class)
+				.isThrownBy(() -> datastore.run(query));
+	}
+
+	/**
+	 * Spring Boot config for tests.
+	 */
+	@AutoConfigurationPackage
+	static class TestConfiguration {
+
+		@Bean
+		public CredentialsProvider credentialsProvider() {
+			return () -> mock(Credentials.class);
+		}
+	}
+
+	/**
+	 * Entity to be stored on Datastore. An instance of `LocalDatastoreHelper` as a bean.
+	 */
+	@org.springframework.cloud.gcp.data.datastore.core.mapping.Entity
+	static class EmulatorEntityTest {
+		@Id
+		private Long id;
+
+		private String property;
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		Long getId() {
+			return this.id;
+		}
+
+		void setProperty(String property) {
+			this.property = property;
+		}
+
+		String getProperty() {
+			return this.property;
+		}
+	}
+}

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<google-cloud-bom.version>0.84.0-alpha</google-cloud-bom.version>
+		<google-cloud-bom.version>0.90.0-alpha</google-cloud-bom.version>
 		<google-auth-library-oauth2-http.version>0.13.0</google-auth-library-oauth2-http.version>
 		<cloud-sql-socket-factory.version>1.0.12</cloud-sql-socket-factory.version>
 	</properties>


### PR DESCRIPTION
fixes #1642

This is my first contribution and I will list some concerns about the code:

- The configuration property `auto-emulator` seems odd.
- The auto configuration are starting and stopping the datastore helper. Probably the exception should be handled properly (instead of logging) or even thrown. I notice there is an error with the datastore shutdown that made the CI to not finish. I'm looking at it.
- The `emulator-host` property already exists users will need to specify port on both properties to configure properly the local datastore instance and client.
- I'm changing the google cloud BOM version to use the feature I developed to be able to manually specify the helper port. I don't think this is right, but I will wait for more instructions.

Suggestions are welcome. Thank you guys.