### PR TITLE
Exclude io.zipkin.zipkin2:zipkin test-jar (1.1.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
 				<groupId>io.zipkin.gcp</groupId>
 				<artifactId>zipkin-sender-stackdriver</artifactId>
 				<version>${zipkin-gcp.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>io.zipkin.zipkin2</groupId>
+						<artifactId>zipkin</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<dependency>

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -172,10 +172,6 @@
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-core</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.zipkin.zipkin2</groupId>
-                    <artifactId>zipkin</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -172,6 +172,10 @@
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.zipkin.zipkin2</groupId>
+                    <artifactId>zipkin</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
@@ -37,6 +37,10 @@
 					<groupId>io.grpc</groupId>
 					<artifactId>grpc-core</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>io.zipkin.zipkin2</groupId>
+					<artifactId>zipkin</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
@@ -37,10 +37,6 @@
 					<groupId>io.grpc</groupId>
 					<artifactId>grpc-core</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>io.zipkin.zipkin2</groupId>
-					<artifactId>zipkin</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Fixes: #1725.