### PR TITLE
Add BigQuery Spring Integration File Message Handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
       openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
       tar -xzf travis.tar.gz;
       export INTEGRATION_TEST_FLAGS="-Dit.pubsub-emulator=true -Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
-          -Dit.cloudsql=true -Dit.datastore=true -Dit.trace=true -Dit.kotlin=true -Dit.vision=true -Dit.firestore=true
+          -Dit.cloudsql=true -Dit.datastore=true -Dit.trace=true -Dit.kotlin=true -Dit.vision=true -Dit.firestore=true -Dit.bigquery=true
           -Dspring.cloud.gcp.sql.instance-connection-name=spring-cloud-gcp-ci:us-central1:testmysql
           -Dspring.cloud.gcp.sql.database-name=code_samples_test_db
           -Dspring.datasource.password=test

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 		<module>spring-cloud-gcp-kotlin-samples</module>
 		<module>spring-cloud-gcp-logging</module>
 		<module>spring-cloud-gcp-data-firestore</module>
+		<module>spring-cloud-gcp-bigquery</module>
 	</modules>
 
 	<properties>

--- a/spring-cloud-gcp-bigquery/pom.xml
+++ b/spring-cloud-gcp-bigquery/pom.xml
@@ -35,7 +35,5 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
     </dependency>
-
-
   </dependencies>
 </project>

--- a/spring-cloud-gcp-bigquery/pom.xml
+++ b/spring-cloud-gcp-bigquery/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>spring-cloud-gcp</artifactId>
+    <groupId>org.springframework.cloud</groupId>
+    <version>1.2.0.BUILD-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>spring-cloud-gcp-bigquery</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.integration</groupId>
+      <artifactId>spring-integration-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquery</artifactId>
+    </dependency>
+
+
+  </dependencies>
+</project>

--- a/spring-cloud-gcp-bigquery/src/main/java/org/springframework/cloud/gcp/bigquery/integration/BigQueryFileMessageHandler.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/org/springframework/cloud/gcp/bigquery/integration/BigQueryFileMessageHandler.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.bigquery.integration;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.bigquery.JobInfo.WriteDisposition;
+import com.google.cloud.bigquery.TableDataWriteChannel;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.WriteChannelConfiguration;
+
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.util.StreamUtils;
+
+/**
+ * Outbound channel adapter which handles sending and loading files to a BigQuery table.
+ */
+public class BigQueryFileMessageHandler extends AbstractReplyProducingMessageHandler {
+
+	private final BigQuery bigQuery;
+
+	private boolean autoDetectSchema = true;
+
+	private WriteDisposition writeDisposition = WriteDisposition.WRITE_APPEND;
+
+	public BigQueryFileMessageHandler(BigQuery bigQuery) {
+		this.bigQuery = bigQuery;
+	}
+
+	@Override
+	protected Object handleRequestMessage(Message<?> message) {
+		try {
+			String datasetName = message.getHeaders().get(BigQuerySpringMessageHeaders.DATASET_NAME, String.class);
+			String tableName = message.getHeaders().get(BigQuerySpringMessageHeaders.TABLE_NAME, String.class);
+			FormatOptions formatOptions = message.getHeaders().get(
+					BigQuerySpringMessageHeaders.FORMAT_OPTIONS, FormatOptions.class);
+
+			TableId tableId = TableId.of(datasetName, tableName);
+
+			WriteChannelConfiguration writeChannelConfiguration = WriteChannelConfiguration
+					.newBuilder(tableId)
+					.setFormatOptions(formatOptions)
+					.setAutodetect(this.autoDetectSchema)
+					.setWriteDisposition(this.writeDisposition)
+					.build();
+
+			TableDataWriteChannel writer = bigQuery.writer(writeChannelConfiguration);
+			InputStream inputStream = convertToInputStream(message.getPayload());
+			OutputStream sink = Channels.newOutputStream(writer);
+
+			try {
+				StreamUtils.copy(inputStream, sink);
+			}
+			finally {
+				inputStream.close();
+				sink.close();
+			}
+
+			return writer.getJob();
+		}
+		catch (FileNotFoundException e) {
+			throw new MessageHandlingException(message, "Failed to find file to write to BigQuery.", e);
+		}
+		catch (IOException e) {
+			throw new MessageHandlingException(message, "Failed to write data to BigQuery tables.", e);
+		}
+	}
+
+	/**
+	 * Sets the {@link WriteDisposition} which specifies how data should be inserted into
+	 * BigQuery tables.
+	 * @param writeDisposition whether data should be appended or truncated to the BigQuery table
+	 */
+	public void setWriteDisposition(WriteDisposition writeDisposition) {
+		this.writeDisposition = writeDisposition;
+	}
+
+	/**
+	 * Sets whether BigQuery should attempt to autodetect the schema of the data when loading
+	 * data into an empty table for the first time.
+	 * @param autoDetectSchema whether data schema should be autodetected from the structure of
+	 * 		the data
+	 */
+	public void setAutoDetectSchema(boolean autoDetectSchema) {
+		this.autoDetectSchema = autoDetectSchema;
+	}
+
+	private static InputStream convertToInputStream(Object payload) throws FileNotFoundException {
+		InputStream result;
+
+		if (payload instanceof File) {
+			result = new BufferedInputStream(new FileInputStream((File) payload));
+		}
+		else if (payload instanceof byte[]) {
+			result = new ByteArrayInputStream((byte[]) payload);
+		}
+		else if (payload instanceof InputStream) {
+			result = (InputStream) payload;
+		}
+		else {
+			throw new IllegalArgumentException(
+					String.format(
+							"Unsupported message payload type: %s. The supported payload types "
+									+ "are: java.io.File, byte[], and java.io.InputStream.",
+							payload.getClass().getName()));
+		}
+		return result;
+	}
+}

