### PR TITLE
Add support to allow multiple IAP audience claims

### DIFF
--- a/docs/src/main/asciidoc/security-iap.adoc
+++ b/docs/src/main/asciidoc/security-iap.adoc
@@ -20,7 +20,7 @@ This functionality relies on Cloud Resource Manager API to retrieve project deta
 * Enable Cloud Resource Manager API in https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com[GCP Console].
 * Make sure your application has `resourcemanager.projects.get` permission.
 
-App Engine automatic _audience_ determination can be overridden by using `spring.cloud.gcp.security.iap.audience` property.
+App Engine automatic _audience_ determination can be overridden by using `spring.cloud.gcp.security.iap.audience` property. It supports multiple allowable audiences by providing a comma-delimited list.
 
 For Compute Engine or Kubernetes Engine `spring.cloud.gcp.security.iap.audience` property *must* be provided, as the _audience_ string depends on the specific Backend Services setup and cannot be inferred automatically.
 To determine the _audience_ value, follow directions in IAP https://cloud.google.com/iap/docs/signed-headers-howto#verify_the_jwt_payload[Verify the JWT payload] guide.

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gcp.autoconfigure.security;
 
 import java.time.Instant;
+import java.util.Collections;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -60,6 +61,7 @@ import static org.mockito.Mockito.when;
  * Tests for IAP auth config.
  *
  * @author Elena Felder
+ * @author Marcel Amado
  *
  * @since 1.1
  */
@@ -136,6 +138,20 @@ public class IapAuthenticationAutoConfigurationTests {
 								OAuth2ResourceServerAutoConfiguration.class,
 								TestConfiguration.class))
 				.run(this::verifyJwtBeans);
+	}
+
+	@Test
+	public void testIapBeansReturnedWhenBothIapWithMultipleAudiencesAndSpringSecurityConfigPresent() {
+		when(mockJwt.getAudience()).thenReturn(Collections.singletonList("aud1"));
+
+		this.contextRunner
+				.withPropertyValues("spring.cloud.gcp.security.iap.audience=aud1, aud2")
+				.run((context) -> {
+					AudienceValidator validator
+							= context.getBean(AudienceValidator.class);
+					OAuth2TokenValidatorResult result = validator.validate(mockJwt);
+					assertThat(result.hasErrors()).isFalse();
+				});
 	}
 
 	@Test


### PR DESCRIPTION
Currently autoconfiguration supports a single audience value. With this commit
now is possible to configure multiple allowable IAP audience claims.

Fixes gh-1468