### PR TITLE
Delegate FirestoreTemplate.save() to call .saveAll()

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplate.java
@@ -147,21 +147,7 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 
 	@Override
 	public <T> Mono<T> save(T entity) {
-		return Mono.defer(() -> {
-			FirestorePersistentEntity<?> persistentEntity = this.mappingContext.getPersistentEntity(entity.getClass());
-			String idVal = getIdValue(entity, persistentEntity);
-
-			Map<String, Value> valuesMap = PublicClassMapper.convertToFirestoreTypes(entity);
-
-			CreateDocumentRequest createDocumentRequest = CreateDocumentRequest.newBuilder()
-					.setParent(this.parent)
-					.setCollectionId(persistentEntity.collectionName())
-					.setDocumentId(idVal)
-					.setDocument(Document.newBuilder().putAllFields(valuesMap))
-					.build();
-			return ObservableReactiveUtil.<Document>unaryCall(
-					obs -> this.firestore.createDocument(createDocumentRequest, obs)).then(Mono.just(entity));
-		});
+		return saveAll(Mono.just(entity)).next();
 	}
 
 	/**

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
@@ -51,6 +51,7 @@ import static org.junit.Assume.assumeThat;
 /**
  * @author Dmitry Solomakha
  * @author Chengyuan Zhao
+ * @author Daniel Zou
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -115,6 +116,18 @@ public class FirestoreIntegrationTests {
 
 		assertThat(usersBeforeDelete).containsExactlyInAnyOrder(alice, bob);
 		assertThat(this.firestoreTemplate.findAll(User.class).collectList().block()).isEmpty();
+	}
+
+
+	@Test
+	public void saveTest() throws InterruptedException {
+		assertThat(this.firestoreTemplate.count(User.class).block()).isEqualTo(0);
+
+		User u1 = new User("Cloud", 22);
+		this.firestoreTemplate.save(u1).block();
+
+		assertThat(this.firestoreTemplate.findAll(User.class).collectList().block())
+				.containsExactly(u1);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplateTests.java
@@ -65,31 +65,6 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void saveTest() {
-		TestEntity testEntity1 = new TestEntity("test_entity_1", 123L);
-
-		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
-			streamObserver.onNext(Document.newBuilder().build());
-			streamObserver.onCompleted();
-			return null;
-		}).when(this.firestoreStub).createDocument(any(), any());
-
-		StepVerifier.create(this.firestoreTemplate.save(testEntity1))
-				.expectNextMatches(testEntity -> testEntity == testEntity1).verifyComplete();
-
-		CreateDocumentRequest expectedCreateDocumentRequest = CreateDocumentRequest.newBuilder()
-				.setParent(this.parent)
-				.setCollectionId("testEntities")
-				.setDocumentId("test_entity_1")
-				.setDocument(Document.newBuilder().putAllFields(createValuesMap("test_entity_1", 123L)))
-				.build();
-
-		verify(this.firestoreStub, times(1)).createDocument(eq(expectedCreateDocumentRequest), any());
-		verify(this.firestoreStub, times(1)).createDocument(any(), any());
-	}
-
-	@Test
 	public void findAllTest() {
 		mockRunQueryMethod();
 


### PR DESCRIPTION
Delegates the FirestoreTemplate.saveAll() method to calling `.save()`. This is done because saveAll() acts as an Upsert and covers the update functionality described in #1796 whereas the former method `CreateDocumentRequest` is used for document creation only.

Fixes #1796.

I moved the save() test to be an integration test because it is difficult to construct mocks to properly unit test bidi streams in `saveAll()`.
