### PR TITLE
Upgrade to zipkin-gcp 0.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 		<spring-cloud-commons.version>2.2.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-sleuth.version>2.2.0.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
-		<zipkin-gcp.version>0.9.0</zipkin-gcp.version>
+		<zipkin-gcp.version>0.14.0</zipkin-gcp.version>
 		<!-- this is a temporary workaround until we upgrade to the latest zipkin-sender-stackdriver -->
 		<brave.version>5.7.0</brave.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
@@ -139,6 +139,7 @@
 				<artifactId>brave</artifactId>
 				<version>${brave.version}</version>
 			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -139,7 +139,7 @@ public class StackdriverTraceAutoConfiguration {
 				// historical constraint. Note: AsyncReporter supports memory bounds
 				.queuedMaxSpans(1000)
 				.messageTimeout(trace.getMessageTimeout(), TimeUnit.SECONDS)
-				.metrics(reporterMetrics).build(StackdriverEncoder.V1);
+				.metrics(reporterMetrics).build(StackdriverEncoder.V2);
 	}
 
 	@Bean(SENDER_BEAN_NAME)

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -129,7 +129,6 @@ public class StackdriverTraceAutoConfigurationTests {
 
 						Span traceSpan = gcpTraceService.getSpan(spanId);
 						assertThat(traceSpan.getDisplayName().getValue()).isEqualTo("foo");
-						// projects/proj/traces/5d77f6be01dfdd74a59170a2cd6920c6/spans/a59170a2cd6920c6
 						assertThat(traceSpan.getAttributes().getAttributeMapMap()).containsKey("foo");
 						assertThat(traceSpan.getAttributes().getAttributeMapMap().get("foo").getStringValue().getValue())
 								.isEqualTo("bar");

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -23,17 +23,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import brave.Span;
 import brave.Tracing;
 import brave.http.HttpClientParser;
 import brave.http.HttpServerParser;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
-import com.google.devtools.cloudtrace.v1.PatchTracesRequest;
-import com.google.devtools.cloudtrace.v1.Trace;
-import com.google.devtools.cloudtrace.v1.TraceServiceGrpc;
-import com.google.devtools.cloudtrace.v1.TraceSpan;
+import com.google.devtools.cloudtrace.v2.BatchWriteSpansRequest;
+import com.google.devtools.cloudtrace.v2.Span;
+import com.google.devtools.cloudtrace.v2.TraceServiceGrpc;
 import com.google.protobuf.Empty;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
@@ -117,26 +115,24 @@ public class StackdriverTraceAutoConfigurationTests {
 			assertThat(context.getBeansOfType(Reporter.class)).containsKeys("stackdriverReporter",
 					"otherReporter");
 
-			Span span = context.getBean(Tracing.class).tracer().nextSpan().name("foo")
+			brave.Span span = context.getBean(Tracing.class).tracer().nextSpan().name("foo")
 					.tag("foo", "bar").start();
 			span.finish();
-			String traceId = span.context().traceIdString();
+			String spanId = span.context().spanIdString();
 
 			MultipleReportersConfig.GcpTraceService gcpTraceService
 					= context.getBean(MultipleReportersConfig.GcpTraceService.class);
 			await().atMost(10, TimeUnit.SECONDS)
 					.pollInterval(Duration.ONE_SECOND)
 					.untilAsserted(() -> {
-						assertThat(gcpTraceService.hasTraceFor(traceId)).isTrue();
+						assertThat(gcpTraceService.hasSpan(spanId)).isTrue();
 
-						Trace trace = gcpTraceService.getTraceFor(traceId);
-						assertThat(trace.getProjectId()).isEqualTo("proj");
-						assertThat(trace.getSpansCount()).isEqualTo(1);
-
-						TraceSpan traceSpan = trace.getSpans(0);
-						assertThat(traceSpan.getName()).isEqualTo("foo");
-						assertThat(traceSpan.getLabelsMap()).containsKey("foo");
-						assertThat(traceSpan.getLabelsMap()).containsValue("bar");
+						Span traceSpan = gcpTraceService.getSpan(spanId);
+						assertThat(traceSpan.getDisplayName().getValue()).isEqualTo("foo");
+						// projects/proj/traces/5d77f6be01dfdd74a59170a2cd6920c6/spans/a59170a2cd6920c6
+						assertThat(traceSpan.getAttributes().getAttributeMapMap()).containsKey("foo");
+						assertThat(traceSpan.getAttributes().getAttributeMapMap().get("foo").getStringValue().getValue())
+								.isEqualTo("bar");
 					});
 
 			MultipleReportersConfig.OtherSender sender
@@ -244,22 +240,24 @@ public class StackdriverTraceAutoConfigurationTests {
 		 */
 		static class GcpTraceService extends TraceServiceGrpc.TraceServiceImplBase {
 
-			private Map<String, Trace> traces = new HashMap<>();
+			private Map<String, Span> traces = new HashMap<>();
 
-			boolean hasTraceFor(String traceId) {
-				return this.traces.containsKey(traceId);
+			boolean hasSpan(String spanId) {
+				return this.traces.containsKey(spanId);
 			}
 
-			Trace getTraceFor(String traceId) {
-				return this.traces.get(traceId);
+			Span getSpan(String spanId) {
+				return this.traces.get(spanId);
 			}
 
 			@Override
-			public void patchTraces(PatchTracesRequest request, StreamObserver<Empty> responseObserver) {
-				request.getTraces().getTracesList().forEach((trace) -> this.traces.put(trace.getTraceId(), trace));
+			public void batchWriteSpans(BatchWriteSpansRequest request,
+					StreamObserver<Empty> responseObserver) {
+				request.getSpansList().forEach((span) -> this.traces.put(span.getSpanId(), span));
 				responseObserver.onNext(Empty.getDefaultInstance());
 				responseObserver.onCompleted();
 			}
+
 		}
 
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -14,10 +14,6 @@
         <version>1.2.0.BUILD-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <grpc-google-cloud-trace.version>0.69.0</grpc-google-cloud-trace.version>
-    </properties>
-
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
     <dependencyManagement>
         <dependencies>
@@ -75,7 +71,6 @@
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-cloud-trace-v1</artifactId>
-            <version>${grpc-google-cloud-trace.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -14,6 +14,10 @@
         <version>1.2.0.BUILD-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <grpc-google-cloud-trace.version>0.69.0</grpc-google-cloud-trace.version>
+    </properties>
+
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
     <dependencyManagement>
         <dependencies>
@@ -67,6 +71,14 @@
             <version>2.5</version>
             <scope>test</scope>
         </dependency>
+        <!-- Stackdriver Trace read operations are only available in its v1 API. Use it to validate data was written during integration tests. -->
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>grpc-google-cloud-trace-v1</artifactId>
+            <version>${grpc-google-cloud-trace.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Upgrading to `zipkin-gcp` 0.14 automatically upgrades our Stackdriver API to V2, which is technically still in Beta.

I had to keep the brave version workaround because `zipkin-gcp` explicitly downgrades it: openzipkin/zipkin-gcp#146