### PR TITLE
Implement collection name inference for Firestore Entities

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImpl.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImpl.java
@@ -21,6 +21,7 @@ import org.springframework.cloud.gcp.data.firestore.FirestoreDataException;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.mapping.model.BasicPersistentEntity;
 import org.springframework.data.util.TypeInformation;
+import org.springframework.util.StringUtils;
 
 /**
  * Metadata class for entities stored in Datastore.
@@ -33,19 +34,16 @@ public class FirestorePersistentEntityImpl<T>
 		extends BasicPersistentEntity<T, FirestorePersistentProperty>
 		implements FirestorePersistentEntity<T> {
 
+	private final String collectionName;
 
 	public FirestorePersistentEntityImpl(TypeInformation<T> information) {
 		super(information);
+		this.collectionName = getEntityCollectionName(information);
 	}
 
 	@Override
 	public String collectionName() {
-		Entity entity = AnnotationUtils.findAnnotation(getType(), Entity.class);
-		String collectionName = (String) AnnotationUtils.getValue(entity, "collectionName");
-		if (collectionName == null || collectionName.isEmpty()) {
-			throw new FirestoreDataException("Entities should be annotated with @Entity and have a collection name");
-		}
-		return collectionName;
+	  return this.collectionName;
 	}
 
 	@Override
@@ -56,5 +54,17 @@ public class FirestorePersistentEntityImpl<T>
 							+ getType());
 		}
 		return getIdProperty();
+	}
+
+	private static <T> String getEntityCollectionName(TypeInformation<T> typeInformation) {
+		Entity entity = AnnotationUtils.findAnnotation(typeInformation.getType(), Entity.class);
+		String collectionName = (String) AnnotationUtils.getValue(entity, "collectionName");
+
+		if (collectionName == null || collectionName.isEmpty()) {
+			// Infer the collection name as the lowercase entity name.
+			return StringUtils.uncapitalize(typeInformation.getType().getSimpleName());
+		} else {
+			return collectionName;
+		}
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImplTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.firestore.mapping;
+
+import org.junit.Test;
+import org.springframework.cloud.gcp.data.firestore.Entity;
+import org.springframework.data.util.ClassTypeInformation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link FirestorePersistentEntityImpl}.
+ *
+ * @author Daniel Zou
+ */
+public class FirestorePersistentEntityImplTests {
+
+	@Test
+	public void testSetCollectionName() {
+		FirestorePersistentEntity<Student> firestorePersistentEntity =
+				new FirestorePersistentEntityImpl<>(ClassTypeInformation.from(Student.class));
+		assertThat(firestorePersistentEntity.collectionName()).isEqualTo("student");
+	}
+
+	@Test
+	public void testInferCollectionName() {
+		FirestorePersistentEntity<Employee> firestorePersistentEntity =
+				new FirestorePersistentEntityImpl<>(ClassTypeInformation.from(Employee.class));
+		assertThat(firestorePersistentEntity.collectionName()).isEqualTo("employee_table");
+	}
+
+	@Entity
+	private static class Student {
+	}
+
+	@Entity(collectionName = "employee_table")
+	private static class Employee {
+	}
+}


### PR DESCRIPTION
This makes it so that if the user omits the `collectionName` from the Entity annotation, we will infer the collection name as the lower-cased name of the class.

Fixes #1787.