### PR TITLE
Disable spring cloud stream autodiscovery in polled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,7 @@ before_install:
           -Dgcs-resource-test-bucket=gcp-storage-resource-bucket-sample
           -Dgcs-read-bucket=gcp-storage-bucket-sample-input
           -Dgcs-write-bucket=gcp-storage-bucket-sample-output
-          -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample
-          -Dspring.cloud.stream.function.definition=none";
+          -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample";
       export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/travis/admin.json;
       export GOOGLE_CLOUD_PROJECT=spring-cloud-gcp-ci;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ before_install:
           -Dgcs-resource-test-bucket=gcp-storage-resource-bucket-sample
           -Dgcs-read-bucket=gcp-storage-bucket-sample-input
           -Dgcs-write-bucket=gcp-storage-bucket-sample-output
-          -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample";
+          -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample
+          -Dspring.cloud.stream.function.definition=none";
       export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/travis/admin.json;
       export GOOGLE_CLOUD_PROJECT=spring-cloud-gcp-ci;
     fi;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-polling-binder-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-polling-binder-sample/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.cloud.stream.bindings.output.destination=[PUBSUB_TOPIC_NAME]
 
 #spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
 #spring.cloud.gcp.credentials.location=file:[LOCAL_PATH_TO_CREDENTIALS]
+
+# Temporary workaround for https://github.com/spring-cloud/spring-cloud-function/issues/409
+spring.cloud.stream.function.definition=none


### PR DESCRIPTION
There are two issues in this sample that are both temporarily addressed by specifying the function explicitly.
1) reactor scheduler being identified as supplier.
2) We might have to rename "input" to "polled-source" or something because "input" is now expected to be only a subscribable channel.
 ```
Bean named 'input' is expected to be of type 'org.springframework.messaging.SubscribableChannel' but was actually of type 'org.springframework.cloud.stream.binder.DefaultPollableMessageSource'
 ```