### PR TITLE
Warn about spring.datasource.url before overwrite

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfiguration.java
@@ -185,12 +185,11 @@ public abstract class GcpCloudSqlAutoConfiguration { //NOSONAR squid:S1610 must 
 								"Not using generated Cloud SQL configuration");
 			}
 
-			properties.setUrl(cloudSqlJdbcInfoProvider.getJdbcUrl());
-
 			if (StringUtils.hasText(properties.getUrl())) {
 				LOGGER.warn("Ignoring provided spring.datasource.url. Overwriting it based on the " +
 						"spring.cloud.gcp.sql.instance-connection-name.");
 			}
+			properties.setUrl(cloudSqlJdbcInfoProvider.getJdbcUrl());
 
 			if (gcpCloudSqlProperties.getCredentials().getEncodedKey() != null) {
 				setCredentialsEncodedKeyProperty(gcpCloudSqlProperties);


### PR DESCRIPTION
This change ensures that the warning about the JDBC URL being ovewriteen
is printed before any exceptions are potentially thrown during
computation of the URL based on spring.cloud.gcp.sql.* properties.