### PR TITLE
Repro of Gradle build issue with Greenwich.SR2 and spring-cloud-gcp-starter-trace

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/build.gradle
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'org.springframework.boot' version '2.1.6.RELEASE'
+    id 'java'
+}
+
+apply plugin: 'io.spring.dependency-management'
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '11'
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    set('springCloudVersion', "Greenwich.SR2")
+}
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-gcp-starter-logging'
+    implementation 'org.springframework.cloud:spring-cloud-gcp-starter-trace'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.awaitility:awaitility:3.1.6'
+
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -9,9 +9,9 @@
 
     <parent>
         <!-- Your own application should inherit from spring-boot-starter-parent -->
-        <artifactId>spring-cloud-gcp-samples</artifactId>
-        <groupId>org.springframework.cloud</groupId>
-        <version>1.2.0.BUILD-SNAPSHOT</version>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <groupId>org.springframework.boot</groupId>
+        <version>2.1.6.RELEASE</version>
     </parent>
 
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
@@ -19,8 +19,8 @@
         <dependencies>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-gcp-dependencies</artifactId>
-                <version>1.2.0.BUILD-SNAPSHOT</version>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>Greenwich.SR2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -42,6 +42,16 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
 
         <!-- Test-related dependencies. -->


### PR DESCRIPTION
**DO NOT MERGE**

Repro of issue #1725 

```shell
cd spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample
gradle build
```
```
> Task :compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find zipkin-tests.jar (io.zipkin.zipkin2:zipkin:2.14.2).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/io/zipkin/zipkin2/zipkin/2.14.2/zipkin-2.14.2-tests.jar
   > Could not find zipkin-tests.jar (io.zipkin.zipkin2:zipkin:2.14.2).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/io/zipkin/zipkin2/zipkin/2.14.2/zipkin-2.14.2-tests.jar

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
1 actionable task: 1 executed
```

Interestingly, there is no issue with the Maven version.