### PR TITLE
1.1.x: bring in latest version of brave

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
 		<spring-cloud-sleuth.version>2.1.4.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Fishtown.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.9.0</zipkin-gcp.version>
+		<!-- this is a temporary workaround until we upgrade to the latest zipkin-sender-stackdriver -->
+		<brave.version>5.7.0</brave.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
 	</properties>
@@ -107,8 +109,19 @@
 				<groupId>io.zipkin.gcp</groupId>
 				<artifactId>brave-propagation-stackdriver</artifactId>
 				<version>${zipkin-gcp.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>io.zipkin.brave</groupId>
+						<artifactId>brave</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
+			<dependency>
+				<groupId>io.zipkin.brave</groupId>
+				<artifactId>brave</artifactId>
+				<version>${brave.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
Backport of #1864 to 1.1.x branch.