### PR TITLE
Create symbolic link to spring-cloud-gcp asciidoc

### DIFF
--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -1,0 +1,1 @@
+spring-cloud-gcp.adoc


### PR DESCRIPTION
Creates a symbolic link `index.adoc` to link to `spring-cloud-gcp.adoc` in order to have an index.adoc in our docs/ directory.

Following the example of spring-cloud-aws here: https://github.com/spring-cloud/spring-cloud-aws/tree/master/docs/src/main/asciidoc