### PR TITLE
PubsubTemplate publish to topics in other projects

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -39,6 +39,7 @@ It provides the common set of operations needed to interact with Google Cloud Pu
 
 `PubSubTemplate` provides asynchronous methods to publish messages to a Google Cloud Pub/Sub topic.
 The `publish()` method takes in a topic name to post the message to, a payload of a generic type and, optionally, a map with the message headers.
+The topic name could either be a canonical topic name within the current project, or the fully-qualified name referring to a topic in a different project using the `projects/<project_name>/topics/<topic_name>` format.
 
 Here is an example of how to publish a message to a Google Cloud Pub/Sub topic:
 
@@ -191,6 +192,8 @@ flux.doOnNext(AcknowledgeablePubsubMessage::ack);
 
 `PubSubAdmin` is the abstraction provided by Spring Cloud GCP to manage Google Cloud Pub/Sub resources.
 It allows for the creation, deletion and listing of topics and subscriptions.
+
+NOTE: Generally when referring to topics, you can either use the short canonical topic name within the current project, or the fully-qualified name referring to a topic in a different project using the `projects/<project_name>/topics/<topic_name>` format.
 
 `PubSubAdmin` depends on `GcpProjectIdProvider` and either a `CredentialsProvider` or a `TopicAdminClient` and a `SubscriptionAdminClient`.
 If given a `CredentialsProvider`, it creates a `TopicAdminClient` and a `SubscriptionAdminClient` with the Google Cloud Java Library for Pub/Sub default settings.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
@@ -104,7 +104,7 @@ public class PubSubAdmin implements AutoCloseable {
 	public Topic createTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		return this.topicAdminClient.createTopic(PubSubTopicUtils.parseTopic(this.projectId, topicName));
+		return this.topicAdminClient.createTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
 	}
 
 	/**
@@ -118,7 +118,7 @@ public class PubSubAdmin implements AutoCloseable {
 		Assert.hasText(topicName, "No topic name was specified.");
 
 		try {
-			return this.topicAdminClient.getTopic(PubSubTopicUtils.parseTopic(this.projectId, topicName));
+			return this.topicAdminClient.getTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
 		}
 		catch (ApiException aex) {
 			if (aex.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
@@ -138,7 +138,7 @@ public class PubSubAdmin implements AutoCloseable {
 	public void deleteTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		this.topicAdminClient.deleteTopic(PubSubTopicUtils.parseTopic(this.projectId, topicName));
+		this.topicAdminClient.deleteTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
 	}
 
 	/**
@@ -224,7 +224,7 @@ public class PubSubAdmin implements AutoCloseable {
 
 		return this.subscriptionAdminClient.createSubscription(
 				ProjectSubscriptionName.of(this.projectId, subscriptionName),
-				PubSubTopicUtils.parseTopic(this.projectId, topicName),
+				PubSubTopicUtils.toProjectTopicName(topicName, this.projectId),
 				pushConfigBuilder.build(),
 				finalAckDeadline);
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
@@ -30,16 +30,17 @@ import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import com.google.pubsub.v1.ProjectName;
 import com.google.pubsub.v1.ProjectSubscriptionName;
-import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
 
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
+import org.springframework.cloud.gcp.pubsub.support.PubSubTopicUtils;
 import org.springframework.util.Assert;
 
 /**
- * Pub/Sub admin utility that creates new topics and subscriptions on Google Cloud Pub/Sub.
+ * Pub/Sub admin utility that creates new topics and subscriptions on Google Cloud
+ * Pub/Sub.
  *
  * @author João André Martins
  * @author Mike Eltsufin
@@ -96,26 +97,28 @@ public class PubSubAdmin implements AutoCloseable {
 	/**
 	 * Create a new topic on Google Cloud Pub/Sub.
 	 *
-	 * @param topicName the name for the new topic
+	 * @param topicName the name for the new topic within the current project, or the
+	 * fully-qualified topic name in the projects/&lt;project_name&gt;/topics/&lt;topic_name&gt; format
 	 * @return the created topic
 	 */
 	public Topic createTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		return this.topicAdminClient.createTopic(ProjectTopicName.of(this.projectId, topicName));
