### PR TITLE
Datastore store ID in Key only

### DIFF
--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -1009,8 +1009,8 @@ public interface TraderRepository extends DatastoreRepository<Trader, String> {
   @Query("SELECT * FROM traders WHERE name = @trader_name")
   List<Trader> tradersByName(@Param("trader_name") String traderName);
 
-  @Query("SELECT * FROM  test_entities_ci WHERE id = @id_val")
-  TestEntity getOneTestEntity(@Param("id_val") long id);
+  @Query("SELECT * FROM  test_entities_ci WHERE name = @trader_name")
+  TestEntity getOneTestEntity(@Param("trader_name") String traderName);
 
   @Query("SELECT * FROM traders WHERE name = @trader_name")
   List<Trader> tradersByNameSort(@Param("trader_name") String traderName, Sort sort);
@@ -1067,11 +1067,11 @@ You can also query for non-entity types:
 	@Query(value = "SELECT __key__ from test_entities_ci limit 1")
 	Key getKey();
 
-	@Query("SELECT id FROM test_entities_ci WHERE id <= @id_val")
-	List<String> getIds(@Param("id_val") long id);
+	@Query("SELECT id FROM test_entities_ci WHERE size <= @size")
+	List<String> getIds(@Param("size") long size);
 
-	@Query("SELECT id FROM test_entities_ci WHERE id <= @id_val limit 1")
-	String getOneId(@Param("id_val") long id);
+	@Query("SELECT id FROM test_entities_ci WHERE size <= @size limit 1")
+	String getOneId(@Param("size") long size);
 ----
 
 SpEL can be used to provide GQL parameters:

--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -975,6 +975,8 @@ It enables dynamic query generation based on a user-provided object. See https:/
 . Currently, only equality queries are supported (no ignore-case matching, regexp matching, etc.).
 . Per-field matchers are not supported.
 . Embedded entities matching is not supported.
+. The `@Id` annotated property is ignored in the example, because Cloud Datastore doesn't store the ID as a regular field.
+
 
 For example, if you want to find all users with the last name "Smith", you would use the following code:
 [source, java]

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -117,8 +117,8 @@ public class GcpDatastoreAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public ReadWriteConversions datastoreReadWriteConversions(DatastoreCustomConversions customConversions,
-			ObjectToKeyFactory objectToKeyFactory) {
-		return new TwoStepsConversions(customConversions, objectToKeyFactory);
+			ObjectToKeyFactory objectToKeyFactory, DatastoreMappingContext datastoreMappingContext) {
+		return new TwoStepsConversions(customConversions, objectToKeyFactory, datastoreMappingContext);
 	}
 
 	@Bean

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
@@ -711,9 +711,14 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		matcherAccessor.getPropertySpecifiers();
 		LinkedList<StructuredQuery.Filter> filters = new LinkedList<>();
 		persistentEntity.doWithColumnBackedProperties((persistentProperty) -> {
-			// ID properties are not stored as regular fields in Datastore.
-			if (!persistentProperty.isIdProperty()
-					&& !example.getMatcher().isIgnoredPath(persistentProperty.getName())) {
+
+			if (!example.getMatcher().isIgnoredPath(persistentProperty.getName())) {
+				// ID properties are not stored as regular fields in Datastore.
+				if (persistentProperty.isIdProperty()) {
+					throw new DatastoreDataException("ID properties cannot be used in query-by-example " +
+							"because they are stored in the Key, not a field: " + persistentProperty);
+				}
+
 				String fieldName = persistentProperty.getFieldName();
 				Value<?> value = probeEntity.getValue(fieldName);
 				if (value instanceof NullValue

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
@@ -711,7 +711,9 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		matcherAccessor.getPropertySpecifiers();
 		LinkedList<StructuredQuery.Filter> filters = new LinkedList<>();
 		persistentEntity.doWithColumnBackedProperties((persistentProperty) -> {
-			if (!example.getMatcher().isIgnoredPath(persistentProperty.getName())) {
+			// ID properties are not stored as regular fields in Datastore.
+			if (!persistentProperty.isIdProperty()
+					&& !example.getMatcher().isIgnoredPath(persistentProperty.getName())) {
 				String fieldName = persistentProperty.getFieldName();
 				Value<?> value = probeEntity.getValue(fieldName);
 				if (value instanceof NullValue

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreCustomConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreCustomConversions.java
@@ -20,6 +20,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.cloud.datastore.BaseKey;
+import com.google.cloud.datastore.Key;
+
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.JodaTimeConverters;
 import org.springframework.data.convert.Jsr310Converters;
@@ -36,13 +40,31 @@ public class DatastoreCustomConversions extends CustomConversions {
 
 	private static final StoreConversions STORE_CONVERSIONS;
 
-	private static final List<Object> STORE_CONVERTERS;
+	private static final List<Converter<?, ?>> STORE_CONVERTERS;
 
 	static {
-		ArrayList<Object> converters = new ArrayList<>();
+		ArrayList<Converter<?, ?>> converters = new ArrayList<>();
 		converters.addAll(JodaTimeConverters.getConvertersToRegister());
 		converters.addAll(Jsr310Converters.getConvertersToRegister());
 		converters.addAll(ThreeTenBackPortConverters.getConvertersToRegister());
+		converters.add(new Converter<BaseKey, Long>() {
+			@Override
+			public Long convert(BaseKey key) {
+				if (key instanceof Key) {
+					return ((Key) key).getId();
+				}
+				return 0L;
+			}
+		});
+		converters.add(new Converter<BaseKey, String>() {
+			@Override
+			public String convert(BaseKey key) {
+				if (key instanceof Key) {
+					return ((Key) key).getName();
+				}
+				return null;
+			}
+		});
 		STORE_CONVERTERS = Collections.unmodifiableList(converters);
 
 		STORE_CONVERSIONS =

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreCustomConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreCustomConversions.java
@@ -23,6 +23,7 @@ import java.util.List;
 import com.google.cloud.datastore.BaseKey;
 import com.google.cloud.datastore.Key;
 
+import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreDataException;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.JodaTimeConverters;
@@ -50,19 +51,29 @@ public class DatastoreCustomConversions extends CustomConversions {
 		converters.add(new Converter<BaseKey, Long>() {
 			@Override
 			public Long convert(BaseKey key) {
+				Long id = null;
 				if (key instanceof Key) {
-					return ((Key) key).getId();
+					id = ((Key) key).getId();
+					if (id == null) {
+						throw new DatastoreDataException("The given key doesn't have a numeric ID but a conversion" +
+								" to Long was attempted: " + key);
+					}
 				}
-				return 0L;
+				return id;
 			}
 		});
 		converters.add(new Converter<BaseKey, String>() {
 			@Override
 			public String convert(BaseKey key) {
+				String name = null;
 				if (key instanceof Key) {
-					return ((Key) key).getName();
+					name = ((Key) key).getName();
+					if (name == null) {
+						throw new DatastoreDataException("The given key doesn't have a String name value but " +
+								"a conversion to String was attempted: " + key);
+					}
 				}
-				return null;
+				return name;
 			}
 		});
 		STORE_CONVERTERS = Collections.unmodifiableList(converters);

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreCustomConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/DatastoreCustomConversions.java
@@ -52,6 +52,7 @@ public class DatastoreCustomConversions extends CustomConversions {
 			@Override
 			public Long convert(BaseKey key) {
 				Long id = null;
+				// embedded entities have IncompleteKey, and have no inner value
 				if (key instanceof Key) {
 					id = ((Key) key).getId();
 					if (id == null) {
@@ -66,6 +67,7 @@ public class DatastoreCustomConversions extends CustomConversions {
 			@Override
 			public String convert(BaseKey key) {
 				String name = null;
+				// embedded entities have IncompleteKey, and have no inner value
 				if (key instanceof Key) {
 					name = ((Key) key).getName();
 					if (name == null) {

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/EntityPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/EntityPropertyValueProvider.java
@@ -49,7 +49,11 @@ public class EntityPropertyValueProvider implements PropertyValueProvider<Datast
 
 	@Override
 	public <T> T getPropertyValue(DatastorePersistentProperty persistentProperty) {
-		if (!persistentProperty.isColumnBacked()) {
+		if (persistentProperty.isIdProperty()) {
+			return this.conversion.convertOnRead(this.entity.getKey(), EmbeddedType.NOT_EMBEDDED,
+					persistentProperty.getTypeInformation());
+		}
+		else if (!persistentProperty.isColumnBacked()) {
 			return null;
 		}
 		return getPropertyValue(persistentProperty.getFieldName(),

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/TwoStepsConversions.java
@@ -287,6 +287,9 @@ public class TwoStepsConversions implements ReadWriteConversions {
 	private EntityValue applyEntityValueBuilder(Object val, String kindName,
 			Consumer<Builder> consumer) {
 
+		/* The following does 3 sequential null checks. We only want an ID value if the object isn't null,
+			has an ID property, and the ID property isn't null.
+		* */
 		Optional idProp = Optional.ofNullable(val)
 				.map(v -> this.datastoreMappingContext.getPersistentEntity(v.getClass()))
 				.map(datastorePersistentEntity -> datastorePersistentEntity.getIdProperty())

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/convert/TwoStepsConversions.java
@@ -38,6 +38,7 @@ import com.google.cloud.datastore.ListValue;
 import com.google.cloud.datastore.Value;
 
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreDataException;
+import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastorePersistentProperty;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.EmbeddedType;
 import org.springframework.cloud.gcp.data.datastore.core.util.ValueUtil;
@@ -50,6 +51,8 @@ import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+
+import static org.springframework.cloud.gcp.data.datastore.core.util.ValueUtil.boxIfNeeded;
 
 /**
  * In order to support {@link CustomConversions}, this class applies 2-step conversions.
@@ -86,12 +89,16 @@ public class TwoStepsConversions implements ReadWriteConversions {
 
 	private final ObjectToKeyFactory objectToKeyFactory;
 
+	private final DatastoreMappingContext datastoreMappingContext;
+
 	private DatastoreEntityConverter datastoreEntityConverter;
 
 	private final Map<Class, Optional<Class<?>>> writeConverters = new ConcurrentHashMap<>();
 
-	public TwoStepsConversions(CustomConversions customConversions, ObjectToKeyFactory objectToKeyFactory) {
+	public TwoStepsConversions(CustomConversions customConversions,
+			ObjectToKeyFactory objectToKeyFactory, DatastoreMappingContext datastoreMappingContext) {
 		this.objectToKeyFactory = objectToKeyFactory;
+		this.datastoreMappingContext = datastoreMappingContext;
 		this.conversionService = new DefaultConversionService();
 		this.internalConversionService = new DefaultConversionService();
 		this.customConversions = customConversions;
@@ -191,7 +198,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 		if (val == null) {
 			return null;
 		}
-		Class targetType = targetTypeInformation.getType();
+		Class targetType = boxIfNeeded(targetTypeInformation.getType());
 		Class sourceType = val.getClass();
 		Object result = null;
 		TypeTargets typeTargets = computeTypeTargets(targetType);
@@ -277,9 +284,17 @@ public class TwoStepsConversions implements ReadWriteConversions {
 		return writeConverter.apply(val);
 	}
 
-	private EntityValue applyEntityValueBuilder(String kindName,
+	private EntityValue applyEntityValueBuilder(Object val, String kindName,
 			Consumer<Builder> consumer) {
-		IncompleteKey key = this.objectToKeyFactory.getIncompleteKey(kindName);
+
+		Optional idProp = Optional.ofNullable(val)
+				.map(v -> this.datastoreMappingContext.getPersistentEntity(v.getClass()))
+				.map(datastorePersistentEntity -> datastorePersistentEntity.getIdProperty())
+				.map(id -> this.datastoreMappingContext.getPersistentEntity(val.getClass())
+						.getPropertyAccessor(val).getProperty(id));
+
+		IncompleteKey key = idProp.isPresent() ? this.objectToKeyFactory.getKeyFromId(idProp.get(), kindName)
+				: this.objectToKeyFactory.getIncompleteKey(kindName);
 		FullEntity.Builder<IncompleteKey> builder = FullEntity.newBuilder(key);
 		consumer.accept(builder);
 		return EntityValue.of(builder.build());
@@ -287,7 +302,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 
 	private EntityValue convertOnWriteSingleEmbeddedMap(Object val, String kindName,
 			TypeInformation valueTypeInformation) {
-		return applyEntityValueBuilder(kindName, (builder) -> {
+		return applyEntityValueBuilder(null, kindName, (builder) -> {
 			Map map = (Map) val;
 			for (Object key : map.keySet()) {
 				String field = convertOnReadSingle(key,
@@ -301,7 +316,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 	}
 
 	private EntityValue convertOnWriteSingleEmbedded(Object val, String kindName) {
-		return applyEntityValueBuilder(kindName,
+		return applyEntityValueBuilder(val, kindName,
 				(builder) -> this.datastoreEntityConverter.write(val, builder));
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/util/ValueUtil.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/util/ValueUtil.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.data.datastore.core.util;
 
+import java.lang.reflect.Array;
+
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -37,6 +39,15 @@ public final class ValueUtil {
 			return CollectionUtils.arrayToList(val);
 		}
 		return val;
+	}
+
+	public static Class boxIfNeeded(Class propertyType) {
+		if (propertyType == null) {
+			return null;
+		}
+		return propertyType.isPrimitive()
+				? Array.get(Array.newInstance(propertyType, 1), 0).getClass()
+				: propertyType;
 	}
 
 	public static boolean isCollectionLike(Class type) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplateTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplateTests.java
@@ -258,14 +258,14 @@ public class DatastoreTemplateTests {
 
 		doAnswer((invocation) -> {
 			FullEntity.Builder builder = invocation.getArgument(1);
-			builder.set("id", "simple_test_entity");
+			builder.set("color", "simple_test_color");
 			builder.set("int_field", 1);
 			return null;
 		}).when(this.datastoreEntityConverter).write(same(this.simpleTestEntity), any());
 
 		doAnswer((invocation) -> {
 			FullEntity.Builder builder = invocation.getArgument(1);
-			builder.set("id", NullValue.of());
+			builder.set("color", NullValue.of());
 			builder.set("int_field", NullValue.of());
 			return null;
 		}).when(this.datastoreEntityConverter).write(same(this.simpleTestEntityNullVallues), any());
@@ -865,7 +865,7 @@ public class DatastoreTemplateTests {
 	public void queryByExampleSimpleEntityTest() {
 		EntityQuery.Builder builder = Query.newEntityQueryBuilder().setKind("test_kind");
 		StructuredQuery.CompositeFilter filter = StructuredQuery.CompositeFilter
-				.and(PropertyFilter.eq("id", "simple_test_entity"),
+				.and(PropertyFilter.eq("color", "simple_test_color"),
 						PropertyFilter.eq("int_field", 1));
 		EntityQuery query = builder.setFilter(filter).build();
 		verifyBeforeAndAfterEvents(null, new AfterQueryEvent(Collections.emptyList(), query),
@@ -880,7 +880,7 @@ public class DatastoreTemplateTests {
 				Example.of(this.simpleTestEntity, ExampleMatcher.matching().withIgnorePaths("intField")), null);
 
 		StructuredQuery.CompositeFilter filter = StructuredQuery.CompositeFilter
-				.and(PropertyFilter.eq("id", "simple_test_entity"));
+				.and(PropertyFilter.eq("color", "simple_test_color"));
 		verify(this.datastore, times(1)).run(builder.setFilter(filter).build());
 	}
 
@@ -900,7 +900,7 @@ public class DatastoreTemplateTests {
 				Example.of(this.simpleTestEntityNullVallues, ExampleMatcher.matching().withIncludeNullValues()), null);
 
 		StructuredQuery.CompositeFilter filter = StructuredQuery.CompositeFilter
-				.and(PropertyFilter.eq("id", NullValue.of()),
+				.and(PropertyFilter.eq("color", NullValue.of()),
 						PropertyFilter.eq("int_field", NullValue.of()));
 		verify(this.datastore, times(1)).run(builder.setFilter(filter).build());
 	}
@@ -981,7 +981,7 @@ public class DatastoreTemplateTests {
 						.build());
 
 		StructuredQuery.CompositeFilter filter = StructuredQuery.CompositeFilter
-				.and(PropertyFilter.eq("id", "simple_test_entity"),
+				.and(PropertyFilter.eq("color", "simple_test_color"),
 						PropertyFilter.eq("int_field", 1));
 		verify(this.datastore, times(1)).run(builder.setFilter(filter)
 				.addOrderBy(StructuredQuery.OrderBy.asc("int_field")).setLimit(10).setOffset(1).build());
@@ -1081,6 +1081,8 @@ public class DatastoreTemplateTests {
 	private static class SimpleTestEntity {
 		@Id
 		String id;
+
+		String color;
 
 		@Field(name = "int_field")
 		int intField;

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -49,6 +49,7 @@ import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreDataEx
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DiscriminatorField;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DiscriminatorValue;
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
 import org.springframework.lang.Nullable;
@@ -721,18 +722,18 @@ public class DefaultDatastoreEntityConverterTests {
 
 	@Test
 	public void testMismatchedStringIdLongProperty() {
-		this.thrown.expect(DatastoreDataException.class);
+		this.thrown.expect(ConversionFailedException.class);
 		this.thrown.expectMessage(
-				"The given key doesn't have a numeric ID but a conversion to Long was attempted:");
+				"The given key doesn't have a numeric ID but a conversion to Long was attempted");
 		ENTITY_CONVERTER.read(LongIdEntity.class,
 				Entity.newBuilder(this.datastore.newKeyFactory().setKind("aKind").newKey("a")).build());
 	}
 
 	@Test
 	public void testMismatchedLongIdStringProperty() {
-		this.thrown.expect(DatastoreDataException.class);
+		this.thrown.expect(ConversionFailedException.class);
 		this.thrown.expectMessage(
-				"The given key doesn't have a String name value but a conversion to String was attempted:");
+				"The given key doesn't have a String name value but a conversion to String was attempted");
 		ENTITY_CONVERTER.read(StringIdEntity.class,
 				Entity.newBuilder(this.datastore.newKeyFactory().setKind("aKind").newKey(1)).build());
 	}

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -66,6 +66,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DefaultDatastoreEntityConverterTests {
 	private static final LocalDatastoreHelper HELPER = LocalDatastoreHelper.create(1.0);
 
+	private static final DatastoreMappingContext datastoreMappingContext = new DatastoreMappingContext();
+
 	private static final DatastoreEntityConverter ENTITY_CONVERTER =
 			new DefaultDatastoreEntityConverter(new DatastoreMappingContext(),
 					new TwoStepsConversions(new DatastoreCustomConversions(
@@ -75,7 +77,7 @@ public class DefaultDatastoreEntityConverterTests {
 								public String convert(HashMap source) {
 									return "Map was converted to String";
 								}
-							})), null));
+							})), null, datastoreMappingContext));
 
 	/**
 	 * Used to check exception messages and types.
@@ -356,7 +358,7 @@ public class DefaultDatastoreEntityConverterTests {
 				Arrays.asList(
 						getIntegerToNewTypeConverter(),
 						getNewTypeToIntegerConverter()
-				)), null));
+						)), null, datastoreMappingContext));
 		Entity.Builder builder = getEntityBuilder();
 		entityConverter.write(item, builder);
 		Entity entity = builder.build();
@@ -435,7 +437,8 @@ public class DefaultDatastoreEntityConverterTests {
 												bcs.iterator().forEachRemaining((s) -> list.add((String) s));
 												return list;
 											}
-										})), null));
+										})),
+								null, datastoreMappingContext));
 
 		Entity.Builder builder = getEntityBuilder();
 		entityConverter.write(item, builder);
@@ -521,7 +524,7 @@ public class DefaultDatastoreEntityConverterTests {
 		DatastoreEntityConverter entityConverter =
 				new DefaultDatastoreEntityConverter(new DatastoreMappingContext(),
 						new TwoStepsConversions(new DatastoreCustomConversions(Collections.singletonList(
-								getNewTypeToIntegerConverter())), null));
+								getNewTypeToIntegerConverter())), null, datastoreMappingContext));
 
 		Entity.Builder builder = getEntityBuilder();
 		entityConverter.write(item, builder);
@@ -551,7 +554,7 @@ public class DefaultDatastoreEntityConverterTests {
 				new DefaultDatastoreEntityConverter(new DatastoreMappingContext(),
 						new TwoStepsConversions(new DatastoreCustomConversions(Collections.singletonList(
 								getNewTypeToIntegerConverter()
-						)), null));
+						)), null, datastoreMappingContext));
 
 		Entity.Builder builder = getEntityBuilder();
 		entityConverter.write(item, builder);
@@ -569,7 +572,7 @@ public class DefaultDatastoreEntityConverterTests {
 						new TwoStepsConversions(new DatastoreCustomConversions(Arrays.asList(
 								getIntegerToNewTypeConverter(),
 								getNewTypeToIntegerConverter()
-						)), null));
+						)), null, datastoreMappingContext));
 
 		Entity.Builder builder = getEntityBuilder();
 		entityConverter.write(item, builder);

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -50,6 +50,7 @@ import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappin
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DiscriminatorField;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DiscriminatorValue;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.annotation.Id;
 import org.springframework.lang.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -718,6 +719,24 @@ public class DefaultDatastoreEntityConverterTests {
 		assertThat(read).as("read objects equals the original one").isEqualTo(item);
 	}
 
+	@Test
+	public void testMismatchedStringIdLongProperty() {
+		this.thrown.expect(DatastoreDataException.class);
+		this.thrown.expectMessage(
+				"The given key doesn't have a numeric ID but a conversion to Long was attempted:");
+		ENTITY_CONVERTER.read(LongIdEntity.class,
+				Entity.newBuilder(this.datastore.newKeyFactory().setKind("aKind").newKey("a")).build());
+	}
+
+	@Test
+	public void testMismatchedLongIdStringProperty() {
+		this.thrown.expect(DatastoreDataException.class);
+		this.thrown.expectMessage(
+				"The given key doesn't have a String name value but a conversion to String was attempted:");
+		ENTITY_CONVERTER.read(StringIdEntity.class,
+				Entity.newBuilder(this.datastore.newKeyFactory().setKind("aKind").newKey(1)).build());
+	}
+
 	private Entity.Builder getEntityBuilder() {
 		return Entity.newBuilder(this.datastore.newKeyFactory().setKind("aKind").newKey("1"));
 	}
@@ -738,6 +757,18 @@ public class DefaultDatastoreEntityConverterTests {
 				return new TestItemUnsupportedFields.NewType(source == 1);
 			}
 		};
+	}
+
+	@org.springframework.cloud.gcp.data.datastore.core.mapping.Entity
+	private static class StringIdEntity {
+		@Id
+		String id;
+	}
+
+	@org.springframework.cloud.gcp.data.datastore.core.mapping.Entity
+	private static class LongIdEntity {
+		@Id
+		long id;
 	}
 
 	@org.springframework.cloud.gcp.data.datastore.core.mapping.Entity

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/EntityPropertyValueProviderTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/EntityPropertyValueProviderTests.java
@@ -43,9 +43,12 @@ public class EntityPropertyValueProviderTests {
 
 	private static final LocalDatastoreHelper HELPER = LocalDatastoreHelper.create(1.0);
 
+	private final DatastoreMappingContext datastoreMappingContext = new DatastoreMappingContext();
+
 	private Datastore datastore;
 
-	private TwoStepsConversions twoStepsConversion = new TwoStepsConversions(new DatastoreCustomConversions(), null);
+	private TwoStepsConversions twoStepsConversion = new TwoStepsConversions(new DatastoreCustomConversions(), null,
+			this.datastoreMappingContext);
 
 	/**
 	 * used to check exception messages and types.
@@ -55,7 +58,7 @@ public class EntityPropertyValueProviderTests {
 
 	private DatastorePersistentEntity<TestDatastoreItem> persistentEntity =
 			(DatastorePersistentEntity<TestDatastoreItem>)
-					new DatastoreMappingContext().getPersistentEntity(TestDatastoreItem.class);
+			this.datastoreMappingContext.getPersistentEntity(TestDatastoreItem.class);
 
 	@Before
 	public void setUp() {

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/TwoStepsConversionsTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/TwoStepsConversionsTests.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreDataException;
+import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
 import org.springframework.core.convert.converter.Converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,8 +41,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 public class TwoStepsConversionsTests {
 
+	private final DatastoreMappingContext datastoreMappingContext = new DatastoreMappingContext();
+
 	private final TwoStepsConversions twoStepsConversions = new TwoStepsConversions(
-			new DatastoreCustomConversions(Arrays.asList()), null);
+			new DatastoreCustomConversions(Arrays.asList()), null, this.datastoreMappingContext);
 
 	@Test
 	public void convertOnReadReturnsNullWhenConvertingNullSimpleValue() {
@@ -93,7 +96,7 @@ public class TwoStepsConversionsTests {
 		};
 
 		TwoStepsConversions twoStepsConversionsThatSpeaksEnglish = new TwoStepsConversions(
-				new DatastoreCustomConversions(Arrays.asList(converter)), null);
+				new DatastoreCustomConversions(Arrays.asList(converter)), null, this.datastoreMappingContext);
 		String result = twoStepsConversionsThatSpeaksEnglish.<String>convertOnRead(3L, null, String.class);
 		assertThat(result).isEqualTo("three");
 	}

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -98,7 +98,7 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 
 	private final TestEntity testEntityA = new TestEntity(1L, "red", 1L, Shape.CIRCLE, null);
 
-	private final TestEntity testEntityB = new TestEntity(2L, "blue", 1L, Shape.CIRCLE, null);
+	private final TestEntity testEntityB = new TestEntity(2L, "blue", 2L, Shape.CIRCLE, null);
 
 	private final TestEntity testEntityC = new TestEntity(3L, "red", 1L, Shape.CIRCLE, null);
 
@@ -140,7 +140,7 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		this.testEntityRepository.saveAll(this.allTestEntities);
 
 		this.millisWaited = waitUntilTrue(
-				() -> this.testEntityRepository.countBySize(1L) == 4);
+				() -> this.testEntityRepository.countBySize(1L) == 3);
 
 	}
 
@@ -153,13 +153,13 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		Page<TestEntity> result1 = this.testEntityRepository
 				.findAll(
 						Example.of(new TestEntity(null, null, null, null, null)),
-						PageRequest.of(0, 2, Sort.by("id")));
+						PageRequest.of(0, 2, Sort.by("size")));
 		assertThat(result1.getTotalElements()).isEqualTo(4);
 		assertThat(result1.getNumber()).isEqualTo(0);
 		assertThat(result1.getNumberOfElements()).isEqualTo(2);
 		assertThat(result1.getTotalPages()).isEqualTo(2);
 		assertThat(result1.hasNext()).isEqualTo(true);
-		assertThat(result1).containsExactly(this.testEntityA, this.testEntityB);
+		assertThat(result1).containsExactly(this.testEntityA, this.testEntityC);
 
 		Page<TestEntity> result2 = this.testEntityRepository
 				.findAll(
@@ -170,13 +170,13 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(result2.getNumberOfElements()).isEqualTo(2);
 		assertThat(result2.getTotalPages()).isEqualTo(2);
 		assertThat(result2.hasNext()).isEqualTo(false);
-		assertThat(result2).containsExactly(this.testEntityC, this.testEntityD);
+		assertThat(result2).containsExactly(this.testEntityD, this.testEntityB);
 
 
 		assertThat(this.testEntityRepository
 				.findAll(
 						Example.of(new TestEntity(null, null, null, null, null)),
-						Sort.by(Sort.Direction.ASC, "id")))
+						Sort.by(Sort.Direction.ASC, "size")))
 				.containsExactly(this.testEntityA, this.testEntityB, this.testEntityC, this.testEntityD);
 
 		assertThat(this.testEntityRepository
@@ -328,12 +328,12 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(this.testEntityRepository.findByEnumQueryParam(Shape.SQUARE).stream()
 				.map(TestEntity::getId).collect(Collectors.toList())).contains(4L);
 
-		assertThat(this.testEntityRepository.deleteBySize(1L)).isEqualTo(4);
+		assertThat(this.testEntityRepository.deleteBySize(1L)).isEqualTo(3);
 
 		this.testEntityRepository.saveAll(this.allTestEntities);
 
 		this.millisWaited = Math.max(this.millisWaited,
-				waitUntilTrue(() -> this.testEntityRepository.countBySize(1L) == 4));
+				waitUntilTrue(() -> this.testEntityRepository.countBySize(1L) == 3));
 
 		assertThat(
 				this.testEntityRepository.removeByColor("red").stream()
@@ -358,8 +358,8 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		TestEntity[] foundByCustomProjectionQuery = this.testEntityRepository
 				.findEntitiesWithCustomProjectionQuery(1L);
 
-		assertThat(this.testEntityRepository.countBySizeAndColor(1, "blue")).isEqualTo(1);
-		assertThat(this.testEntityRepository.getById(2L).getColor()).isEqualTo("blue");
+		assertThat(this.testEntityRepository.countBySizeAndColor(2, "blue")).isEqualTo(1);
+		assertThat(this.testEntityRepository.getBySize(2L).getColor()).isEqualTo("blue");
 		assertThat(this.testEntityRepository.countBySizeAndColor(1, "red")).isEqualTo(3);
 		assertThat(
 				this.testEntityRepository.findTop3BySizeAndColor(1, "red").stream()
@@ -369,22 +369,22 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(this.testEntityRepository.getKeys().stream().map(Key::getId).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder(1L, 2L, 3L, 4L);
 
-		assertThat(foundByCustomQuery.size()).isEqualTo(1);
-		assertThat(this.testEntityRepository.countEntitiesWithCustomQuery(1L)).isEqualTo(4);
+		assertThat(foundByCustomQuery.size()).isEqualTo(3);
+		assertThat(this.testEntityRepository.countEntitiesWithCustomQuery(1L)).isEqualTo(3);
 		assertThat(this.testEntityRepository.existsByEntitiesWithCustomQuery(1L)).isTrue();
 		assertThat(this.testEntityRepository.existsByEntitiesWithCustomQuery(100L)).isFalse();
 		assertThat(foundByCustomQuery.get(0).getBlobField()).isEqualTo(Blob.copyFrom("testValueA".getBytes()));
 
-		assertThat(foundByCustomProjectionQuery.length).isEqualTo(1);
+		assertThat(foundByCustomProjectionQuery.length).isEqualTo(3);
 		assertThat(foundByCustomProjectionQuery[0].getBlobField()).isNull();
 		assertThat(foundByCustomProjectionQuery[0].getId()).isEqualTo((Long) 1L);
 
 		this.testEntityA.setBlobField(null);
 
 		assertThat(this.testEntityRepository.getKey().getId()).isEqualTo((Long) 1L);
-		assertThat(this.testEntityRepository.getIds(1L).length).isEqualTo(1);
-		assertThat(this.testEntityRepository.getOneId(1L)).isEqualTo(1);
-		assertThat(this.testEntityRepository.getOneTestEntity(1L)).isNotNull();
+		assertThat(this.testEntityRepository.getSizes(1L).length).isEqualTo(3);
+		assertThat(this.testEntityRepository.getOneSize(2L)).isEqualTo(2);
+		assertThat(this.testEntityRepository.getOneTestEntity(2L)).isNotNull();
 
 		this.testEntityRepository.save(this.testEntityA);
 
@@ -403,7 +403,7 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 				this.millisWaited * WAIT_FOR_EVENTUAL_CONSISTENCY_SAFETY_MULTIPLE);
 
 		this.millisWaited = Math.max(this.millisWaited,
-				waitUntilTrue(() -> this.testEntityRepository.countBySize(1L) == 4));
+				waitUntilTrue(() -> this.testEntityRepository.countBySize(1L) == 3));
 
 		this.testEntityRepository.deleteAll();
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -147,12 +147,14 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 	@Test
 	public void testFindByExample() {
 		assertThat(this.testEntityRepository
-				.findAll(Example.of(new TestEntity(null, "red", null, Shape.CIRCLE, null))))
+				.findAll(Example.of(new TestEntity(null, "red", null, Shape.CIRCLE, null),
+						ExampleMatcher.matching().withIgnorePaths("id"))))
 				.containsExactlyInAnyOrder(this.testEntityA, this.testEntityC);
 
 		Page<TestEntity> result1 = this.testEntityRepository
 				.findAll(
-						Example.of(new TestEntity(null, null, null, null, null)),
+						Example.of(new TestEntity(null, null, null, null, null),
+								ExampleMatcher.matching().withIgnorePaths("id")),
 						PageRequest.of(0, 2, Sort.by("size")));
 		assertThat(result1.getTotalElements()).isEqualTo(4);
 		assertThat(result1.getNumber()).isEqualTo(0);
@@ -163,7 +165,8 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 
 		Page<TestEntity> result2 = this.testEntityRepository
 				.findAll(
-						Example.of(new TestEntity(null, null, null, null, null)),
+						Example.of(new TestEntity(null, null, null, null, null),
+								ExampleMatcher.matching().withIgnorePaths("id")),
 						result1.getPageable().next());
 		assertThat(result2.getTotalElements()).isEqualTo(4);
 		assertThat(result2.getNumber()).isEqualTo(1);
@@ -175,7 +178,8 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 
 		assertThat(this.testEntityRepository
 				.findAll(
-						Example.of(new TestEntity(null, null, null, null, null)),
+						Example.of(new TestEntity(null, null, null, null, null),
+								ExampleMatcher.matching().withIgnorePaths("id")),
 						Sort.by(Sort.Direction.ASC, "size")))
 				.containsExactly(this.testEntityA, this.testEntityB, this.testEntityC, this.testEntityD);
 
@@ -191,11 +195,12 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 
 		assertThat(this.testEntityRepository
 				.exists(Example.of(new TestEntity(null, "red", null, null, null),
-						ExampleMatcher.matching().withIncludeNullValues())))
+						ExampleMatcher.matching().withIgnorePaths("id").withIncludeNullValues())))
 				.isEqualTo(false);
 
 		assertThat(this.testEntityRepository
-				.exists(Example.of(new TestEntity(null, "red", null, null, null))))
+				.exists(Example.of(new TestEntity(null, "red", null, null, null),
+						ExampleMatcher.matching().withIgnorePaths("id"))))
 				.isEqualTo(true);
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/ParallelDatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/ParallelDatastoreIntegrationTests.java
@@ -66,7 +66,7 @@ public class ParallelDatastoreIntegrationTests extends AbstractDatastoreIntegrat
 
 		waitUntilTrue(() -> this.testEntityRepository.count() == PARALLEL_OPERATIONS - 1);
 
-		performOperation(x -> assertThat(this.testEntityRepository.getIds(x).length).isEqualTo(x));
+		performOperation(x -> assertThat(this.testEntityRepository.getSizes(x).length).isEqualTo(x));
 
 		performOperation(x -> this.testEntityRepository.deleteBySize((long) x));
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TestEntityRepository.java
@@ -41,8 +41,8 @@ import org.springframework.lang.Nullable;
  */
 public interface TestEntityRepository extends DatastoreRepository<TestEntity, Long> {
 
-	@Query("select * from  test_entities_ci where id = @id_val")
-	LinkedList<TestEntity> findEntitiesWithCustomQuery(@Param("id_val") long id);
+	@Query("select * from  test_entities_ci where size = @size ")
+	LinkedList<TestEntity> findEntitiesWithCustomQuery(@Param("size") long size);
 
 	@Query("select * from  test_entities_ci where color = @color")
 	Slice<TestEntity> findEntitiesWithCustomQuerySlice(@Param("color") String color, Pageable pageable);
@@ -68,11 +68,11 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 	List<TestEntity> findByEnumQueryParam(@Param("enum_val") Shape shape);
 
 	@Query(value = "select __key__ from |org.springframework.cloud.gcp.data.datastore.it.TestEntity| "
-			+ "where id = :#{#id_val}", exists = true)
-	boolean existsByEntitiesWithCustomQuery(@Param("id_val") long id);
+			+ "where size = :#{#size}", exists = true)
+	boolean existsByEntitiesWithCustomQuery(@Param("size") long size);
 
-	@Query("select id from  test_entities_ci where id <= @id_val ")
-	TestEntity[] findEntitiesWithCustomProjectionQuery(@Param("id_val") long id);
+	@Query("select size from  test_entities_ci where size <= @size ")
+	TestEntity[] findEntitiesWithCustomProjectionQuery(@Param("size") long size);
 
 	@Query("select __key__ from test_entities_ci")
 	Set<Key> getKeys();
@@ -84,22 +84,22 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 	Key getKey();
 
 	// Also involves conversion from long id to String
-	@Query("select id from  test_entities_ci where id <= @id_val ")
-	Long[] getIds(@Param("id_val") long id);
+	@Query("select size from  test_entities_ci where size <= @size ")
+	long[] getSizes(@Param("size") long size);
 
 	// Also involves conversion from long id to String
-	@Query("select id from  test_entities_ci where id <= @id_val")
-	long getOneId(@Param("id_val") long id);
+	@Query("select size from  test_entities_ci where size <= @size and size >= @size")
+	long getOneSize(@Param("size") long size);
 
-	@Query("select * from  test_entities_ci where id = @id_val")
-	TestEntity getOneTestEntity(@Param("id_val") long id);
+	@Query("select * from  test_entities_ci where size= @size")
+	TestEntity getOneTestEntity(@Param("size") long size);
 
 	long countBySizeAndColor(long size, String color);
 
 	LinkedList<TestEntity> findTop3BySizeAndColor(long size, String color);
 
-	@Query("select * from  test_entities_ci where id = @id")
-	TestEntityProjection getById(@Param("id") long id);
+	@Query("select * from  test_entities_ci where size = @size")
+	TestEntityProjection getBySize(@Param("size") long size);
 
 	Page<TestEntity> findByShape(Shape shape, Pageable pageable);
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -75,6 +75,8 @@ public class GqlDatastoreQueryTests {
 	/** Constant for which if two doubles are within DELTA, they are considered equal. */
 	private static final Offset<Double> DELTA = Offset.offset(0.00001);
 
+	private final DatastoreMappingContext datastoreMappingContext = new DatastoreMappingContext();
+
 	private DatastoreTemplate datastoreTemplate;
 
 	private DatastoreEntityConverter datastoreEntityConverter;
@@ -90,7 +92,8 @@ public class GqlDatastoreQueryTests {
 		this.queryMethod = mock(DatastoreQueryMethod.class);
 		this.datastoreTemplate = mock(DatastoreTemplate.class);
 		this.datastoreEntityConverter = mock(DatastoreEntityConverter.class);
-		this.readWriteConversions = new TwoStepsConversions(new DatastoreCustomConversions(), null);
+		this.readWriteConversions = new TwoStepsConversions(new DatastoreCustomConversions(), null,
+				this.datastoreMappingContext);
 		when(this.datastoreTemplate.getDatastoreEntityConverter()).thenReturn(this.datastoreEntityConverter);
 		when(this.datastoreEntityConverter.getConversions()).thenReturn(this.readWriteConversions);
 		this.evaluationContextProvider = mock(QueryMethodEvaluationContextProvider.class);
@@ -98,7 +101,7 @@ public class GqlDatastoreQueryTests {
 
 	private GqlDatastoreQuery<Trade> createQuery(String gql, boolean isPageQuery, boolean isSliceQuery) {
 		GqlDatastoreQuery<Trade> spy = spy(new GqlDatastoreQuery<>(Trade.class, this.queryMethod,
-				this.datastoreTemplate, gql, this.evaluationContextProvider, new DatastoreMappingContext()));
+				this.datastoreTemplate, gql, this.evaluationContextProvider, this.datastoreMappingContext));
 		doReturn(isPageQuery).when(spy).isPageQuery();
 		doReturn(isSliceQuery).when(spy).isSliceQuery();
 		return spy;

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -109,7 +109,8 @@ public class PartTreeDatastoreQueryTests {
 		this.datastoreTemplate = mock(DatastoreTemplate.class);
 		this.datastoreMappingContext = new DatastoreMappingContext();
 		this.datastoreEntityConverter = mock(DatastoreEntityConverter.class);
-		this.readWriteConversions = new TwoStepsConversions(new DatastoreCustomConversions(), null);
+		this.readWriteConversions = new TwoStepsConversions(new DatastoreCustomConversions(), null,
+				datastoreMappingContext);
 		when(this.datastoreTemplate.getDatastoreEntityConverter())
 				.thenReturn(this.datastoreEntityConverter);
 		when(this.datastoreEntityConverter.getConversions())

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/test/java/com/example/DatastoreBookshelfExampleTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/test/java/com/example/DatastoreBookshelfExampleTests.java
@@ -48,6 +48,9 @@ public class DatastoreBookshelfExampleTests {
 	@Autowired
 	private DatastoreTemplate datastoreTemplate;
 
+	@Autowired
+	private BookRepository bookRepository;
+
 	@After
 	public void cleanUp() {
 		this.datastoreTemplate.deleteAll(Book.class);


### PR DESCRIPTION
Fixes #1677 
Fixes #1683 

Stores the ID value in the key of the entity only. does not have a separate column for the ID. 