### PR TITLE
Upgrade dependencies to align with latest S-Cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<spring-cloud-commons.version>2.2.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-sleuth.version>2.2.0.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
-		<spring-cloud-stream.version>Germantown.BUILD-SNAPSHOT</spring-cloud-stream.version>
+		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.9.0</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
@@ -125,7 +125,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>3.1.2</version>
+			<version>3.1.6</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This should fix constantly failing CI plans, like this:

https://jenkins.spring.io/blue/organizations/jenkins/spring-cloud-gcp-master-ci/detail/spring-cloud-gcp-master-ci/1830/pipeline/