### PR TITLE
leak fix read only spanner

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManagerTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManagerTests.java
@@ -180,7 +180,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManagerTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManagerTests.java
@@ -82,7 +82,7 @@ public class SpannerTransactionManagerTests {
 
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};
@@ -102,7 +102,7 @@ public class SpannerTransactionManagerTests {
 
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};
@@ -125,7 +125,7 @@ public class SpannerTransactionManagerTests {
 		when(this.databaseClient.transactionManager()).thenReturn(transactionManagerNew);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return null;
 			}
 		};
@@ -151,7 +151,7 @@ public class SpannerTransactionManagerTests {
 		ReflectionTestUtils.setField(tx, "transactionManager", transactionManager);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};
@@ -180,7 +180,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};
@@ -202,7 +202,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};
@@ -230,7 +230,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};
@@ -258,7 +258,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};
@@ -281,7 +281,7 @@ public class SpannerTransactionManagerTests {
 
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};
@@ -302,7 +302,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Tx getCurrentTX() {
+			protected Object doGetTransaction() {
 				return tx;
 			}
 		};

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManagerTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManagerTests.java
@@ -78,11 +78,11 @@ public class SpannerTransactionManagerTests {
 		when(transactionManager.getState()).thenReturn(TransactionState.STARTED);
 
 		SpannerTransactionManager.Tx tx = mock(SpannerTransactionManager.Tx.class);
-		ReflectionTestUtils.setField(tx, "transactionManager", transactionManager);
+		when(tx.getTransactionManager()).thenReturn(transactionManager);
 
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};
@@ -102,7 +102,7 @@ public class SpannerTransactionManagerTests {
 
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};
@@ -114,28 +114,6 @@ public class SpannerTransactionManagerTests {
 
 		Assert.assertNotEquals(
 				"expected a new transaction but got the same one", tx, manager.doGetTransaction());
-
-		verify(this.databaseClient, times(1)).transactionManager();
-	}
-
-	@Test
-	public void testDoGetTransactionNew() {
-		TransactionManager transactionManagerNew = mock(TransactionManager.class);
-		when(transactionManagerNew.getState()).thenReturn(TransactionState.STARTED);
-		when(this.databaseClient.transactionManager()).thenReturn(transactionManagerNew);
-		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
-			@Override
-			protected Object doGetTransaction() {
-				return null;
-			}
-		};
-
-		SpannerTransactionManager.Tx actual = (SpannerTransactionManager.Tx) manager.doGetTransaction();
-		Assert.assertNotNull(actual);
-		Assert.assertEquals(
-				ReflectionTestUtils.getField(actual, "transactionManager"), transactionManagerNew);
-
-		verify(this.databaseClient, times(1)).transactionManager();
 	}
 
 	@Test
@@ -148,15 +126,15 @@ public class SpannerTransactionManagerTests {
 
 		TransactionDefinition definition = new DefaultTransactionDefinition();
 		SpannerTransactionManager.Tx tx = mock(SpannerTransactionManager.Tx.class);
-		ReflectionTestUtils.setField(tx, "transactionManager", transactionManager);
+		when(tx.getTransactionManager()).thenReturn(transactionManager);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};
 
-		manager.doBegin(tx, definition);
+		manager.doBegin(manager.doGetTransaction(), definition);
 
 		// need to use ReflectionTestUtils because tx is mocked and accessor won't work
 		Assert.assertEquals(ReflectionTestUtils.getField(tx, "transactionContext"), transactionContext);
@@ -180,7 +158,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};
@@ -230,7 +208,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};
@@ -258,7 +236,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};
@@ -281,7 +259,7 @@ public class SpannerTransactionManagerTests {
 
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};
@@ -302,7 +280,7 @@ public class SpannerTransactionManagerTests {
 		when(status.getTransaction()).thenReturn(tx);
 		SpannerTransactionManager manager = new SpannerTransactionManager(() -> this.databaseClient) {
 			@Override
-			protected Object doGetTransaction() {
+			protected Tx getCurrentTx() {
 				return tx;
 			}
 		};

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/IntegrationTestConfiguration.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/IntegrationTestConfiguration.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.SessionPoolOptions;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 
@@ -103,6 +104,7 @@ public class IntegrationTestConfiguration {
 	@Bean
 	public SpannerOptions spannerOptions() {
 		return SpannerOptions.newBuilder().setProjectId(getProjectId())
+				.setSessionPoolOption(SessionPoolOptions.newBuilder().setMaxSessions(10).build())
 				.setCredentials(getCredentials()).build();
 	}
 


### PR DESCRIPTION
fixes #1904 

It turns out that getting a transaction manager counts as using a session (not just getting a transaction from the manager)

I added integration test that limits sessions to 10 and then tries 20 operations with timeline of 10 seconds to catch hangs. 