### PR TITLE
Improve Spanner readonly transactional test

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManager.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManager.java
@@ -178,6 +178,7 @@ public class SpannerTransactionManager extends AbstractPlatformTransactionManage
 		}
 		else {
 			tx.transactionContext = tx.transactionManager.begin();
+			tx.isReadOnly = false;
 		}
 
 		logger.debug(tx + " begin; state = " + tx.transactionManager.getState());

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateTransactionManagerTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplateTransactionManagerTests.java
@@ -142,11 +142,13 @@ public class SpannerTemplateTransactionManagerTests {
 
 	@Test
 	public void readOnlyTest() {
+		// The transactionManager will NOT be started in readonly
+		when(this.transactionManager.getState()).thenReturn(TransactionManager.TransactionState.COMMITTED);
+
 		this.transactionalService.readOnlyOperation();
 		// begin() is for read-write transactions
 		verify(this.transactionManager, times(0)).begin();
 		verify(this.databaseClient, times(1)).readOnlyTransaction();
-		verify(this.transactionManager, times(1)).commit();
 		verify(this.readOnlyTransaction, times(1)).close();
 		verify(this.transactionManager, times(0)).rollback();
 	}


### PR DESCRIPTION
related #1897

makes fix and improves closing of readonly transactions.

Previously it was still located in a block that expected the transaction state to be STARTED, but this is not correct. Test improved to account for this.