### PR TITLE
Add PartTree Query Count Detection

### DIFF
--- a/spring-cloud-gcp-data-firestore/pom.xml
+++ b/spring-cloud-gcp-data-firestore/pom.xml
@@ -52,13 +52,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <artifactId>spring-cloud-gcp-core</artifactId>
-            <groupId>org.springframework.cloud</groupId>
         </dependency>
     </dependencies>
 

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQuery.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQuery.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import com.google.cloud.firestore.PublicClassMapper;
 import com.google.firestore.v1.StructuredQuery;
+import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.gcp.core.util.MapBuilder;
 import org.springframework.cloud.gcp.data.firestore.FirestoreDataException;
@@ -85,7 +86,14 @@ public class PartTreeFirestoreQuery implements RepositoryQuery {
 		}
 
 		StructuredQuery.Builder builder = createBuilderWithFilter(parameters);
-		return this.reactiveOperations.execute(builder, this.persistentEntity.getType());
+		Flux<?> result = this.reactiveOperations.execute(builder, this.persistentEntity.getType());
+
+		if (this.tree.isCountProjection()) {
+			return result.count();
+		}
+		else {
+			return result;
+		}
 	}
 
 	private StructuredQuery.Builder createBuilderWithFilter(Object[] parameters) {

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.firestore;
+
+import java.util.Objects;
+
+import org.springframework.data.annotation.Id;
+
+@Entity(collectionName = "usersCollection")
+public class User {
+	@Id
+	private String name;
+
+	private Integer age;
+
+	public User(String name, Integer age) {
+		this.name = name;
+		this.age = age;
+	}
+
+	User() {
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Integer getAge() {
+		return this.age;
+	}
+
+	public void setAge(Integer age) {
+		this.age = age;
+	}
+
+	@Override
+	public String toString() {
+		return "User{" +
+				"name='" + this.name + '\'' +
+				", age=" + this.age +
+				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		User user = (User) o;
+		return Objects.equals(getName(), user.getName()) &&
+				Objects.equals(getAge(), user.getAge());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getName(), getAge());
+	}
+}

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java
@@ -20,6 +20,11 @@ import java.util.Objects;
 
 import org.springframework.data.annotation.Id;
 
+/**
+ * Sample entity for integration tests.
+ *
+ * @author Daniel Zou
+ */
 @Entity(collectionName = "usersCollection")
 public class User {
 	@Id
@@ -32,7 +37,7 @@ public class User {
 		this.age = age;
 	}
 
-	User() {
+	public User() {
 	}
 
 	public String getName() {

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTests.java
@@ -50,14 +50,10 @@ public class FirestoreIntegrationTests {
 	@Autowired
 	FirestoreTemplate firestoreTemplate;
 
-	@Autowired
-	UserRepository userRepository;
-
 	@BeforeClass
 	public static void checkToRun() throws IOException {
-		assumeThat(
-				"Firestore-sample tests are disabled. Please use '-Dit.firestore=true' "
-						+ "to enable them. ",
+		assumeThat("Firestore-sample tests are disabled. "
+						+ "Please use '-Dit.firestore=true' to enable them. ",
 				System.getProperty("it.firestore"), is("true"));
 
 		ch.qos.logback.classic.Logger root =
@@ -99,9 +95,7 @@ public class FirestoreIntegrationTests {
 		this.firestoreTemplate.save(alice).block();
 		this.firestoreTemplate.save(bob).block();
 
-		assertThat(this.userRepository.count().block()).isEqualTo(2);
 		assertThat(this.firestoreTemplate.deleteAll(User.class).block()).isEqualTo(2);
-
 		assertThat(usersBeforeDelete).containsExactlyInAnyOrder(alice, bob);
 		assertThat(this.firestoreTemplate.findAll(User.class).collectList().block()).isEmpty();
 	}
@@ -129,13 +123,7 @@ public class FirestoreIntegrationTests {
 		this.firestoreTemplate.saveAll(users).blockLast();
 
 		assertThat(this.firestoreTemplate.count(User.class).block()).isEqualTo(2);
-
-		assertThat(this.userRepository.findByAge(22).collectList().block()).containsExactly(u1);
-		assertThat(this.userRepository.findByAgeAndName(22, "Cloud").collectList().block()).containsExactly(u1);
-		assertThat(this.userRepository.findByAgeGreaterThan(10).collectList().block()).containsExactlyInAnyOrder(u1, u2);
-
 		assertThat(this.firestoreTemplate.deleteAll(User.class).block()).isEqualTo(2);
-		assertThat(this.userRepository.existsById("Cloud").block()).isFalse();
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2019 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.gcp.data.firestore;
+package org.springframework.cloud.gcp.data.firestore.it;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 
 import ch.qos.logback.classic.Level;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.firestore.v1.FirestoreGrpc;
-import io.grpc.CallCredentials;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
-import io.grpc.auth.MoreCallCredentials;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,13 +29,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingContext;
-import org.springframework.cloud.gcp.data.firestore.repository.config.EnableReactiveFirestoreRepositories;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.data.annotation.Id;
+import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
+import org.springframework.cloud.gcp.data.firestore.User;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -56,7 +44,7 @@ import static org.junit.Assume.assumeThat;
  * @author Daniel Zou
  */
 @RunWith(SpringRunner.class)
-@ContextConfiguration
+@ContextConfiguration(classes = FirestoreIntegrationTestsConfiguration.class)
 public class FirestoreIntegrationTests {
 
 	@Autowired
@@ -185,95 +173,5 @@ public class FirestoreIntegrationTests {
 
 		this.firestoreTemplate.deleteAll(User.class).block();
 		assertThat(this.firestoreTemplate.count(User.class).block()).isEqualTo(0);
-	}
-
-	/**
-	 * Spring config for the tests.
-	 */
-	@Configuration
-	@PropertySource("application-test.properties")
-	@EnableReactiveFirestoreRepositories
-	static class Config {
-
-		@Value("projects/${test.integration.firestore.project-id}/databases/(default)/documents")
-		String defaultParent;
-
-		@Bean
-		public FirestoreTemplate firestoreTemplate() throws IOException {
-
-			GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
-			CallCredentials callCredentials = MoreCallCredentials.from(credentials);
-
-			// Create a channel
-			ManagedChannel channel = ManagedChannelBuilder
-					.forAddress("firestore.googleapis.com", 443)
-					.build();
-
-			return new FirestoreTemplate(FirestoreGrpc.newStub(channel).withCallCredentials(callCredentials),
-					defaultParent);
-		}
-
-		@Bean
-		public FirestoreMappingContext firestoreMappingContext() {
-			return new FirestoreMappingContext();
-		}
-	}
-
-	@Entity(collectionName = "usersCollection")
-	public static class User {
-		@Id
-		private String name;
-
-		private Integer age;
-
-		User(String name, Integer age) {
-			this.name = name;
-			this.age = age;
-		}
-
-		User() {
-		}
-
-		public String getName() {
-			return this.name;
-		}
-
-		public void setName(String name) {
-			this.name = name;
-		}
-
-		public Integer getAge() {
-			return this.age;
-		}
-
-		public void setAge(Integer age) {
-			this.age = age;
-		}
-
-		@Override
-		public String toString() {
-			return "User{" +
-					"name='" + this.name + '\'' +
-					", age=" + this.age +
-					'}';
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-			User user = (User) o;
-			return Objects.equals(getName(), user.getName()) &&
-					Objects.equals(getAge(), user.getAge());
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(getName(), getAge());
-		}
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.firestore.it;
+
+import java.io.IOException;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firestore.v1.FirestoreGrpc;
+import io.grpc.CallCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.auth.MoreCallCredentials;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
+import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingContext;
+import org.springframework.cloud.gcp.data.firestore.repository.config.EnableReactiveFirestoreRepositories;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Spring config for the integration tests.
+ */
+@Configuration
+@PropertySource("application-test.properties")
+@EnableReactiveFirestoreRepositories
+public class FirestoreIntegrationTestsConfiguration {
+	@Value("projects/${test.integration.firestore.project-id}/databases/(default)/documents")
+	String defaultParent;
+
+	@Bean
+	public FirestoreTemplate firestoreTemplate() throws IOException {
+		GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+		CallCredentials callCredentials = MoreCallCredentials.from(credentials);
+
+		// Create a channel
+		ManagedChannel channel = ManagedChannelBuilder
+				.forAddress("firestore.googleapis.com", 443)
+				.build();
+
+		return new FirestoreTemplate(FirestoreGrpc.newStub(channel).withCallCredentials(callCredentials),
+				defaultParent);
+	}
+
+	@Bean
+	public FirestoreMappingContext firestoreMappingContext() {
+		return new FirestoreMappingContext();
+	}
+}

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -54,7 +54,7 @@ public class FirestoreRepositoryIntegrationTests {
 				System.getProperty("it.firestore"), is("true"));
 
 		ch.qos.logback.classic.Logger root =
-        (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.grpc.netty");
+				(ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.grpc.netty");
 		root.setLevel(Level.INFO);
 	}
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.firestore.it;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.Level;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
+import org.springframework.cloud.gcp.data.firestore.User;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = FirestoreIntegrationTestsConfiguration.class)
+public class FirestoreRepositoryIntegrationTests {
+
+	@Autowired
+	FirestoreTemplate firestoreTemplate;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@BeforeClass
+	public static void checkToRun() throws IOException {
+		assumeThat(
+				"Firestore-sample tests are disabled. Please use '-Dit.firestore=true' "
+						+ "to enable them. ",
+				System.getProperty("it.firestore"), is("true"));
+
+		ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.grpc.netty");
+		root.setLevel(Level.INFO);
+	}
+
+	@Before
+	public void cleanTestEnvironment() {
+		this.firestoreTemplate.deleteAll(User.class).block();
+	}
+
+	@Test
+	public void countTest() {
+		Flux<User> users = Flux.create(sink -> {
+			for (int i = 1; i < 10; i++) {
+				sink.next(new User("blah-person" + i, i));
+			}
+			sink.complete();
+		});
+
+		this.firestoreTemplate.saveAll(users).blockLast();
+
+		long count = this.userRepository.countByAgeIsGreaterThan(5).block();
+		assertThat(count).isEqualTo(4);
+	}
+}

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -17,13 +17,12 @@
 package org.springframework.cloud.gcp.data.firestore.it;
 
 import java.io.IOException;
+import java.util.stream.IntStream;
 
-import ch.qos.logback.classic.Level;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,10 +51,6 @@ public class FirestoreRepositoryIntegrationTests {
 				"Firestore-sample tests are disabled. Please use '-Dit.firestore=true' "
 						+ "to enable them. ",
 				System.getProperty("it.firestore"), is("true"));
-
-		ch.qos.logback.classic.Logger root =
-				(ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.grpc.netty");
-		root.setLevel(Level.INFO);
 	}
 
 	@Before
@@ -65,12 +60,8 @@ public class FirestoreRepositoryIntegrationTests {
 
 	@Test
 	public void countTest() {
-		Flux<User> users = Flux.create(sink -> {
-			for (int i = 1; i < 10; i++) {
-				sink.next(new User("blah-person" + i, i));
-			}
-			sink.complete();
-		});
+		Flux<User> users = Flux.fromStream(IntStream.range(1, 10).boxed())
+				.map(n -> new User("blah-person" + n, n));
 
 		this.firestoreTemplate.saveAll(users).blockLast();
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -53,7 +53,8 @@ public class FirestoreRepositoryIntegrationTests {
 						+ "to enable them. ",
 				System.getProperty("it.firestore"), is("true"));
 
-		ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.grpc.netty");
+		ch.qos.logback.classic.Logger root =
+        (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.grpc.netty");
 		root.setLevel(Level.INFO);
 	}
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/UserRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/UserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2019 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,25 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.gcp.data.firestore;
+package org.springframework.cloud.gcp.data.firestore.it;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.gcp.data.firestore.FirestoreReactiveRepository;
+import org.springframework.cloud.gcp.data.firestore.User;
 
 /**
  * A test custom repository.
  *
  * @author Chengyuan Zhao
  */
-public interface UserRepository extends FirestoreReactiveRepository<FirestoreIntegrationTests.User> {
-	Flux<FirestoreIntegrationTests.User> findByAge(Integer age);
+public interface UserRepository extends FirestoreReactiveRepository<User> {
+	Flux<User> findByAge(Integer age);
 
-	Flux<FirestoreIntegrationTests.User> findByAgeAndName(Integer age, String name);
+	Flux<User> findByAgeAndName(Integer age, String name);
 
-	Flux<FirestoreIntegrationTests.User> findByAgeGreaterThan(Integer age);
+	Flux<User> findByAgeGreaterThan(Integer age);
+
+	Mono<Long> countByAgeIsGreaterThan(Integer age);
 }

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 public class PartTreeFirestoreQueryTests {
 
 	private static final User DUMMY_USER = new User("Hello", 23);
-	private static final Consumer<InvocationOnMock> NOOP = invocation -> {};
+	private static final Consumer<InvocationOnMock> NOOP = invocation -> { };
 
 	private final FirestoreTemplate firestoreTemplate = mock(FirestoreTemplate.class);
 	private final QueryMethod queryMethod = mock(QueryMethod.class);

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
@@ -23,10 +23,11 @@ import com.google.firestore.v1.StructuredQuery;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gcp.data.firestore.FirestoreDataException;
-import org.springframework.cloud.gcp.data.firestore.FirestoreIntegrationTests;
 import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
+import org.springframework.cloud.gcp.data.firestore.User;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingContext;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.ResultProcessor;
@@ -39,9 +40,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PartTreeFirestoreQueryTests {
+
+	private static final User DUMMY_USER = new User("Hello", 23);
+	private static final Consumer<InvocationOnMock> NOOP = invocation -> {};
+
 	private final FirestoreTemplate firestoreTemplate = mock(FirestoreTemplate.class);
 	private final QueryMethod queryMethod = mock(QueryMethod.class);
-	private static final Consumer<InvocationOnMock> NOOP = invocation -> { };
 
 	@Test
 	public void testPartTreeQuery() {
@@ -72,11 +76,18 @@ public class PartTreeFirestoreQueryTests {
 			builder.setWhere(StructuredQuery.Filter.newBuilder().setCompositeFilter(compositeFilter.build()));
 			assertThat(actualBuilder.build()).isEqualTo(builder.build());
 
-			assertThat(clazz).isEqualTo(FirestoreIntegrationTests.User.class);
+			assertThat(clazz).isEqualTo(User.class);
 		});
 
 		partTreeFirestoreQuery.execute(new Object[]{22});
+	}
 
+	@Test
+	public void testPartTreeQueryCount() {
+		PartTreeFirestoreQuery partTreeFirestoreQuery = createPartTreeQuery("countByAgeGreaterThan", NOOP);
+
+		Mono<Long> count = (Mono<Long>) partTreeFirestoreQuery.execute(new Object[] { 22 });
+		assertThat(count.block()).isEqualTo(1);
 	}
 
 	@Test
@@ -113,12 +124,12 @@ public class PartTreeFirestoreQueryTests {
 	private PartTreeFirestoreQuery createPartTreeQuery(String methodName, Consumer<InvocationOnMock> validator) {
 		when(this.firestoreTemplate.execute(any(), any())).thenAnswer(invocation -> {
 			validator.accept(invocation);
-			return Flux.empty();
+			return Flux.just(DUMMY_USER);
 		});
 
 		when(this.queryMethod.getName()).thenReturn(methodName);
 		ReturnedType returnedType = mock(ReturnedType.class);
-		when(returnedType.getDomainType()).thenAnswer(invocation -> FirestoreIntegrationTests.User.class);
+		when(returnedType.getDomainType()).thenAnswer(invocation -> User.class);
 		ResultProcessor resultProcessor = mock(ResultProcessor.class);
 		when(resultProcessor.getReturnedType()).thenReturn(returnedType);
 		when(this.queryMethod.getResultProcessor()).thenReturn(resultProcessor);


### PR DESCRIPTION
Adds check to see if the PartTree query is a `count` and then call `.count()` in those cases.

Fixes #1884.

Notes: had to refactor some tests to add tests for this feature.