+		return this.topicAdminClient.createTopic(PubSubTopicUtils.parseTopic(this.projectId, topicName));
 	}
 
 	/**
 	 * Get the configuration of a Google Cloud Pub/Sub topic.
 	 *
-	 * @param topicName canonical topic name, e.g., "topicName"
+	 * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic name in the
+	 * "projects/&lt;project_name&gt;/topics/&lt;topic_name&gt;" format
 	 * @return topic configuration or {@code null} if topic doesn't exist
 	 */
 	public Topic getTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
 		try {
-			return this.topicAdminClient.getTopic(ProjectTopicName.of(this.projectId, topicName));
+			return this.topicAdminClient.getTopic(PubSubTopicUtils.parseTopic(this.projectId, topicName));
 		}
 		catch (ApiException aex) {
 			if (aex.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
@@ -129,12 +132,13 @@ public class PubSubAdmin implements AutoCloseable {
 	/**
 	 * Delete a topic from Google Cloud Pub/Sub.
 	 *
-	 * @param topicName the name of the topic to be deleted
+	 * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic
+	 * name in the "projects/&lt;project_name&gt;/topics/&lt;topic_name&gt;" format
 	 */
 	public void deleteTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		this.topicAdminClient.deleteTopic(ProjectTopicName.of(this.projectId, topicName));
+		this.topicAdminClient.deleteTopic(PubSubTopicUtils.parseTopic(this.projectId, topicName));
 	}
 
 	/**
@@ -167,8 +171,8 @@ public class PubSubAdmin implements AutoCloseable {
 	 *
 	 * @param subscriptionName the name of the new subscription
 	 * @param topicName the name of the topic being subscribed to
-	 * @param ackDeadline deadline in seconds before a message is resent, must be between 10 and 600 seconds.
-	 *                    If not provided, set to default of 10 seconds
+	 * @param ackDeadline deadline in seconds before a message is resent, must be between 10
+	 * and 600 seconds. If not provided, set to default of 10 seconds
 	 * @return the created subscription
 	 */
 	public Subscription createSubscription(String subscriptionName, String topicName,
@@ -194,11 +198,12 @@ public class PubSubAdmin implements AutoCloseable {
 	 * Create a new subscription on Google Cloud Pub/Sub.
 	 *
 	 * @param subscriptionName the name of the new subscription
-	 * @param topicName the name of the topic being subscribed to
-	 * @param ackDeadline deadline in seconds before a message is resent, must be between 10 and 600 seconds.
-	 *                    If not provided, set to default of 10 seconds
-	 * @param pushEndpoint the URL of the service receiving the push messages. If not provided, uses
-	 *                     message pulling by default
+	 * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic name in the
+	 * "projects/&lt;project_name&gt;/topics/&lt;topic_name&gt;" format
+	 * @param ackDeadline deadline in seconds before a message is resent, must be between 10
+	 * and 600 seconds. If not provided, set to default of 10 seconds
+	 * @param pushEndpoint the URL of the service receiving the push messages. If not
+	 * provided, uses message pulling by default
 	 * @return the created subscription
 	 */
 	public Subscription createSubscription(String subscriptionName, String topicName,
@@ -219,7 +224,7 @@ public class PubSubAdmin implements AutoCloseable {
 
 		return this.subscriptionAdminClient.createSubscription(
 				ProjectSubscriptionName.of(this.projectId, subscriptionName),
-				ProjectTopicName.of(this.projectId, topicName),
+				PubSubTopicUtils.parseTopic(this.projectId, topicName),
 				pushConfigBuilder.build(),
 				finalAckDeadline);
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -128,7 +128,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 		return this.publishers.computeIfAbsent(topic, (key) -> {
 			try {
 				Publisher.Builder publisherBuilder =
-						Publisher.newBuilder(PubSubTopicUtils.parseTopic(this.projectId, topic));
+						Publisher.newBuilder(PubSubTopicUtils.toProjectTopicName(topic, this.projectId));
 
 				if (this.executorProvider != null) {
 					publisherBuilder.setExecutorProvider(this.executorProvider);

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -65,7 +65,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 	/**
 	 * Create {@link DefaultPublisherFactory} instance based on the provided {@link GcpProjectIdProvider}.
 	 * <p>The {@link GcpProjectIdProvider} must not be null, neither provide an empty {@code projectId}.
-	 * @param projectIdProvider provides the GCP project ID
+	 * @param projectIdProvider provides the default GCP project ID for selecting the topic
 	 */
 	public DefaultPublisherFactory(GcpProjectIdProvider projectIdProvider) {
 		Assert.notNull(projectIdProvider, "The project ID provider can't be null.");
@@ -128,8 +128,15 @@ public class DefaultPublisherFactory implements PublisherFactory {
 	public Publisher createPublisher(String topic) {
 		return this.publishers.computeIfAbsent(topic, (key) -> {
 			try {
+				String finalProject = this.projectId;
+				String finalTopic = topic;
+				if (topic.contains("/")) {
+					int splitIndex = topic.indexOf("/");
+					finalProject = topic.substring(0, splitIndex);
+					finalTopic = topic.substring(splitIndex + 1);
+				}
 				Publisher.Builder publisherBuilder =
-						Publisher.newBuilder(ProjectTopicName.of(this.projectId, key));
+						Publisher.newBuilder(ProjectTopicName.of(finalProject, finalTopic));
 
 				if (this.executorProvider != null) {
 					publisherBuilder.setExecutorProvider(this.executorProvider);

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -27,7 +27,6 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
-import com.google.pubsub.v1.ProjectTopicName;
 
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.cloud.gcp.pubsub.core.PubSubException;
@@ -128,15 +127,8 @@ public class DefaultPublisherFactory implements PublisherFactory {
 	public Publisher createPublisher(String topic) {
 		return this.publishers.computeIfAbsent(topic, (key) -> {
 			try {
-				String finalProject = this.projectId;
-				String finalTopic = topic;
-				if (topic.contains("/")) {
-					int splitIndex = topic.indexOf("/");
-					finalProject = topic.substring(0, splitIndex);
-					finalTopic = topic.substring(splitIndex + 1);
-				}
 				Publisher.Builder publisherBuilder =
-						Publisher.newBuilder(ProjectTopicName.of(finalProject, finalTopic));
+						Publisher.newBuilder(PubSubTopicUtils.parseTopic(this.projectId, topic));
 
 				if (this.executorProvider != null) {
 					publisherBuilder.setExecutorProvider(this.executorProvider);

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtils.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.pubsub.support;
 
 import com.google.pubsub.v1.ProjectTopicName;
 
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -36,11 +37,11 @@ public final class PubSubTopicUtils {
 	 * fully-qualified topic name. If the specified topic is in the
 	 * projects/&lt;project_name&gt;/topics/&lt;topic_name&gt; format, then the {@code projectId} is
 	 * ignored}
-	 * @param projectId the project ID to use if the topic is not a fully-qualified name
 	 * @param topic the topic name in the project or the fully-qualified project name
+	 * @param projectId the project ID to use if the topic is not a fully-qualified name
 	 * @return the Pub/Sub object representing the topic name
 	 */
-	public static ProjectTopicName parseTopic(String projectId, String topic) {
+	public static ProjectTopicName toProjectTopicName(String topic, @Nullable String projectId) {
 		Assert.notNull(topic, "The topic can't be null.");
 
 		ProjectTopicName projectTopicName = null;

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtils.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.pubsub.support;
+
+import com.google.pubsub.v1.ProjectTopicName;
+
+import org.springframework.util.Assert;
+
+/**
+ * Various utility methods for dealing with Pub/Sub topics.
+ *
+ * @author Mike Eltsufin
+ * @since 1.2
+ */
+public final class PubSubTopicUtils {
+
+	private PubSubTopicUtils() {
+	}
+
+	/**
+	 * Creates a {@link ProjectTopicName} based on a topic name within a project or the
+	 * fully-qualified topic name. If the specified topic is in the
+	 * projects/&lt;project_name&gt;/topics/&lt;topic_name&gt; format, then the {@code projectId} is
+	 * ignored}
+	 * @param projectId the project ID to use if the topic is not a fully-qualified name
+	 * @param topic the topic name in the project or the fully-qualified project name
+	 * @return the Pub/Sub object representing the topic name
+	 */
+	public static ProjectTopicName parseTopic(String projectId, String topic) {
+		Assert.notNull(topic, "The topic can't be null.");
+
+		ProjectTopicName projectTopicName = null;
+
+		if (ProjectTopicName.isParsableFrom(topic)) {
+			// Fully-qualified topic name in the "projects/<project_name>/topics/<topic_name>" format
+			projectTopicName = ProjectTopicName.parse(topic);
+		}
+		else {
+			Assert.notNull(projectId, "The project ID can't be null when using canonical topic name.");
+			projectTopicName = ProjectTopicName.of(projectId, topic);
+		}
+
+		return projectTopicName;
+	}
+}

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtilsTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.pubsub.support;
+
+import com.google.pubsub.v1.ProjectTopicName;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PubSubTopicUtils}.
+ *
+ * @author Mike Eltsufin
+ */
+public class PubSubTopicUtilsTests {
+
+	/**
+	 * used to check exception messages and types.
+	 */
+	@Rule
+	public ExpectedException expectedEx = ExpectedException.none();
+
+	@Test
+	public void testParseTopic_canonical() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic(project, topic);
+
+		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
+		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+	}
+
+	@Test
+	public void testParseTopic_no_topic() {
+		expectedEx.expect(IllegalArgumentException.class);
+		expectedEx.expectMessage("The topic can't be null.");
+
+		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic("topicA", null);
+	}
+
+	@Test
+	public void testParseTopic_canonical_no_project() {
+		expectedEx.expect(IllegalArgumentException.class);
+		expectedEx.expectMessage("The project ID can't be null when using canonical topic name.");
+
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic(null, topic);
+
+		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
+		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+	}
+
+	@Test
+	public void testParseTopic_fqn() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic(project, fqn);
+
+		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
+		assertThat(parsedProjectTopicName.toString()).isEqualTo("projects/" + project + "/topics/" + topic);
+	}
+
+	@Test
+	public void testParseTopic_fqn_no_project() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic(null, fqn);
+
+		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
+		assertThat(parsedProjectTopicName.toString()).isEqualTo("projects/" + project + "/topics/" + topic);
+	}
+}

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@
 package org.springframework.cloud.gcp.pubsub.support;
 
 import com.google.pubsub.v1.ProjectTopicName;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link PubSubTopicUtils}.
@@ -30,68 +29,53 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class PubSubTopicUtilsTests {
 
-	/**
-	 * used to check exception messages and types.
-	 */
-	@Rule
-	public ExpectedException expectedEx = ExpectedException.none();
-
 	@Test
-	public void testParseTopic_canonical() {
+	public void testToProjectTopicName_canonical() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;
 
-		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic(project, topic);
+		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(topic, project);
 
 		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
 		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
 	}
 
 	@Test
-	public void testParseTopic_no_topic() {
-		expectedEx.expect(IllegalArgumentException.class);
-		expectedEx.expectMessage("The topic can't be null.");
-
-		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic("topicA", null);
+	public void testToProjectTopicName_no_topic() {
+		assertThatThrownBy(() -> PubSubTopicUtils.toProjectTopicName(null, "topicA"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("The topic can't be null.");
 	}
 
 	@Test
-	public void testParseTopic_canonical_no_project() {
-		expectedEx.expect(IllegalArgumentException.class);
-		expectedEx.expectMessage("The project ID can't be null when using canonical topic name.");
+	public void testToProjectTopicName_canonical_no_project() {
+		assertThatThrownBy(() -> PubSubTopicUtils.toProjectTopicName("topicA", null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("The project ID can't be null when using canonical topic name.");
+	}
 
+	@Test
+	public void testToProjectTopicName_fqn() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;
 
-		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic(null, topic);
+		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(fqn, project);
 
 		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
 		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
 	}
 
 	@Test
-	public void testParseTopic_fqn() {
+	public void testToProjectTopicName_fqn_no_project() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;
 
-		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic(project, fqn);
+		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(fqn, null);
 
 		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName.toString()).isEqualTo("projects/" + project + "/topics/" + topic);
-	}
-
-	@Test
-	public void testParseTopic_fqn_no_project() {
-		String project = "projectA";
-		String topic = "topicA";
-		String fqn = "projects/" + project + "/topics/" + topic;
-
-		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.parseTopic(null, fqn);
-
-		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName.toString()).isEqualTo("projects/" + project + "/topics/" + topic);
+		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
 	}
 }


### PR DESCRIPTION
This change to the DefaultPublisherFactory allows the project id of the
topic to be overwitten directly from the topic specification in the
topic string.

This allows use-cases like
pubSubTemplate.publish("projects/other-project/topics/the-topic", "payload").

This change applied across the board to allow publishing, subscribing, creating, and deleting topics using fully-qualified topic names.

Fixes #1678.