### PR TITLE
Bring in latest version of brave

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
 		<spring-cloud-sleuth.version>2.2.0.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.9.0</zipkin-gcp.version>
+		<!-- this is a temporary workaround until we upgrade to the latest zipkin-sender-stackdriver -->
+		<brave.version>5.7.0</brave.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
 	</properties>
@@ -124,8 +126,19 @@
 				<groupId>io.zipkin.gcp</groupId>
 				<artifactId>brave-propagation-stackdriver</artifactId>
 				<version>${zipkin-gcp.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>io.zipkin.brave</groupId>
+						<artifactId>brave</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
+			<dependency>
+				<groupId>io.zipkin.brave</groupId>
+				<artifactId>brave</artifactId>
+				<version>${brave.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
`spring-cloud-sleuth` [used](https://github.com/spring-cloud/spring-cloud-sleuth/commit/3ab6ec26d715d09668e6777f735ea04cb7b3d045#diff-0ecf75b0f184cfd1aaa27352c71d0950) some new functionality that Brave added. Unfortunately, with our old version of Brave, `spring-cloud-gcp` does not know what those classes are. Cue "uh... is it modern?" meme.

Excluding old version and bringing in the latest Brave will fix the build... for now.
The real solution is to upgrade to latest Zipkin dependencies #1862.

Stack trace:
```
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'tracingFilter' defined in class path resource [org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.class]: Unsatisfied dependency expressed through method 'tracingFilter' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'httpTracing' defined in class path resource [org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfiguration.class]: Unsatisfied dependency expressed through method 'httpTracing' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration': Injection of autowired dependencies failed; nested exception is java.lang.TypeNotPresentException: Type brave.TracingCustomizer not present
...
java.lang.ClassNotFoundException: brave.TracingCustomizer
```