### PR TITLE
Add null check for trace probability property

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -61,6 +61,7 @@ import org.springframework.cloud.sleuth.sampler.SamplerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.util.Assert;
 
 /**
  * Config for Stackdriver Trace.
@@ -206,6 +207,8 @@ public class StackdriverTraceAutoConfiguration {
 		@RefreshScope
 		@ConditionalOnMissingBean
 		public Sampler defaultTraceSampler(SamplerProperties config) {
+			Assert.notNull(config.getProbability(),
+				"spring.sleuth.sampler.probability property is required for the default ProbabilityBasedSampler");
 			return new ProbabilityBasedSampler(config);
 		}
 	}
@@ -219,6 +222,8 @@ public class StackdriverTraceAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public Sampler defaultTraceSampler(SamplerProperties config) {
+			Assert.notNull(config.getProbability(),
+				"spring.sleuth.sampler.probability property is required for the default ProbabilityBasedSampler");
 			return new ProbabilityBasedSampler(config);
 		}
 	}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gcp.autoconfigure.trace;
 
+import brave.sampler.Sampler;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -143,6 +144,25 @@ public class StackdriverTraceAutoConfigurationTests {
 					= (MultipleReportersConfig.OtherSender) context.getBean("otherSender");
 			await().atMost(10, TimeUnit.SECONDS)
 					.untilAsserted(() -> assertThat(sender.isSpanSent()).isTrue());
+		});
+	}
+
+	@Test
+	public void nullProbabilityThrowsException() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+				StackdriverTraceAutoConfigurationTests.MockConfiguration.class,
+				StackdriverTraceAutoConfiguration.class,
+				GcpContextAutoConfiguration.class,
+				TraceAutoConfiguration.class,
+				SleuthLogAutoConfiguration.class,
+				RefreshAutoConfiguration.class))
+			.withPropertyValues("spring.cloud.gcp.trace.enabled", "true");
+
+		contextRunner.run(ctx -> {
+			assertThat(ctx.getStartupFailure()).isNotNull();
+			assertThat(ctx.getStartupFailure()).hasMessageContaining(
+				"spring.sleuth.sampler.probability property is required for the default ProbabilityBasedSampler");
 		});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gcp.autoconfigure.trace;
 
-import brave.sampler.Sampler;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
Adds assert before creating a default `ProbabilityBasedSampler`.

Fixes #1749.