--- a/spring-cloud-gcp-bigquery/src/main/java/org/springframework/cloud/gcp/bigquery/integration/BigQuerySpringMessageHeaders.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/org/springframework/cloud/gcp/bigquery/integration/BigQuerySpringMessageHeaders.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.bigquery.integration;
+
+/**
+ * Spring Integration {@link org.springframework.messaging.Message} headers used with
+ * Spring Cloud GCP BigQuery integration.
+ */
+public final class BigQuerySpringMessageHeaders {
+
+	private static final String PREFIX = "gcp_bigquery_";
+
+	/** BigQuery dataset name message header. */
+	public static final String DATASET_NAME = PREFIX + "dataset_name";
+
+	/** BigQuery table name message header. */
+	public static final String TABLE_NAME = PREFIX + "table_name";
+
+	/** Input data file format message header. */
+	public static final String FORMAT_OPTIONS = PREFIX + "format_options";
+
+	private BigQuerySpringMessageHeaders() {
+	}
+}

--- a/spring-cloud-gcp-bigquery/src/test/java/org/springframework/cloud/gcp/bigquery/integration/BigQueryFileMessageHandlerIntegrationTests.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/org/springframework/cloud/gcp/bigquery/integration/BigQueryFileMessageHandlerIntegrationTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.bigquery.integration;
+
+import java.io.File;
+import java.util.HashMap;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobInfo.WriteDisposition;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableResult;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeThat;
+
+public class BigQueryFileMessageHandlerIntegrationTests {
+
+	private static final String DATASET_NAME = "test_dataset";
+
+	private static final String TABLE_NAME = "test_table";
+
+	private BigQuery bigquery;
+
+	private BigQueryFileMessageHandler messageHandler;
+
+	@BeforeClass
+	public static void prepare() {
+		assumeThat(
+				"BigQuery integration tests are disabled. "
+						+ "Please use '-Dit.bigquery=true' to enable them.",
+				System.getProperty("it.bigquery"), is("true"));
+	}
+
+	@Before
+	public void setup() {
+		this.bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+		this.messageHandler = new BigQueryFileMessageHandler(this.bigquery);
+		this.messageHandler.setWriteDisposition(WriteDisposition.WRITE_EMPTY);
+
+		// Clear the previous dataset before beginning the test.
+		this.bigquery.delete(TableId.of(DATASET_NAME, TABLE_NAME));
+	}
+
+	@Test
+	public void testMessageHandlerLoadFile() throws InterruptedException {
+		HashMap<String, Object> messageHeaders = new HashMap<>();
+		messageHeaders.put(BigQuerySpringMessageHeaders.DATASET_NAME, "test_dataset");
+		messageHeaders.put(BigQuerySpringMessageHeaders.TABLE_NAME, "test_table");
+		messageHeaders.put(BigQuerySpringMessageHeaders.FORMAT_OPTIONS, FormatOptions.csv());
+
+		Message<File> message = MessageBuilder.createMessage(
+				new File("src/test/resources/data.csv"),
+				new MessageHeaders(messageHeaders));
+
+		Job job = (Job) this.messageHandler.handleRequestMessage(message);
+		job.waitFor();
+
+		QueryJobConfiguration queryJobConfiguration = QueryJobConfiguration
+				.newBuilder("SELECT * FROM test_dataset.test_table").build();
+		TableResult result = this.bigquery.query(queryJobConfiguration);
+
+		assertThat(result.getTotalRows()).isEqualTo(1);
+		assertThat(
+				result.getValues().iterator().next().get("State").getStringValue()).isEqualTo("Alabama");
+	}
+
+}

--- a/spring-cloud-gcp-bigquery/src/test/resources/data.csv
+++ b/spring-cloud-gcp-bigquery/src/test/resources/data.csv
@@ -1,0 +1,2 @@
+CountyId,State,County,TotalPop,Men,Women,Hispanic,White,Black,Native,Asian,Pacific,VotingAgeCitizen,Income,IncomeErr,IncomePerCap,IncomePerCapErr,Poverty,ChildPoverty,Professional,Service,Office,Construction,Production,Drive,Carpool,Transit,Walk,OtherTransp,WorkAtHome,MeanCommute,Employed,PrivateWork,PublicWork,SelfEmployed,FamilyWork,Unemployment
+1001,Alabama,Autauga County,55036,26899,28137,2.7,75.4,18.9,0.3,0.9,0.0,41016,55317,2838,27824,2024,13.7,20.1,35.3,18.0,23.2,8.1,15.4,86.0,9.6,0.1,0.6,1.3,2.5,25.8,24112,74.1,20.2,5.6,0.1,5.2


### PR DESCRIPTION
This adds a Spring Integration `MessageHandler` implementation for data files for BigQuery load operations. This is the outbound channel adapter for loading data files into big query.

Contributes to #1764.