### PR TITLE
Fix Firestore Autoconfiguration test breakage

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -16,12 +16,10 @@
 
 package org.springframework.cloud.gcp.autoconfigure.firestore;
 
-import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import java.io.IOException;
 
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.api.gax.grpc.GrpcTransportChannel;
-import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.firestore.v1.FirestoreGrpc;


### PR DESCRIPTION
Fix the Firestore autoconfiguration test breakage.

This resolves the error:

```
java.lang.IllegalStateException: Unstarted application context org.springframework.boot.test.context.assertj.AssertableApplicationContext[startupFailure=org.springframework.beans.factory.BeanCreationException] failed to start

    at org.springframework.cloud.gcp.autoconfigure.firestore.GcpFirestoreAutoConfigurationTests.lambda$testTestRepositoryCreated$1(GcpFirestoreAutoConfigurationTests.java:59)

    at org.springframework.cloud.gcp.autoconfigure.firestore.GcpFirestoreAutoConfigurationTests.testTestRepositoryCreated(GcpFirestoreAutoConfigurationTests.java:59)

Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'firestoreOptions' defined in org.springframework.cloud.gcp.autoconfigure.firestore.GcpFirestoreAutoConfiguration: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.google.cloud.firestore.FirestoreOptions]: Factory method 'firestoreOptions' threw exception; nested exception is java.lang.IllegalArgumentException: Only GRPC channels are allowed for Firestore.

    at org.springframework.cloud.gcp.autoconfigure.firestore.GcpFirestoreAutoConfigurationTests.testTestRepositoryCreated(GcpFirestoreAutoConfigurationTests.java:59)

Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.google.cloud.firestore.FirestoreOptions]: Factory method 'firestoreOptions' threw exception; nested exception is java.lang.IllegalArgumentException: Only GRPC channels are allowed for Firestore.

    at org.springframework.cloud.gcp.autoconfigur
```

Which was introduced by #1875.