### PR TITLE
Fix FirestoreSampleAppTests

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -176,6 +176,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>grpc-google-cloud-firestore-v1</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- BigQuery -->
         <dependency>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -109,7 +109,6 @@ public class GcpFirestoreAutoConfiguration {
 	 * The Firestore reactive template and data repositories support auto-configuration.
 	 */
 	@ConditionalOnClass({ FirestoreGrpc.FirestoreStub.class })
-	@ConditionalOnMissingBean(CloudSqlJdbcInfoProvider.class)
 	class FirestoreReactiveAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.cloud.gcp.autoconfigure.sql.CloudSqlJdbcInfoProvider;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
@@ -104,32 +105,40 @@ public class GcpFirestoreAutoConfiguration {
 		return firestoreOptions.getService();
 	}
 
-	@Bean
-	@ConditionalOnMissingBean
-	public FirestoreGrpc.FirestoreStub firestoreGrpcStub(
-			ManagedChannel firestoreManagedChannel) throws IOException {
-		return FirestoreGrpc.newStub(firestoreManagedChannel)
-				.withCallCredentials(MoreCallCredentials.from(this.credentialsProvider.getCredentials()));
-	}
+	/**
+	 * The Firestore reactive template and data repositories support auto-configuration
+	 */
+	@ConditionalOnClass({ FirestoreGrpc.FirestoreStub.class })
+	@ConditionalOnMissingBean(CloudSqlJdbcInfoProvider.class)
+	class FirestoreReactiveAutoConfiguration {
+		@Bean
+		@ConditionalOnMissingBean
+		public FirestoreGrpc.FirestoreStub firestoreGrpcStub(
+				ManagedChannel firestoreManagedChannel) throws IOException {
+			return FirestoreGrpc.newStub(firestoreManagedChannel)
+					.withCallCredentials(MoreCallCredentials.from(
+							GcpFirestoreAutoConfiguration.this.credentialsProvider.getCredentials()));
+		}
 
-	@Bean
-	@ConditionalOnMissingBean
-	public FirestoreMappingContext firestoreMappingContext() {
-		return new FirestoreMappingContext();
-	}
+		@Bean
+		@ConditionalOnMissingBean
+		public FirestoreMappingContext firestoreMappingContext() {
+			return new FirestoreMappingContext();
+		}
 
-	@Bean
-	@ConditionalOnMissingBean
-	public FirestoreTemplate firestoreTemplate(FirestoreGrpc.FirestoreStub firestoreStub) {
-		return new FirestoreTemplate(firestoreStub, this.firestoreRootPath);
-	}
+		@Bean
+		@ConditionalOnMissingBean
+		public FirestoreTemplate firestoreTemplate(FirestoreGrpc.FirestoreStub firestoreStub) {
+			return new FirestoreTemplate(firestoreStub, GcpFirestoreAutoConfiguration.this.firestoreRootPath);
+		}
 
-	@Bean
-	@ConditionalOnMissingBean
-	public ManagedChannel firestoreManagedChannel() {
-		return ManagedChannelBuilder
-				.forTarget(this.hostPort)
-				.userAgent(USER_AGENT_HEADER_PROVIDER.getUserAgent())
-				.build();
+		@Bean
+		@ConditionalOnMissingBean
+		public ManagedChannel firestoreManagedChannel() {
+			return ManagedChannelBuilder
+					.forTarget(GcpFirestoreAutoConfiguration.this.hostPort)
+					.userAgent(USER_AGENT_HEADER_PROVIDER.getUserAgent())
+					.build();
+		}
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -33,7 +33,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
-import org.springframework.cloud.gcp.autoconfigure.sql.CloudSqlJdbcInfoProvider;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -106,7 +106,7 @@ public class GcpFirestoreAutoConfiguration {
 	}
 
 	/**
-	 * The Firestore reactive template and data repositories support auto-configuration
+	 * The Firestore reactive template and data repositories support auto-configuration.
 	 */
 	@ConditionalOnClass({ FirestoreGrpc.FirestoreStub.class })
 	@ConditionalOnMissingBean(CloudSqlJdbcInfoProvider.class)

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreIntegrationTests.java
@@ -36,10 +36,12 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingContext;
 import org.springframework.cloud.gcp.data.firestore.repository.config.EnableReactiveFirestoreRepositories;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.annotation.Id;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -56,8 +58,6 @@ import static org.junit.Assume.assumeThat;
 @RunWith(SpringRunner.class)
 @ContextConfiguration
 public class FirestoreIntegrationTests {
-
-	private static final String DEFAULT_PARENT = "projects/spring-cloud-gcp-ci-firestore/databases/(default)/documents";
 
 	@Autowired
 	FirestoreTemplate firestoreTemplate;
@@ -191,8 +191,12 @@ public class FirestoreIntegrationTests {
 	 * Spring config for the tests.
 	 */
 	@Configuration
+	@PropertySource("application-test.properties")
 	@EnableReactiveFirestoreRepositories
 	static class Config {
+
+		@Value("projects/${test.integration.firestore.project-id}/databases/(default)/documents")
+		String defaultParent;
 
 		@Bean
 		public FirestoreTemplate firestoreTemplate() throws IOException {
@@ -206,7 +210,7 @@ public class FirestoreIntegrationTests {
 					.build();
 
 			return new FirestoreTemplate(FirestoreGrpc.newStub(channel).withCallCredentials(callCredentials),
-					DEFAULT_PARENT);
+					defaultParent);
 		}
 
 		@Bean

--- a/spring-cloud-gcp-data-firestore/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-data-firestore/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+test.integration.firestore.project-id=spring-cloud-gcp-ci-firestore


### PR DESCRIPTION
Without this fix, we get:
```
Caused by: java.lang.ClassNotFoundException: com.google.firestore.v1.FirestoreGrpc$FirestoreStub
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 84 common frames omitted
```