### PR TITLE
Fix CloudFoundry tests for Java 11

### DIFF
--- a/spring-cloud-gcp-cloudfoundry/pom.xml
+++ b/spring-cloud-gcp-cloudfoundry/pom.xml
@@ -40,4 +40,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- CloudFoundry test utils depend on JMockit, which requires
+                     using the jdk.attach.allowAttachSelf property on JDK 11 -->
+                <configuration>
+                    <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Fixes the CloudFoundry tests for Java 11 by enabling `-Djdk.attach.allowAttachSelf=true` for JVM option in the surefire plugin (the plugin that runs the tests).

This resolves the issue of the `Can not attach to current VM` errors.
https://stackoverflow.com/questions/50498102/how-to-set-jdk-attach-allowattachself-true-globally

If you would like to reproduce, set your java version to 11 then try running the tests in Intellij. Then add this and try running again.