### PR TITLE
Remove Spring Profile activeByDefault

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,9 +225,6 @@
 	<profiles>
 		<profile>
 			<id>spring</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
 			<repositories>
 				<repository>
 					<id>spring-snapshots</id>


### PR DESCRIPTION
Removes the Spring profile `activeByDefault` setting from pom.xml.

Fixes: #1698