### PR TITLE
Fix Cloud Vision Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
       openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
       tar -xzf travis.tar.gz;
       export INTEGRATION_TEST_FLAGS="-Dit.pubsub-emulator=true -Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
-          -Dit.cloudsql=true -Dit.datastore=true -Dit.trace=true -Dit.kotlin=true
+          -Dit.cloudsql=true -Dit.datastore=true -Dit.trace=true -Dit.kotlin=true -Dit.vision=true
           -Dspring.cloud.gcp.sql.instance-connection-name=spring-cloud-gcp-ci:us-central1:testmysql
           -Dspring.cloud.gcp.sql.database-name=code_samples_test_db
           -Dspring.datasource.password=test

--- a/docs/src/main/asciidoc/vision.adoc
+++ b/docs/src/main/asciidoc/vision.adoc
@@ -33,35 +33,6 @@ dependencies {
 }
 ----
 
-==== Cloud Vision OCR Dependencies
-
-If you are interested in applying optical character recognition (OCR) on documents for your project, you'll need to add both `spring-cloud-gcp-starter-vision` and `spring-cloud-gcp-starter-storage` to your dependencies.
-The storage starter is necessary because the Cloud Vision API will process your documents and write OCR output files all within your Google Cloud Storage buckets.
-
-Maven coordinates using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
-
-[source,xml]
-----
-<dependency>
-  <groupId>org.springframework.cloud</groupId>
-  <artifactId>spring-cloud-gcp-starter-vision</artifactId>
-</dependency>
-<dependency>
-  <groupId>org.springframework.cloud</groupId>
-  <artifactId>spring-cloud-gcp-starter-storage</artifactId>
-</dependency>
-----
-
-Gradle coordinates:
-
-[source]
-----
-dependencies {
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-vision'
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage'
-}
-----
-
 === Image Analysis
 
 The `CloudVisionTemplate` allows you to easily analyze images; it provides the following method for interfacing with Cloud Vision:

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/test/java/com/example/VisionApiSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/test/java/com/example/VisionApiSampleApplicationTests.java
@@ -16,8 +16,9 @@
 
 package com.example;
 
-import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -77,13 +78,11 @@ public class VisionApiSampleApplicationTests {
 					ModelAndView result = response.getModelAndView();
 					Map<String, Float> annotations = (Map<String, Float>) result.getModelMap().get("annotations");
 
-					// This represents the annotation on the image with the best score
-					String bestAnnotation = annotations.entrySet().stream()
-							.max(Comparator.comparingDouble((e) -> e.getValue()))
-							.get()
-							.getKey();
+					List<String> annotationNames = annotations.keySet().stream()
+							.map(name -> name.toLowerCase().trim())
+							.collect(Collectors.toList());
 
-					assertThat(bestAnnotation).isEqualTo("boston terrier");
+					assertThat(annotationNames).contains("boston terrier");
 				});
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo/pom.xml
@@ -19,11 +19,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-starter-storage</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>

--- a/spring-cloud-gcp-vision/pom.xml
+++ b/spring-cloud-gcp-vision/pom.xml
@@ -28,7 +28,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-gcp-storage</artifactId>
-			<optional>true</optional>
 		</dependency>
 
 		<!-- Integration Test Dependencies -->


### PR DESCRIPTION
Makes the storage dependency non-optional because it is imported by autoconfiguration class.

Fixes #1729.