### PR TITLE
Fix `project-id` configuration property

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
@@ -64,7 +64,7 @@ public class GcpDatastoreEmulatorIntegrationTests {
 						DatastoreRepositoriesAutoConfiguration.class,
 						GcpDatastoreEmulatorAutoConfiguration.class))
 				.withUserConfiguration(TestConfiguration.class)
-				.withPropertyValues("spring.cloud.gcp.datastore.project-id=test-project",
+				.withPropertyValues("spring.cloud.gcp.project-id=test-project",
 						"spring.cloud.gcp.datastore.namespace=test-namespace",
 						"spring.cloud.gcp.datastore.emulator.port=8181",
 						"spring.cloud.gcp.datastore.emulator.enabled=true",


### PR DESCRIPTION
The `project-id` must be with the `spring.cloud.gcp.` prefix, but not
`spring.cloud.gcp.datastore.`.
Otherwise we end up with the auto-configured `DefaultGcpProjectIdProvider`
which falls back to the credential JSON file