### PR TITLE
Spanner doesn't wrap query with no pageable

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -1084,7 +1084,7 @@ The SQL query for the method can be mapped to repository methods in one of two w
 
 The names of the tags of the SQL correspond to the `@Param` annotated names of the method parameters.
 
-Custom SQL query methods can accept a single `Sort` or `Pageable` parameter that is applied on top of any sorting or paging in the SQL:
+Custom SQL query methods can accept a single `Sort` or `Pageable` parameter that is applied on top of any paging but will override any sorting in the SQL:
 
 [source, java]
 ----

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -167,10 +167,8 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		List<Trade> buyTradesRetrieved = this.tradeRepository
 				.annotatedTradesByAction("BUY");
 		assertThat(buyTradesRetrieved).containsExactlyInAnyOrderElementsOf(trader1BuyTrades);
-		assertThat(buyTradesRetrieved.get(0).getId()
-				.compareTo(buyTradesRetrieved.get(1).getId())).isPositive();
-		assertThat(buyTradesRetrieved.get(1).getId()
-				.compareTo(buyTradesRetrieved.get(2).getId())).isPositive();
+		assertThat(buyTradesRetrieved.get(0).getId()).isGreaterThan(buyTradesRetrieved.get(1).getId());
+		assertThat(buyTradesRetrieved.get(1).getId()).isGreaterThan(buyTradesRetrieved.get(2).getId());
 
 		List<Trade> customSortedTrades = this.tradeRepository.sortedTrades(PageRequest
 				.of(2, 2, org.springframework.data.domain.Sort.by(Order.asc("id"))));

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -167,6 +167,10 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		List<Trade> buyTradesRetrieved = this.tradeRepository
 				.annotatedTradesByAction("BUY");
 		assertThat(buyTradesRetrieved).containsExactlyInAnyOrderElementsOf(trader1BuyTrades);
+		assertThat(buyTradesRetrieved.get(0).getId()
+				.compareTo(buyTradesRetrieved.get(1).getId())).isPositive();
+		assertThat(buyTradesRetrieved.get(1).getId()
+				.compareTo(buyTradesRetrieved.get(2).getId())).isPositive();
 
 		List<Trade> customSortedTrades = this.tradeRepository.sortedTrades(PageRequest
 				.of(2, 2, org.springframework.data.domain.Sort.by(Order.asc("id"))));

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/TradeRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/TradeRepository.java
@@ -72,7 +72,7 @@ public interface TradeRepository extends SpannerRepository<Trade, Key> {
 	List<String> getFirstStringList(@Param("action") String action);
 
 	@Query("SELECT * FROM :org.springframework.cloud.gcp.data.spanner.test.domain.Trade:"
-			+ " WHERE action=@action AND action=#{#action} ORDER BY action desc")
+			+ " WHERE action=@action AND action=#{#action} ORDER BY id desc")
 	List<Trade> annotatedTradesByAction(@Param("action") String action);
 
 	List<TradeProjection> findByActionIgnoreCase(String action);


### PR DESCRIPTION
fixes #1843

Cloud spanner doesn't preserve derived tables' orders, so we avoid wrapping the derived table if possible.