### PR TITLE
Add error propagation for pubsub stream binder

### DIFF
--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -76,7 +76,11 @@ The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `Ac
 Automatic acking (`AckMode.AUTO`)
 
 A message is acked with GCP Pub/Sub if the adapter sent it to the channel and no exceptions were thrown.
-If a `RuntimeException` is thrown while the message is processed, then the message is nacked.
+
+If a `RuntimeException` is thrown while the message is processed, then the message is handled in the following way:
+
+* If an error channel is configured for the adapter (`pubSubInboundChannelAdapater.getErrorChannel() != null`) then the message will be acked and forwarded with the error to the error channel.
+* If no error channel is configured for the adapter, then the message is n'acked.
 
 Automatic acking OK (`AckMode.AUTO_ACK`)
 

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -80,7 +80,7 @@ A message is acked with GCP Pub/Sub if the adapter sent it to the channel and no
 If a `RuntimeException` is thrown while the message is processed, then the message is handled in the following way:
 
 * If an error channel is configured for the adapter (`pubSubInboundChannelAdapater.getErrorChannel() != null`) then the message will be acked and forwarded with the error to the error channel.
-* If no error channel is configured for the adapter, then the message is n'acked.
+* If no error channel is configured for the adapter, then the message is nacked.
 
 Automatic acking OK (`AckMode.AUTO_ACK`)
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -80,7 +80,13 @@ public class PubSubMessageChannelBinder
 	protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group,
 			ExtendedConsumerProperties<PubSubConsumerProperties> properties) {
 
-		return new PubSubInboundChannelAdapter(this.pubSubTemplate, destination.getName());
+		PubSubInboundChannelAdapter adapter = new PubSubInboundChannelAdapter(this.pubSubTemplate,
+				destination.getName());
+
+		ErrorInfrastructure errorInfrastructure = registerErrorInfrastructure(destination, group, properties);
+		adapter.setErrorChannel(errorInfrastructure.getErrorChannel());
+
+		return adapter;
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -90,6 +90,12 @@ public class PubSubMessageChannelBinder
 	}
 
 	@Override
+	protected String errorsBaseName(
+			ConsumerDestination destination, String group, ExtendedConsumerProperties<PubSubConsumerProperties> properties) {
+		return destination.getName() + ".errors";
+	}
+
+	@Override
 	public PubSubConsumerProperties getExtendedConsumerProperties(String channelName) {
 		return this.pubSubExtendedBindingProperties.getExtendedConsumerProperties(channelName);
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -153,7 +153,14 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 		}
 		catch (RuntimeException re) {
 			if (this.ackMode == AckMode.AUTO) {
-				message.nack();
+				if (getErrorChannel() != null) {
+					// If the error channel is present, acknowledge the message.
+					// It gets forwarded to the error channel once PubSubException is thrown.
+					message.ack();
+				}
+				else {
+					message.nack();
+				}
 			}
 			throw new PubSubException("Sending Spring message failed.", re);
 		}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -161,10 +161,8 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 			throw new PubSubException("Sending Spring message failed.", re);
 		}
 		finally {
-			if (this.ackMode == AckMode.AUTO || this.ackMode == AckMode.AUTO_ACK) {
-				if (!messageNacked) {
-					message.ack();
-				}
+			if (!messageNacked && (this.ackMode == AckMode.AUTO || this.ackMode == AckMode.AUTO_ACK)) {
+				message.ack();
 			}
 		}
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/README.adoc
@@ -1,8 +1,12 @@
 = Spring Cloud GCP Stream Binder for Pub/Sub Code Sample
 
 This code sample demonstrates how to use the Spring Cloud Stream binder for Google Cloud Pub/Sub.
+
 The sample app prompts a user for a message and their user name.
 That data is added to a `UserMessage` object, together with the time of message creation, and is sent through Google Cloud Pub/Sub to a sink which simply logs the message.
+
+Additionally, you may specify the setting `throwError` through the app.
+If set to true, this will trigger an exception in the message handler and demonstrate how messages will be forwarded to the error channel.
 
 If the topic for the sink and source does not exist, the binder will automatically create them in Google Cloud Pub/Sub based on the values in link:src/main/resources/application.properties[application.properties].
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/README.adoc
@@ -20,10 +20,11 @@ Alternatively, if you have the https://cloud.google.com/sdk/[Google Cloud SDK] i
 
 2. Set your project ID using the `spring.cloud.gcp.project-id` property in link:src/main/resources/application.properties[application.properties] or use the `gcloud config set project [PROJECT_ID]` Cloud SDK command.
 
-3. Set the topic and, optionally, group name in the link:src/main/resources/application.properties[application.properties] file.
+3. In the link:src/main/resources/application.properties[application.properties] file, a topic and group name is already preconfigured for you.
+The topic will be created in your account if it does not already exist.
 +
-You can rely on the binder to create the topic and subscription, or you can create them manually from the https://console.cloud.google.com/cloudpubsub[Google Cloud Console].
-If you create the subscription manually, make sure it follows the naming convention of `<topicName>.<consumerGroup>`.
+Setting the topic name and group allows you to configure error handling for your Pub/Sub binder.
+An error handler is configured in link:src/main/java/com/example/SinkExample.java[SinkExample.java].
 
 4. Run the `mvn clean spring-boot:run` in the root of the code sample to get the app running.
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
@@ -48,7 +48,7 @@ public class SinkExample {
 
 	// Note that the error inputChannel is formatted as [Pub/Sub subscription name with group].[group name].errors
 	// If you change the topic name in application.properties, you also have to change the inputChannel below.
-	@ServiceActivator(inputChannel = "my-topic.my-group.my-group.errors")
+	@ServiceActivator(inputChannel = "my-topic.my-group.errors")
 	public void error(Message<MessagingException> message) {
 		LOGGER.error("The message that was sent is now processed by the error handler.");
 		LOGGER.error("Failed message: " + message.getPayload().getFailedMessage());

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
@@ -22,6 +22,8 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 
 /**
  * Example of a sink for the sample app.
@@ -35,7 +37,17 @@ public class SinkExample {
 
 	@StreamListener(Sink.INPUT)
 	public void handleMessage(UserMessage userMessage) {
+		if (userMessage.isThrowError()) {
+			throw new RuntimeException("An error was triggered in the message handler!");
+		}
+
 		LOGGER.info("New message received from " + userMessage.getUsername() + ": " + userMessage.getBody() +
 				" at " + userMessage.getCreatedAt());
+	}
+
+	@StreamListener("errorChannel")
+	public void handleErrorMessage(Message<MessagingException> message) {
+		LOGGER.error("The message that was sent is now processed by the error handler.");
+		LOGGER.error("Failed message: " + message.getPayload().getFailedMessage());
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
@@ -21,7 +21,9 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 
@@ -45,8 +47,10 @@ public class SinkExample {
 				" at " + userMessage.getCreatedAt());
 	}
 
-	@StreamListener("errorChannel")
-	public void handleErrorMessage(Message<MessagingException> message) {
+	// Note that the error inputChannel is formatted as [Pub/Sub subscription name with group].[group name].errors
+	// If you change the topic name in application.properties, you also have to change the inputChannel below.
+	@ServiceActivator(inputChannel = "my-topic.my-group.my-group.errors")
+	public void error(Message<MessagingException> message) {
 		LOGGER.error("The message that was sent is now processed by the error handler.");
 		LOGGER.error("Failed message: " + message.getPayload().getFailedMessage());
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
@@ -21,7 +21,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SourceExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SourceExample.java
@@ -39,9 +39,11 @@ public class SourceExample {
 	private Source source;
 
 	@PostMapping("/newMessage")
-	public UserMessage sendMessage(@RequestParam("messageBody") String messageBody,
-			@RequestParam("username") String username) {
-		UserMessage userMessage = new UserMessage(messageBody, username, LocalDateTime.now());
+	public UserMessage sendMessage(
+			@RequestParam("messageBody") String messageBody,
+			@RequestParam("username") String username,
+			@RequestParam("throwError") boolean shouldThrowError) {
+		UserMessage userMessage = new UserMessage(messageBody, username, LocalDateTime.now(), shouldThrowError);
 		this.source.output().send(new GenericMessage<>(userMessage));
 		return userMessage;
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/UserMessage.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/UserMessage.java
@@ -31,13 +31,16 @@ public class UserMessage {
 
 	private LocalDateTime createdAt;
 
+	private boolean throwError;
+
 	public UserMessage() {
 	}
 
-	public UserMessage(String body, String username, LocalDateTime createdAt) {
+	public UserMessage(String body, String username, LocalDateTime createdAt, boolean throwError) {
 		this.body = body;
 		this.username = username;
 		this.createdAt = createdAt;
+		this.throwError = throwError;
 	}
 
 	public String getBody() {
@@ -62,5 +65,13 @@ public class UserMessage {
 
 	public void setCreatedAt(LocalDateTime createdAt) {
 		this.createdAt = createdAt;
+	}
+
+	public boolean isThrowError() {
+		return throwError;
+	}
+
+	public void setThrowError(boolean throwError) {
+		this.throwError = throwError;
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.cloud.stream.bindings.input.destination=[PUBSUB_TOPIC_NAME]
 spring.cloud.stream.bindings.output.destination=[PUBSUB_TOPIC_NAME]
 
 # If group is specified, the Pub/Sub subscription name will be [PUBSUB_TOPIC_NAME].[PUBSUB_GROUP_NAME]
-#spring.cloud.stream.bindings.input.group=[PUBSUB_GROUP_NAME]
+spring.cloud.stream.bindings.input.group=my-group
 
 #spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
 #spring.cloud.gcp.credentials.location=file:[LOCAL_PATH_TO_CREDENTIALS]

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-spring.cloud.stream.bindings.input.destination=[PUBSUB_TOPIC_NAME]
-spring.cloud.stream.bindings.output.destination=[PUBSUB_TOPIC_NAME]
+spring.cloud.stream.bindings.input.destination=my-topic
+spring.cloud.stream.bindings.output.destination=my-topic
 
 # If group is specified, the Pub/Sub subscription name will be [PUBSUB_TOPIC_NAME].[PUBSUB_GROUP_NAME]
 spring.cloud.stream.bindings.input.group=my-group

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/static/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/static/index.html
@@ -12,7 +12,7 @@
 
         Throw Error? (triggers the error handler)
         <select name="throwError">
-            <option value="false">false</option>
+            <option value="false" selected>false</option>
             <option value="true">true</option>
         </select>
         <br/>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/static/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/resources/static/index.html
@@ -9,6 +9,14 @@
     <form action="/newMessage" method="post">
         Message body: <input type="text" name="messageBody" /><br/>
         Username: <input type="text" name="username" /><br/>
+
+        Throw Error? (triggers the error handler)
+        <select name="throwError">
+            <option value="false">false</option>
+            <option value="true">true</option>
+        </select>
+        <br/>
+
         <input type="submit" value="Post it!"/>
     </form>
 </body>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/test/java/com/example/SampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/test/java/com/example/SampleAppIntegrationTest.java
@@ -49,8 +49,9 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
-		"spring.cloud.stream.bindings.input.destination=sub1",
-		"spring.cloud.stream.bindings.output.destination=sub1" })
+		"spring.cloud.stream.bindings.input.destination=my-topic",
+		"spring.cloud.stream.bindings.output.destination=my-topic",
+		"spring.cloud.stream.bindings.input.group=my-group"})
 @DirtiesContext
 public class SampleAppIntegrationTest {
 


### PR DESCRIPTION
Adds error propagation for the pub/sub stream binder.

Note that with error handling, I modified the ack'ing logic of the `PubSubInboundChannelAdapter` to ack messages and forward them to an error channel if an errorChannel is initialized for the adapter. Spring typically initializes an error channel for the adapter if it is created through Spring autoconfiguration.

Details:

If AckMode.AUTO is set:

If a RuntimeException is thrown while the message is processed, then the message is handled in the following way:

* If an error channel is configured for the adapter (pubSubInboundChannelAdapater.getErrorChannel() != null) then the message will be acked and forwarded with the error to the error channel.
* If no error channel is configured for the adapter, then the message is n’acked.

If Automatic acking OK (AckMode.AUTO_ACK) is set:

* No change to existing behavior.

If Manually acking (AckMode.MANUAL) is set:

* No change to existing behavior.

Fixes #1938.
