### PR TITLE
Change Cloud SQL auto-configuration to ignore spring.datasource.url

### DIFF
--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -59,19 +59,20 @@ In other words, properties like the SQL username, `spring.datasource.username`, 
 There is also some configuration specific to Google Cloud SQL:
 
 |===
-| Property name | Description | Default value | Unused if specified property(ies)
-| `spring.cloud.gcp.sql.enabled` | Enables or disables Cloud SQL auto configuration | `true` |
-| `spring.cloud.gcp.sql.database-name` | Name of the database to connect to. | |
-`spring.datasource.url`
+| Property name | Description | Default value
+| `spring.cloud.gcp.sql.enabled` | Enables or disables Cloud SQL auto configuration | `true`
+| `spring.cloud.gcp.sql.database-name` | Name of the database to connect to. |
 | `spring.cloud.gcp.sql.instance-connection-name` | A string containing a Google Cloud SQL instance's project ID, region and name, each separated by a colon.
-For example, `my-project-id:my-region:my-instance-name`. | | `spring.datasource.url`
+For example, `my-project-id:my-region:my-instance-name`. |
 | `spring.cloud.gcp.sql.credentials.location` | File system path to the Google OAuth2 credentials private key file.
 Used to authenticate and authorize new connections to a Google Cloud SQL instance.
-| Default credentials provided by the Spring GCP Boot starter |
+| Default credentials provided by the Spring GCP Boot starter
 | `spring.cloud.gcp.sql.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key in JSON format.
 Used to authenticate and authorize new connections to a Google Cloud SQL instance.
-| Default credentials provided by the Spring GCP Boot starter |
+| Default credentials provided by the Spring GCP Boot starter
 |===
+
+NOTE: If you provide your own `spring.datasource.url`, it will be ignored, unless you disable Cloud SQL auto configuration with `spring.cloud.gcp.sql.enabled=false`.
 
 ==== `DataSource` creation flow
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
@@ -197,9 +197,7 @@ public abstract class GcpCloudSqlAutoConfiguration { //NOSONAR squid:S1610 must 
 				LOGGER.warn("Ignoring provided spring.datasource.url. Overwriting it based on the " +
 						"spring.cloud.gcp.sql.instance-connection-name.");
 			}
-
 			properties.setUrl(cloudSqlJdbcInfoProvider.getJdbcUrl());
-
 
 			if (gcpCloudSqlProperties.getCredentials().getEncodedKey() != null) {
 				setCredentialsEncodedKeyProperty(gcpCloudSqlProperties);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
@@ -192,12 +192,12 @@ public abstract class GcpCloudSqlAutoConfiguration { //NOSONAR squid:S1610 must 
 				LOGGER.warn("spring.datasource.driver-class-name is specified. " +
 								"Not using generated Cloud SQL configuration");
 			}
-			if (StringUtils.isEmpty(properties.getUrl())) {
-				properties.setUrl(cloudSqlJdbcInfoProvider.getJdbcUrl());
-			}
-			else {
-				LOGGER.warn("spring.datasource.url is specified. "
-						+ "Not using generated Cloud SQL configuration");
+
+			properties.setUrl(cloudSqlJdbcInfoProvider.getJdbcUrl());
+
+			if (StringUtils.hasText(properties.getUrl())) {
+				LOGGER.warn("Ignoring provided spring.datasource.url. Overwriting it based on the " +
+						"spring.cloud.gcp.sql.instance-connection-name.");
 			}
 
 			if (gcpCloudSqlProperties.getCredentials().getEncodedKey() != null) {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
@@ -193,12 +193,13 @@ public abstract class GcpCloudSqlAutoConfiguration { //NOSONAR squid:S1610 must 
 								"Not using generated Cloud SQL configuration");
 			}
 
-			properties.setUrl(cloudSqlJdbcInfoProvider.getJdbcUrl());
-
 			if (StringUtils.hasText(properties.getUrl())) {
 				LOGGER.warn("Ignoring provided spring.datasource.url. Overwriting it based on the " +
 						"spring.cloud.gcp.sql.instance-connection-name.");
 			}
+
+			properties.setUrl(cloudSqlJdbcInfoProvider.getJdbcUrl());
+
 
 			if (gcpCloudSqlProperties.getCredentials().getEncodedKey() != null) {
 				setCredentialsEncodedKeyProperty(gcpCloudSqlProperties);


### PR DESCRIPTION
Backport of #1739 for the `1.1.x` branch.

Previously, the auto-configuration would not overwrite `spring.datasource.url` if it was non-empty.

Fixes: #1732.