### PR TITLE
Reintroduce stackdriver appender to logging and tracing tests

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/resources/logback-test.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+	<include resource="org/springframework/cloud/gcp/logging/logback-appender.xml" />
+
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<!-- encoders are assigned the type
 		ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
@@ -10,5 +12,6 @@
 
 	<root level="INFO">
 		<appender-ref ref="STDOUT" />
+		<appender-ref ref="STACKDRIVER" />
 	</root>
 </configuration>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/resources/logback-test.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+	<include resource="org/springframework/cloud/gcp/logging/logback-appender.xml" />
+
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<!-- encoders are assigned the type
 		ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
@@ -10,5 +12,6 @@
 
 	<root level="INFO">
 		<appender-ref ref="STDOUT" />
+		<appender-ref ref="STACKDRIVER" />
 	</root>
 </configuration>


### PR DESCRIPTION
logback-test has overridden logback-spring. We could remove logback-test, but it's nice to be consistent, so I just added the stackdriver appender into the test config.