### PR TITLE
Provide a fake stream function definition to prevent autodiscovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,7 @@ before_install:
           -Dgcs-resource-test-bucket=gcp-storage-resource-bucket-sample
           -Dgcs-read-bucket=gcp-storage-bucket-sample-input
           -Dgcs-write-bucket=gcp-storage-bucket-sample-output
-          -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample
-          -Dspring.cloud.stream.function.definition=none";
+          -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample";
       export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/travis/admin.json;
       export GOOGLE_CLOUD_PROJECT=spring-cloud-gcp-ci;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ before_install:
           -Dgcs-resource-test-bucket=gcp-storage-resource-bucket-sample
           -Dgcs-read-bucket=gcp-storage-bucket-sample-input
           -Dgcs-write-bucket=gcp-storage-bucket-sample-output
-          -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample";
+          -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample
+          -Dspring.cloud.stream.function.definition=none";
       export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/travis/admin.json;
       export GOOGLE_CLOUD_PROJECT=spring-cloud-gcp-ci;
     fi;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.cloud.stream.bindings.output.destination=[PUBSUB_TOPIC_NAME]
 
 #spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
 #spring.cloud.gcp.credentials.location=file:[LOCAL_PATH_TO_CREDENTIALS]
+
+# Temporary workaround for https://github.com/spring-cloud/spring-cloud-function/issues/409
+spring.cloud.stream.function.definition=none


### PR DESCRIPTION
This prevents `pubSubReactiveScheduler` from being identified as a valid Spring Cloud Stream function provider. 