### PR TITLE
1.1.x: Make Trace Sender thread pool Spring-managed bean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ git:
   depth: 9999999
 jdk:
   - oraclejdk8
-env:
-  global:
-    - GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/travis/admin.json
-    - GOOGLE_CLOUD_PROJECT=spring-cloud-gcp-ci
+dist: trusty
 branches:
   only:
     - master
@@ -35,12 +32,12 @@ script:
       ./mvnw test -B -P codecov ${INTEGRATION_TEST_FLAGS} && bash <(curl -s https://codecov.io/bash) -F integration;
     fi;
 install:
-  - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -B -V
 before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;
       tar -xzf travis.tar.gz;
-      INTEGRATION_TEST_FLAGS="-Dit.pubsub-emulator=true -Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
+      export INTEGRATION_TEST_FLAGS="-Dit.pubsub-emulator=true -Dit.spanner=true -Dit.storage=true -Dit.config=true -Dit.pubsub=true -Dit.logging=true
           -Dit.cloudsql=true -Dit.datastore=true -Dit.trace=true -Dit.kotlin=true
           -Dspring.cloud.gcp.sql.instance-connection-name=spring-cloud-gcp-ci:us-central1:testmysql
           -Dspring.cloud.gcp.sql.database-name=code_samples_test_db
@@ -49,8 +46,9 @@ before_install:
           -Dgcs-read-bucket=gcp-storage-bucket-sample-input
           -Dgcs-write-bucket=gcp-storage-bucket-sample-output
           -Dgcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample";
+      export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/travis/admin.json;
+      export GOOGLE_CLOUD_PROJECT=spring-cloud-gcp-ci;
     fi;
-    export INTEGRATION_TEST_FLAGS;
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   - source $HOME/google-cloud-sdk/path.bash.inc
   - gcloud components update --quiet

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.gcp.autoconfigure.trace;
 
 import java.io.IOException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import brave.http.HttpClientParser;
@@ -62,6 +61,7 @@ import org.springframework.cloud.sleuth.sampler.SamplerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * Config for Stackdriver Trace.
@@ -119,10 +119,18 @@ public class StackdriverTraceAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(name = "traceSenderThreadPool")
+	public ThreadPoolTaskScheduler traceSenderThreadPool(GcpTraceProperties traceProperties) {
+		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+		scheduler.setPoolSize(traceProperties.getNumExecutorThreads());
+		scheduler.setThreadNamePrefix("gcp-trace-sender");
+		return scheduler;
+	}
+
+	@Bean
 	@ConditionalOnMissingBean(name = "traceExecutorProvider")
-	public ExecutorProvider traceExecutorProvider(GcpTraceProperties traceProperties) {
-		return FixedExecutorProvider.create(
-				Executors.newScheduledThreadPool(traceProperties.getNumExecutorThreads()));
+	public ExecutorProvider traceExecutorProvider(@Qualifier("traceSenderThreadPool") ThreadPoolTaskScheduler scheduler) {
+		return FixedExecutorProvider.create(scheduler.getScheduledExecutor());
 	}
 
 	@Bean(destroyMethod = "shutdownNow")


### PR DESCRIPTION
Applies #1927 fix to 1.1.x branch.

This resolves the problem of the thread pool not being properly closed
when the application context closes.

Fixes: #1506.
Fixes: #1925.