### PR TITLE
Remove flaky assertion from BigQuery Integration Test

### DIFF
--- a/spring-cloud-gcp-bigquery/src/test/java/org/springframework/cloud/gcp/bigquery/integration/outbound/BigQueryFileMessageHandlerIntegrationTests.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/org/springframework/cloud/gcp/bigquery/integration/outbound/BigQueryFileMessageHandlerIntegrationTests.java
@@ -156,7 +156,6 @@ public class BigQueryFileMessageHandlerIntegrationTests {
 		ListenableFuture<Job> jobFuture =
 				(ListenableFuture<Job>) this.messageHandler.handleRequestMessage(message);
 		jobFuture.cancel(true);
-		assertThat(this.taskScheduler.getScheduledThreadPoolExecutor().getQueue()).hasSize(1);
 
 		await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
 			// This asserts that the BigQuery job polling task is no longer in the scheduler after cancel.


### PR DESCRIPTION
Removes flaky assertion from BigQuery integration test.

Low level details: The thread checking the bigquery job may get cancelled (causing the `queue.size() == 0`) before assertion is run. Thus, just remove it and verify that it ends being `queue.size() == 0`; this is the real important condition to check.