### PR TITLE
Modify FirestoreTemplate to use Batched Deletes

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import com.google.cloud.firestore.PublicClassMapper;
 import com.google.firestore.v1.CreateDocumentRequest;
-import com.google.firestore.v1.DeleteDocumentRequest;
 import com.google.firestore.v1.Document;
 import com.google.firestore.v1.DocumentMask;
 import com.google.firestore.v1.FirestoreGrpc.FirestoreStub;
@@ -34,8 +33,6 @@ import com.google.firestore.v1.Value;
 import com.google.firestore.v1.Write;
 import com.google.firestore.v1.WriteRequest;
 import com.google.firestore.v1.WriteResponse;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Empty;
 import io.grpc.stub.StreamObserver;
 import org.apache.commons.lang3.StringUtils;
 import org.reactivestreams.Publisher;
@@ -77,9 +74,9 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 
 	private final FirestoreMappingContext mappingContext = new FirestoreMappingContext();
 
-	private Duration saveAllBufferTimeout = Duration.ofMillis(500);
+	private Duration writeBufferTimeout = Duration.ofMillis(500);
 
-	private int saveAllBufferWriteSize = FIRESTORE_WRITE_MAX_SIZE;
+	private int writeBufferSize = FIRESTORE_WRITE_MAX_SIZE;
 
 	/**
 	 * Constructor for FirestoreTemplate.
@@ -97,16 +94,16 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 
 	/**
 	 * Sets the {@link Duration} for how long to wait for the entity buffer to fill before sending
-	 * the buffered entities to Firestore.
+	 * the buffered entities to Firestore for insert/update/delete operations.
 	 * @param bufferTimeout duration to wait for entity buffer to fill before sending to Firestore.
 	 * 		(default = 500ms)
 	 */
