### PR TITLE
Fix linked code snippets in Pub/Sub and Firestore docs

### DIFF
--- a/docs/src/main/asciidoc/firestore.adoc
+++ b/docs/src/main/asciidoc/firestore.adoc
@@ -34,9 +34,9 @@ The starter automatically configures and registers a `Firestore` bean in the Spr
  @Autowired
  Firestore firestore;
 
-include::../../src/test/java/org/springframework/cloud/gcp/sample/firestore/FirestoreDocumentationTests.java[tag=write]
+include::../../test/java/org/springframework/cloud/gcp/sample/firestore/FirestoreDocumentationTests.java[tag=write]
 
-include::../../src/test/java/org/springframework/cloud/gcp/sample/firestore/FirestoreDocumentationTests.java[tag=read]
+include::../../test/java/org/springframework/cloud/gcp/sample/firestore/FirestoreDocumentationTests.java[tag=read]
 ----
 
 === Configuration

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -45,7 +45,7 @@ Here is an example of how to publish a message to a Google Cloud Pub/Sub topic:
 
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=publish]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=publish]
 ----
 
 By default, the `SimplePubSubMessageConverter` is used to convert payloads of type `byte[]`, `ByteString`, `ByteBuffer`, and `String` to Pub/Sub messages.
@@ -61,7 +61,7 @@ The subscription name could either be a canonical subscription name within the c
 Subscribe to a subscription with a message handler:
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=subscribe]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=subscribe]
 ----
 ===== Subscribe methods
 `PubSubTemplate` provides the following subscribe methods:
@@ -84,7 +84,7 @@ This is different from subscribing to a subscription, in the sense that subscrib
 Pull up to 10 messages:
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=pull]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=pull]
 ----
 
 ===== Pull methods
@@ -122,7 +122,7 @@ For serialization and deserialization of POJOs using Jackson JSON, configure a `
 
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=json_bean]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=json_bean]
 ----
 
 NOTE: Alternatively, you can set it directly by calling the `setMessageConverter()` method on the `PubSubTemplate`.
@@ -132,20 +132,20 @@ Assuming you have the following class defined:
 
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=json_convertible_class]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=json_convertible_class]
 ----
 
 You can serialize objects to JSON on publish automatically:
 
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=json_publish]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=json_publish]
 ----
 
-And thatt's how you convert messages to objects on pull:
+And that's how you convert messages to objects on pull:
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=json_pull]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=json_pull]
 ----
 
 
@@ -248,7 +248,7 @@ Here is an example of how to list every Google Cloud Pub/Sub topic name in a pro
 
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=list_topics]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=list_topics]
 ----
 
 ==== Creating a subscription
@@ -319,7 +319,7 @@ Here is an example of how to list every subscription name in a project:
 
 [source,java,indent=0]
 ----
-include::../../src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=list_subscriptions]
+include::../../test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationTests.java[tag=list_subscriptions]
 ----
 
 [#pubsub-configuration]


### PR DESCRIPTION
`../..` goes up to `src`; so specifying `src` in the relative URL breaks links.