### PR TITLE
Let Hibernate auto-detect dialect for Cloud SQL JPA

### DIFF
--- a/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/main/resources/application.properties
@@ -6,8 +6,6 @@ spring.datasource.continue-on-error=true
 # Enforces database initialization
 spring.datasource.initialization-mode=always
 
-# Cloud SQL (MySQL) only supports InnoDB, not MyISAM
-spring.jpa.database-platform=org.hibernate.dialect.MySQL55Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
 
 # Leave empty for root, uncomment and fill out if you specified a user

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/README.adoc
@@ -42,7 +42,7 @@ It writes a few house tuples to the database and then reads and prints each hous
 
 == Running with Cloud SQL (PostgreSQL)
 
-To run the sample with PostgreSQL instead of MySQL, follow the same basic steps, but replace MySQL starter in the `pom.xml` with the PostgreSQL starter, and change the Hibernate dialect in `application.properties` to `PostgreSQL9Dialect`.
+To run the sample with PostgreSQL instead of MySQL, follow the same basic steps, but replace MySQL starter in the `pom.xml` with the PostgreSQL starter.
 
 In `pom.xml` comment out `spring-cloud-gcp-starter-sql-mysql` and uncomment `spring-cloud-gcp-starter-sql-postgresql`:
 [source,xml]
@@ -53,7 +53,3 @@ In `pom.xml` comment out `spring-cloud-gcp-starter-sql-mysql` and uncomment `spr
 </dependency>
 ----
 
-In `src/main/resources/application.properties` change the dialect to `PostgreSQL9Dialect`:
-----
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL9Dialect
-----

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/main/resources/application.properties
@@ -3,12 +3,6 @@ spring.cloud.gcp.sql.database-name=
 
 spring.jpa.hibernate.ddl-auto=create-drop
 
-# Cloud SQL (MySQL) only supports InnoDB, not MyISAM
-spring.jpa.database-platform=org.hibernate.dialect.MySQL55Dialect
-
-# Cloud SQL (PostgreSQL) dialect
-#spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL9Dialect
-
 # Leave empty for root, uncomment and fill out if you specified a user
 #spring.datasource.username=
 


### PR DESCRIPTION
Hibernate now automatically determines the dialect. So, we don't need to
specify it in our samples. Verified that it works for both Cloud SQL
MySQL and Cloud SQL Postgres.

Closes: #392.