-	public void setSaveAllBufferTimeoutDuration(Duration bufferTimeout) {
-		this.saveAllBufferTimeout = bufferTimeout;
+	public void setWriteBufferTimeout(Duration bufferTimeout) {
+		this.writeBufferTimeout = bufferTimeout;
 	}
 
-	public Duration getSaveAllBufferTimeoutDuration() {
-		return this.saveAllBufferTimeout;
+	public Duration getWriteBufferTimeout() {
+		return this.writeBufferTimeout;
 	}
 
 	/**
@@ -114,15 +111,15 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	 * <p>The maximum buffer size is 500. In most cases users should leave this at the maximum value.
 	 * @param bufferWriteSize the entity buffer size for buffered operations (default = 500)
 	 */
-	public void setSaveAllBufferWriteSize(int bufferWriteSize) {
+	public void setWriteBufferSize(int bufferWriteSize) {
 		Assert.isTrue(
 				bufferWriteSize <= FIRESTORE_WRITE_MAX_SIZE,
 				"The FirestoreTemplate buffer write size must be less than " + FIRESTORE_WRITE_MAX_SIZE);
-		this.saveAllBufferWriteSize = bufferWriteSize;
+		this.writeBufferSize = bufferWriteSize;
 	}
 
-	public int getSaveAllBufferWriteSize() {
-		return this.saveAllBufferWriteSize;
+	public int getWriteBufferSize() {
+		return this.writeBufferSize;
 	}
 
 	@Override
@@ -171,12 +168,12 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	 * {@inheritdoc}
 	 *
 	 * <p>The buffer size and buffer timeout settings for {@link #saveAll} can be modified by calling
-	 * {@link #setSaveAllBufferWriteSize} and {@link #setSaveAllBufferTimeoutDuration}.
+	 * {@link #setWriteBufferSize} and {@link #setWriteBufferTimeout}.
 	 */
 	@Override
 	public <T> Flux<T> saveAll(Publisher<T> instances) {
 		Flux<List<T>> inputs = Flux.from(instances).bufferTimeout(
-				this.saveAllBufferWriteSize, this.saveAllBufferTimeout);
+				this.writeBufferSize, this.writeBufferTimeout);
 
 		return ObservableReactiveUtil.streamingBidirectionalCall(
 				this::openWriteStream, inputs, this::buildWriteRequest);
@@ -194,30 +191,81 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 		return findAllDocuments(entityClass, ID_PROJECTION).count();
 	}
 
+	/**
+	 * {@inheritdoc}
+	 *
+	 * <p>The buffer size and buffer timeout settings for {@link #saveAll} can be modified by calling
+	 * {@link #setWriteBufferSize} and {@link #setWriteBufferTimeout}.
+	 */
 	@Override
 	public <T> Mono<Long> deleteAll(Class<T> clazz) {
-		return findAllDocuments(clazz).map(Document::getName).flatMap(this::callDelete).count();
+		Flux<List<String>> documentBuffers =
+				findAllDocuments(clazz)
+						.map(Document::getName)
+						.bufferTimeout(this.writeBufferSize, this.writeBufferTimeout);
+
+		return ObservableReactiveUtil
+				.streamingBidirectionalCall(this::openWriteStream, documentBuffers, this::buildDeleteRequest)
+				.count();
 	}
 
+	/**
+	 * {@inheritdoc}
+	 *
+	 * <p>The buffer size and buffer timeout settings for {@link #saveAll} can be modified by calling
+	 * {@link #setWriteBufferSize} and {@link #setWriteBufferTimeout}.
+	 */
 	@Override
 	public <T> Mono<Void> delete(Publisher<T> entityPublisher) {
-		return Flux.from(entityPublisher).map(this::buildResourceName).flatMap(id -> callDelete(id)).then();
+		Flux<List<String>> documentBuffers =
+				Flux.from(entityPublisher)
+						.map(this::buildResourceName)
+						.bufferTimeout(this.writeBufferSize, this.writeBufferTimeout);
+
+		return ObservableReactiveUtil
+				.streamingBidirectionalCall(this::openWriteStream, documentBuffers, this::buildDeleteRequest)
+				.then();
 	}
 
+	/**
+	 * {@inheritdoc}
+	 *
+	 * <p>The buffer size and buffer timeout settings for {@link #saveAll} can be modified by calling
+	 * {@link #setWriteBufferSize} and {@link #setWriteBufferTimeout}.
+	 */
 	@Override
 	public <T> Mono<Void> deleteById(Publisher<String> idPublisher, Class entityClass) {
 		return Mono.defer(() -> {
-			FirestorePersistentEntity<?> persistentEntity = this.mappingContext.getPersistentEntity(entityClass);
-			return Flux.from(idPublisher).flatMap(id -> callDelete(buildResourceName(persistentEntity, id)))
+			FirestorePersistentEntity<?> persistentEntity =
+					this.mappingContext.getPersistentEntity(entityClass);
+
+			Flux<List<String>> documentBuffers =
+					Flux.from(idPublisher)
+							.map(id -> buildResourceName(persistentEntity, id))
+							.bufferTimeout(this.writeBufferSize, this.writeBufferTimeout);
+
+			return ObservableReactiveUtil
+					.streamingBidirectionalCall(this::openWriteStream, documentBuffers, this::buildDeleteRequest)
 					.then();
 		});
 	}
 
-	private Mono<Empty> callDelete(String docName) {
-		DeleteDocumentRequest deleteDocumentRequest = DeleteDocumentRequest.newBuilder().setName(docName)
-				.build();
-		return ObservableReactiveUtil.unaryCall(
-						obs -> this.firestore.deleteDocument(deleteDocumentRequest, obs));
+	private WriteRequest buildDeleteRequest(
+			List<String> documentIds, WriteResponse writeResponse) {
+
+		WriteRequest.Builder writeRequestBuilder =
+				WriteRequest.newBuilder()
+						.setStreamId(writeResponse.getStreamId())
+						.setStreamToken(writeResponse.getStreamToken());
+
+		for (String documentId : documentIds) {
+			Write write = Write.newBuilder()
+					.setDelete(documentId)
+					.build();
+
+			writeRequestBuilder.addWrites(write);
+		}
+		return writeRequestBuilder.build();
 	}
 
 	private <T> Flux<Document> findAllDocuments(Class<T> clazz) {
@@ -238,9 +286,12 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 				.setStructuredQuery(builder.build())
 				.build();
 
-		return ObservableReactiveUtil.<RunQueryResponse>streamingCall(obs -> this.firestore.runQuery(request, obs))
-				.filter(RunQueryResponse::hasDocument).map(RunQueryResponse::getDocument);
+		return ObservableReactiveUtil
+				.<RunQueryResponse>streamingCall(obs -> this.firestore.runQuery(request, obs))
+				.filter(RunQueryResponse::hasDocument)
+				.map(RunQueryResponse::getDocument);
 	}
+
 
 	private Mono<Document> getDocument(String id, Class aClass, DocumentMask documentMask) {
 		FirestorePersistentEntity<?> persistentEntity = this.mappingContext.getPersistentEntity(aClass);
@@ -264,31 +315,29 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 		return requestStreamObserver;
 	}
 
-	private <T> Mono<WriteRequest> writeEntityStream(T entity, Flux<WriteResponse> responses) {
-		Mono<WriteResponse> firstResponse = responses.next();
-		return firstResponse.map(
-			initialResponse -> buildWriteRequest(initialResponse.getStreamId(), initialResponse.getStreamToken(), entity));
-	}
+	private <T> WriteRequest buildWriteRequest(List<T> entityList, WriteResponse writeResponse) {
+		WriteRequest.Builder writeRequestBuilder =
+				WriteRequest.newBuilder()
+						.setStreamId(writeResponse.getStreamId())
+						.setStreamToken(writeResponse.getStreamToken());
 
-	private <T> WriteRequest buildWriteRequest(String streamId, ByteString streamToken, T entity) {
-		String documentResourceName = buildResourceName(entity);
-		Map<String, Value> valuesMap = PublicClassMapper.convertToFirestoreTypes(entity);
+		for (T entity : entityList)	{
+			String documentResourceName = buildResourceName(entity);
+			Map<String, Value> valuesMap = PublicClassMapper.convertToFirestoreTypes(entity);
+			Write write = Write.newBuilder()
+					.setUpdate(Document.newBuilder()
+							.putAllFields(valuesMap)
+							.setName(documentResourceName))
+					.build();
+			writeRequestBuilder.addWrites(write);
+		}
 
-		return WriteRequest.newBuilder()
-			.setStreamId(streamId)
-			.setStreamToken(streamToken)
-			.addWrites(Write.newBuilder()
-				.setUpdate(Document.newBuilder()
-					.putAllFields(valuesMap)
-					.setName(documentResourceName)
-					.build())
-				.build())
-			.build();
+		return writeRequestBuilder.build();
 	}
 
 	private <T> String buildResourceName(T entity) {
-		FirestorePersistentEntity<?> persistentEntity = this.mappingContext
-			.getPersistentEntity(entity.getClass());
+		FirestorePersistentEntity<?> persistentEntity =
+				this.mappingContext.getPersistentEntity(entity.getClass());
 		FirestorePersistentProperty idProperty = persistentEntity.getIdPropertyOrFail();
 		Object idVal = persistentEntity.getPropertyAccessor(entity).getProperty(idProperty);
 
@@ -306,22 +355,4 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 		return idVal.toString();
 	}
 
-	private <T> WriteRequest buildWriteRequest(List<T> entityList, WriteResponse writeResponse) {
-		WriteRequest.Builder writeRequestBuilder =
-				WriteRequest.newBuilder()
-						.setStreamId(writeResponse.getStreamId())
-						.setStreamToken(writeResponse.getStreamToken());
-
-		for (T entity : entityList)	{
-			String documentResourceName = buildResourceName(entity);
-			Map<String, Value> valuesMap = PublicClassMapper.convertToFirestoreTypes(entity);
-			Write write = Write.newBuilder()
-					.setUpdate(
-							Document.newBuilder().putAllFields(valuesMap).setName(documentResourceName))
-					.build();
-			writeRequestBuilder.addWrites(write);
-		}
-
-		return writeRequestBuilder.build();
-	}
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/util/ObservableReactiveUtil.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/util/ObservableReactiveUtil.java
@@ -95,6 +95,7 @@ public final class ObservableReactiveUtil {
 						.cache(1);
 
 		return inputs
+				.switchIfEmpty(responsesFlux.next().thenMany(inputs))
 				.flatMap(input ->
 						responsesFlux.next()
 								.map(mostRecentResponse -> responseHandler.apply(input, mostRecentResponse))

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
@@ -141,62 +141,84 @@ public class FirestoreIntegrationTests {
 
 		assertThat(this.firestoreTemplate.findAll(User.class).count().block()).isEqualTo(1000);
 	}
+
+	@Test
+	public void deleteTest() throws InterruptedException {
+		this.firestoreTemplate.save(new User("alpha", 45)).block();
+		this.firestoreTemplate.save(new User("beta", 23)).block();
+		this.firestoreTemplate.save(new User("gamma", 44)).block();
+		this.firestoreTemplate.save(new User("Joe Hogan", 22)).block();
+
+		assertThat(this.firestoreTemplate.count(User.class).block()).isEqualTo(4);
+
+		this.firestoreTemplate.delete(Mono.just(new User("alpha", 45))).block();
+		assertThat(this.firestoreTemplate.findAll(User.class).map(User::getName).collectList().block())
+				.containsExactlyInAnyOrder("beta", "gamma", "Joe Hogan");
+
+		this.firestoreTemplate.deleteById(Mono.just("beta"), User.class).block();
+		assertThat(this.firestoreTemplate.findAll(User.class).map(User::getName).collectList().block())
+				.containsExactlyInAnyOrder("gamma", "Joe Hogan");
+
+		this.firestoreTemplate.deleteAll(User.class).block();
+		assertThat(this.firestoreTemplate.count(User.class).block()).isEqualTo(0);
+	}
+
+	@Entity(collectionName = "usersFirestoreTemplate")
+	static class User {
+		@Id
+		private String name;
+
+		private Integer age;
+
+		User(String name, Integer age) {
+			this.name = name;
+			this.age = age;
+		}
+
+		User() {
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Integer getAge() {
+			return this.age;
+		}
+
+		public void setAge(Integer age) {
+			this.age = age;
+		}
+
+		@Override
+		public String toString() {
+			return "User{" +
+					"name='" + this.name + '\'' +
+					", age=" + this.age +
+					'}';
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			User user = (User) o;
+			return Objects.equals(getName(), user.getName()) &&
+					Objects.equals(getAge(), user.getAge());
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(getName(), getAge());
+		}
+	}
 }
 
-@Entity(collectionName = "usersFirestoreTemplate")
-class User {
-	@Id
-	private String name;
-
-	private Integer age;
-
-	User(String name, Integer age) {
-		this.name = name;
-		this.age = age;
-	}
-
-	User() {
-	}
-
-	public String getName() {
-		return this.name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public Integer getAge() {
-		return this.age;
-	}
-
-	public void setAge(Integer age) {
-		this.age = age;
-	}
-
-	@Override
-	public String toString() {
-		return "User{" +
-				"name='" + this.name + '\'' +
-				", age=" + this.age +
-				'}';
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		User user = (User) o;
-		return Objects.equals(getName(), user.getName()) &&
-				Objects.equals(getAge(), user.getAge());
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(getName(), getAge());
-	}
-}


### PR DESCRIPTION
Modify the FirestoreTemplate to use batched deletes so that deletions of larger number of entities is efficient.

Fixes #1798.