### PR TITLE
Upgrade to Google Cloud Java library version 0.9.0

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<google-cloud-bom.version>0.84.0-alpha</google-cloud-bom.version>
+		<google-cloud-bom.version>0.90.0-alpha</google-cloud-bom.version>
 		<google-auth-library-oauth2-http.version>0.13.0</google-auth-library-oauth2-http.version>
 		<cloud-sql-socket-factory.version>1.0.12</cloud-sql-socket-factory.version>
 	</properties>


### PR DESCRIPTION
The new version includes the fix for the issue with pending Stackdriver
Logging writes not being flushed on close and causing hanging.

Fixes #1608.