### PR TITLE
Refactor Bidi Streaming Write to Buffer Entities before writing

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreReactiveOperations.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreReactiveOperations.java
@@ -40,7 +40,7 @@ public interface FirestoreReactiveOperations {
 	 * Saves multiple objects to Cloud Firestore. Not atomic. Behaves as insert or update.
 	 * @param instances the objects to save.
 	 * @param <T> the type of the objects to save.
-	 * @return a flux of the instances that were saved
+	 * @return a {@link Flux} of the instances that were saved
 	 */
 	<T> Flux<T> saveAll(Publisher<T> instances);
 

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreReactiveOperations.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreReactiveOperations.java
@@ -40,9 +40,9 @@ public interface FirestoreReactiveOperations {
 	 * Saves multiple objects to Cloud Firestore. Not atomic. Behaves as insert or update.
 	 * @param instances the objects to save.
 	 * @param <T> the type of the objects to save.
-	 * @return a flux of the instances that were saved.
+	 * @return a Mono indicating completion of the operation.
 	 */
-	<T> Flux<T> saveAll(Publisher<T> instances);
+	<T> Mono<Void> saveAll(Publisher<T> instances);
 
 	/**
 	 * Get all the entities of the given domain type.

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreReactiveOperations.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreReactiveOperations.java
@@ -42,7 +42,7 @@ public interface FirestoreReactiveOperations {
 	 * @param <T> the type of the objects to save.
 	 * @return a Mono indicating completion of the operation.
 	 */
-	<T> Mono<Void> saveAll(Publisher<T> instances);
+	<T> Flux<T> saveAll(Publisher<T> instances);
 
 	/**
 	 * Get all the entities of the given domain type.

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreReactiveOperations.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreReactiveOperations.java
@@ -40,7 +40,7 @@ public interface FirestoreReactiveOperations {
 	 * Saves multiple objects to Cloud Firestore. Not atomic. Behaves as insert or update.
 	 * @param instances the objects to save.
 	 * @param <T> the type of the objects to save.
-	 * @return a Mono indicating completion of the operation.
+	 * @return a flux of the instances that were saved
 	 */
 	<T> Flux<T> saveAll(Publisher<T> instances);
 

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-
 package org.springframework.cloud.gcp.data.firestore;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.cloud.firestore.PublicClassMapper;
 import com.google.firestore.v1.CreateDocumentRequest;
@@ -35,12 +33,10 @@ import com.google.firestore.v1.Value;
 import com.google.firestore.v1.Write;
 import com.google.firestore.v1.WriteRequest;
 import com.google.firestore.v1.WriteResponse;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import io.grpc.stub.StreamObserver;
 import org.apache.commons.lang3.StringUtils;
 import org.reactivestreams.Publisher;
-import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -48,6 +44,7 @@ import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingCont
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestorePersistentEntity;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestorePersistentProperty;
 import org.springframework.cloud.gcp.data.firestore.util.ObservableReactiveUtil;
+import org.springframework.util.Assert;
 
 /**
  * An implementation of {@link FirestoreReactiveOperations}.
@@ -96,7 +93,7 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	}
 
 	public Duration getBufferTimeoutDuration() {
-	  return this.bufferTimeout;
+		return this.bufferTimeout;
 	}
 
 	/**

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
@@ -65,9 +65,9 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 
 	private final FirestoreMappingContext mappingContext = new FirestoreMappingContext();
 
-	private Duration bufferTimeout = Duration.ofMillis(500);
+	private Duration saveAllBufferTimeout = Duration.ofMillis(500);
 
-	private int firestoreBufferWriteSize = FIRESTORE_WRITE_MAX_SIZE;
+	private int saveAllBufferWriteSize = FIRESTORE_WRITE_MAX_SIZE;
 
 	/**
 	 * Constructor for FirestoreTemplate.
@@ -89,11 +89,11 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	 * 		(default = 500ms)
 	 */
 	public void setSaveAllBufferTimeoutDuration(Duration bufferTimeout) {
-		this.bufferTimeout = bufferTimeout;
+		this.saveAllBufferTimeout = bufferTimeout;
 	}
 
 	public Duration getSaveAllBufferTimeoutDuration() {
-		return this.bufferTimeout;
+		return this.saveAllBufferTimeout;
 	}
 
 	/**
@@ -105,11 +105,11 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 		Assert.isTrue(
 				bufferWriteSize <= FIRESTORE_WRITE_MAX_SIZE,
 				"The FirestoreTemplate buffer write size must be less than " + FIRESTORE_WRITE_MAX_SIZE);
-		this.firestoreBufferWriteSize = bufferWriteSize;
+		this.saveAllBufferWriteSize = bufferWriteSize;
 	}
 
 	public int getSaveAllBufferWriteSize() {
-		return this.firestoreBufferWriteSize;
+		return this.saveAllBufferWriteSize;
 	}
 
 	public <T> Mono<T> findById(Publisher idPublisher, Class<T> aClass) {
@@ -154,7 +154,7 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	@Override
 	public <T> Flux<T> saveAll(Publisher<T> instances) {
 		Flux<List<T>> inputs = Flux.from(instances).bufferTimeout(
-				this.firestoreBufferWriteSize, this.bufferTimeout);
+				this.saveAllBufferWriteSize, this.saveAllBufferTimeout);
 
 		return ObservableReactiveUtil.streamingBidirectionalCall(
 				this::openWriteStream, inputs, this::buildWriteRequest);

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
@@ -88,28 +88,28 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	 * @param bufferTimeout duration to wait for entity buffer to fill before sending to Firestore.
 	 * 		(default = 500ms)
 	 */
-	public void setBufferTimeoutDuration(Duration bufferTimeout) {
+	public void setSaveAllBufferTimeoutDuration(Duration bufferTimeout) {
 		this.bufferTimeout = bufferTimeout;
 	}
 
-	public Duration getBufferTimeoutDuration() {
+	public Duration getSaveAllBufferTimeoutDuration() {
 		return this.bufferTimeout;
 	}
 
 	/**
 	 * Sets how many entities to include in an insert/update/delete buffered operation.
 	 * <p>The maximum buffer size is 500. In most cases users should leave this at the maximum value.
-	 * @param firestoreBufferWriteSize the entity buffer size for buffered operations (default = 500)
+	 * @param bufferWriteSize the entity buffer size for buffered operations (default = 500)
 	 */
-	public void setFirestoreBufferWriteSize(int firestoreBufferWriteSize) {
+	public void setSaveAllBufferWriteSize(int bufferWriteSize) {
 		Assert.isTrue(
-				firestoreBufferWriteSize <= FIRESTORE_WRITE_MAX_SIZE,
+				bufferWriteSize <= FIRESTORE_WRITE_MAX_SIZE,
 				"The FirestoreTemplate buffer write size must be less than " + FIRESTORE_WRITE_MAX_SIZE);
-		this.firestoreBufferWriteSize = firestoreBufferWriteSize;
+		this.firestoreBufferWriteSize = bufferWriteSize;
 	}
 
-	public int getFirestoreBufferWriteSize() {
-		return firestoreBufferWriteSize;
+	public int getSaveAllBufferWriteSize() {
+		return this.firestoreBufferWriteSize;
 	}
 
 	public <T> Mono<T> findById(Publisher idPublisher, Class<T> aClass) {
@@ -145,10 +145,16 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 		});
 	}
 
+	/**
+	 * {@inheritdoc}
+	 *
+	 * <p>The buffer size and buffer timeout settings for {@link #saveAll} can be modified by calling
+	 * {@link #setSaveAllBufferWriteSize} and {@link #setSaveAllBufferTimeoutDuration}.
+	 */
 	@Override
 	public <T> Flux<T> saveAll(Publisher<T> instances) {
 		Flux<List<T>> inputs = Flux.from(instances).bufferTimeout(
-				FIRESTORE_WRITE_MAX_SIZE, bufferTimeout);
+				this.firestoreBufferWriteSize, this.bufferTimeout);
 
 		return ObservableReactiveUtil.streamingBidirectionalCall(
 				this::openWriteStream, inputs, this::buildWriteRequest);

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
@@ -20,6 +20,7 @@ package org.springframework.cloud.gcp.data.firestore;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.cloud.firestore.PublicClassMapper;
 import com.google.firestore.v1.CreateDocumentRequest;
@@ -37,7 +38,6 @@ import com.google.firestore.v1.WriteResponse;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import io.grpc.stub.StreamObserver;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.StringUtils;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -85,7 +85,7 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	/**
 	 * Sets the {@link Duration} for how long to wait for the entity buffer to fill before sending
 	 * the buffered entities to Firestore.
-	 * @param bufferTimeout
+	 * @param bufferTimeout duration to wait for entity buffer to fill before sending to Firestore.
 	 */
 	public void setBufferTimeoutDuration(Duration bufferTimeout) {
 		this.bufferTimeout = bufferTimeout;

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
@@ -107,7 +107,7 @@ public class FirestoreIntegrationTests {
 
 		assertThat(this.firestoreTemplate.findAll(User.class).collectList().block()).isEmpty();
 
-		this.firestoreTemplate.saveAll(users).block();
+		this.firestoreTemplate.saveAll(users).blockLast();
 
 		assertThat(this.firestoreTemplate.findAll(User.class).collectList().block().size())
 				.isEqualTo(2);
@@ -125,7 +125,7 @@ public class FirestoreIntegrationTests {
 
 		assertThat(this.firestoreTemplate.findAll(User.class).collectList().block()).isEmpty();
 
-		this.firestoreTemplate.saveAll(users).block();
+		this.firestoreTemplate.saveAll(users).blockLast();
 
 		assertThat(this.firestoreTemplate.findAll(User.class).count().block()).isEqualTo(1000);
 	}

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
@@ -87,11 +87,8 @@ public class FirestoreIntegrationTests {
 		this.firestoreTemplate.save(alice).block();
 		this.firestoreTemplate.save(bob).block();
 
-		assertThat(this.firestoreTemplate.findById(Mono.just("Bob"), User.class).block())
-				.isEqualTo(bob);
-		assertThat(
-				this.firestoreTemplate.findAllById(Flux.just("Bob", "Alice"), User.class).collectList()
-						.block())
+		assertThat(this.firestoreTemplate.findById(Mono.just("Bob"), User.class).block()).isEqualTo(bob);
+		assertThat(this.firestoreTemplate.findAllById(Flux.just("Bob", "Alice"), User.class).collectList().block())
 				.containsExactly(bob, alice);
 
 		List<User> usersBeforeDelete = this.firestoreTemplate.findAll(User.class).collectList().block();

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
@@ -89,7 +89,7 @@ public class FirestoreIntegrationTests {
 
 		assertThat(this.firestoreTemplate.findById(Mono.just("Bob"), User.class).block()).isEqualTo(bob);
 		assertThat(this.firestoreTemplate.findAllById(Flux.just("Bob", "Alice"), User.class).collectList().block())
-				.containsExactly(bob, alice);
+				.containsExactlyInAnyOrder(bob, alice);
 
 		List<User> usersBeforeDelete = this.firestoreTemplate.findAll(User.class).collectList().block();
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
@@ -54,10 +54,10 @@ public class FirestoreIntegrationTests {
 	@Before
 	public void setup() throws IOException {
 
-		// assumeThat(
-		// 		"Firestore-sample tests are disabled. Please use '-Dit.firestore=true' "
-		// 				+ "to enable them. ",
-		// 		System.getProperty("it.firestore"), is("true"));
+		assumeThat(
+				"Firestore-sample tests are disabled. Please use '-Dit.firestore=true' "
+						+ "to enable them. ",
+				System.getProperty("it.firestore"), is("true"));
 
 		ch.qos.logback.classic.Logger root =
 				(ch.qos.logback.classic.Logger)


### PR DESCRIPTION
Refactors the Bidi Streaming write (the saveAll() operation) to buffer the incoming entities before writing.

Fixes #1813.

Note that I wasn't able to generalize this solution to put it in ObservableReactiveUtils... It is getting complex and it felt to me that the generalization would be harder to understand than just keeping the code here.