### PR TITLE
use @DocumentId and @Document annotations

### DIFF
--- a/docs/src/main/asciidoc/firestore.adoc
+++ b/docs/src/main/asciidoc/firestore.adoc
@@ -81,15 +81,16 @@ Spring Data Cloud Firestore allows you to map domain POJOs to https://firebase.g
 [source,java,indent=0]
 ----
 import org.springframework.data.annotation.Id;
-import org.springframework.cloud.gcp.data.firestore.Entity;
+import org.springframework.cloud.gcp.data.firestore.Document;
 
 include::../../../../spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java[tag=class_definition]
 
 ----
 
-`@Entity(collectionName = "usersCollection")` annotation configures the collection name for the documents of this type.
+`@Document(collectionName = "usersCollection")` annotation configures the collection name for the documents of this type.
+This annotation is optional, by default the collection name is derived from the class name.
 
-`@Id` annotation marks a field to be used as document id. This annotation is required.
+`@DocumentId` annotation marks a field to be used as document id. This annotation is required.
 
 NOTE: Internally we use Firestore client library object mapping. See https://developers.google.com/android/reference/com/google/firebase/firestore/package-summary[the documentation] for supported annotations.
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
@@ -117,7 +117,7 @@ public class GcpDatastoreEmulatorIntegrationTests {
 	}
 
 	/**
-	 * Entity to be stored on Datastore. An instance of `LocalDatastoreHelper` as a bean.
+	 * Document to be stored on Datastore. An instance of `LocalDatastoreHelper` as a bean.
 	 */
 	@org.springframework.cloud.gcp.data.datastore.core.mapping.Entity
 	static class EmulatorEntityTest {

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/Document.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/Document.java
@@ -24,7 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for a class that represents a Firestore Entity.
+ * Annotation for a class that represents a Firestore Document.
  *
  * @author Dmitry Solomakha
  *
@@ -33,12 +33,12 @@ import java.lang.annotation.Target;
 @Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Entity {
+public @interface Document {
 
 	/**
-	 * The collection name of the Entity in Firestore, which can differ from the name of the
+	 * The collection name of the Document in Firestore, which can differ from the name of the
 	 * class which it annotates.
-	 * @return The Collection name of the Entity
+	 * @return The Collection name of the Document
 	 */
 	String collectionName() default "";
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImpl.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImpl.java
@@ -70,24 +70,4 @@ public class FirestorePersistentEntityImpl<T>
 			return collectionName;
 		}
 	}
-
-	@Override
-	public void addPersistentProperty(FirestorePersistentProperty property) {
-		super.addPersistentProperty(property);
-
-		if (property.isDocumemtId()) {
-			this.idProperty = property;
-		}
-	}
-
-	@Override
-	public FirestorePersistentProperty getIdProperty() {
-		return this.idProperty;
-	}
-
-	@Override
-	public boolean hasIdProperty() {
-		return this.idProperty != null;
-	}
-
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImpl.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImpl.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.gcp.data.firestore.mapping;
 
-import org.springframework.cloud.gcp.data.firestore.Entity;
+import org.springframework.cloud.gcp.data.firestore.Document;
 import org.springframework.cloud.gcp.data.firestore.FirestoreDataException;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.mapping.model.BasicPersistentEntity;
@@ -35,6 +35,8 @@ public class FirestorePersistentEntityImpl<T>
 		implements FirestorePersistentEntity<T> {
 
 	private final String collectionName;
+
+	private FirestorePersistentProperty idProperty;
 
 	public FirestorePersistentEntityImpl(TypeInformation<T> information) {
 		super(information);
@@ -57,15 +59,35 @@ public class FirestorePersistentEntityImpl<T>
 	}
 
 	private static <T> String getEntityCollectionName(TypeInformation<T> typeInformation) {
-		Entity entity = AnnotationUtils.findAnnotation(typeInformation.getType(), Entity.class);
-		String collectionName = (String) AnnotationUtils.getValue(entity, "collectionName");
+		Document document = AnnotationUtils.findAnnotation(typeInformation.getType(), Document.class);
+		String collectionName = (String) AnnotationUtils.getValue(document, "collectionName");
 
 		if (StringUtils.isEmpty(collectionName)) {
-			// Infer the collection name as the uncapitalized entity name.
+			// Infer the collection name as the uncapitalized document name.
 			return StringUtils.uncapitalize(typeInformation.getType().getSimpleName());
 		}
 		else {
 			return collectionName;
 		}
 	}
+
+	@Override
+	public void addPersistentProperty(FirestorePersistentProperty property) {
+		super.addPersistentProperty(property);
+
+		if (property.isDocumemtId()) {
+			this.idProperty = property;
+		}
+	}
+
+	@Override
+	public FirestorePersistentProperty getIdProperty() {
+		return this.idProperty;
+	}
+
+	@Override
+	public boolean hasIdProperty() {
+		return this.idProperty != null;
+	}
+
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentProperty.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentProperty.java
@@ -28,4 +28,5 @@ import org.springframework.data.mapping.PersistentProperty;
 public interface FirestorePersistentProperty
 		extends PersistentProperty<FirestorePersistentProperty> {
 
+	boolean isDocumemtId();
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentProperty.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentProperty.java
@@ -27,6 +27,4 @@ import org.springframework.data.mapping.PersistentProperty;
  */
 public interface FirestorePersistentProperty
 		extends PersistentProperty<FirestorePersistentProperty> {
-
-	boolean isDocumemtId();
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentPropertyImpl.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentPropertyImpl.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.data.firestore.mapping;
 
+import com.google.cloud.firestore.annotation.DocumentId;
+
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
@@ -50,5 +52,10 @@ public class FirestorePersistentPropertyImpl
 	@Override
 	protected Association<FirestorePersistentProperty> createAssociation() {
 		return new Association<>(this, null);
+	}
+
+	@Override
+	public boolean isDocumemtId() {
+		return findAnnotation(DocumentId.class) != null;
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentPropertyImpl.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentPropertyImpl.java
@@ -55,7 +55,7 @@ public class FirestorePersistentPropertyImpl
 	}
 
 	@Override
-	public boolean isDocumemtId() {
+	public boolean isIdProperty() {
 		return findAnnotation(DocumentId.class) != null;
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/repository/config/FirestoreRepositoryConfigurationExtension.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/repository/config/FirestoreRepositoryConfigurationExtension.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.cloud.gcp.data.firestore.Entity;
+import org.springframework.cloud.gcp.data.firestore.Document;
 import org.springframework.cloud.gcp.data.firestore.FirestoreReactiveRepository;
 import org.springframework.cloud.gcp.data.firestore.repository.support.FirestoreRepositoryFactoryBean;
 import org.springframework.core.annotation.AnnotationAttributes;
@@ -64,7 +64,7 @@ public class FirestoreRepositoryConfigurationExtension extends RepositoryConfigu
 
 	@Override
 	protected Collection<Class<? extends Annotation>> getIdentifyingAnnotations() {
-		return Collections.singleton(Entity.class);
+		return Collections.singleton(Document.class);
 	}
 
 	@Override

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/FirestoreTemplateTests.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.firestore.v1.Document;
 import com.google.firestore.v1.DocumentMask;
 import com.google.firestore.v1.FirestoreGrpc.FirestoreStub;
 import com.google.firestore.v1.GetDocumentRequest;
@@ -84,7 +83,7 @@ public class FirestoreTemplateTests {
 	@Test
 	public void findByIdTest() {
 		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onNext(buildDocument("e1", 100L));
 
 			streamObserver.onCompleted();
@@ -105,7 +104,7 @@ public class FirestoreTemplateTests {
 	@Test
 	public void findByIdErrorTest() {
 		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onError(new RuntimeException("Firestore error"));
 			return null;
 		}).when(this.firestoreStub).getDocument(any(), any());
@@ -127,7 +126,7 @@ public class FirestoreTemplateTests {
 	@Test
 	public void findByIdNotFoundTest() {
 		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onError(new RuntimeException("NOT_FOUND: Document"));
 
 			streamObserver.onCompleted();
@@ -158,7 +157,7 @@ public class FirestoreTemplateTests {
 				.build();
 
 		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onNext(buildDocument("e1", 100L));
 
 			streamObserver.onCompleted();
@@ -166,7 +165,7 @@ public class FirestoreTemplateTests {
 		}).when(this.firestoreStub).getDocument(eq(request1), any());
 
 		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onNext(buildDocument("e2", 200L));
 
 			streamObserver.onCompleted();
@@ -174,7 +173,7 @@ public class FirestoreTemplateTests {
 		}).when(this.firestoreStub).getDocument(eq(request2), any());
 
 		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onError(new RuntimeException("NOT_FOUND: Document"));
 
 			streamObserver.onCompleted();
@@ -260,7 +259,7 @@ public class FirestoreTemplateTests {
 				.build();
 
 		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onNext(buildDocument("e1", 100L));
 
 			streamObserver.onCompleted();
@@ -282,7 +281,7 @@ public class FirestoreTemplateTests {
 				.build();
 
 		doAnswer(invocation -> {
-			StreamObserver<Document> streamObserver = invocation.getArgument(1);
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onError(new RuntimeException("NOT_FOUND: Document"));
 
 			streamObserver.onCompleted();
@@ -304,8 +303,8 @@ public class FirestoreTemplateTests {
 		return valuesMap;
 	}
 
-	private Document buildDocument(String name, long l) {
-		return Document.newBuilder().setName(this.parent + "/testEntities/" + name)
+	private com.google.firestore.v1.Document buildDocument(String name, long l) {
+		return com.google.firestore.v1.Document.newBuilder().setName(this.parent + "/testEntities/" + name)
 				.putAllFields(createValuesMap(name, l)).build();
 	}
 
@@ -323,7 +322,7 @@ public class FirestoreTemplateTests {
 		}).when(this.firestoreStub).runQuery(any(), any());
 	}
 
-	@Entity(collectionName = "testEntities")
+	@Document(collectionName = "testEntities")
 	static class TestEntity {
 		@Id
 		String idField;

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.gcp.data.firestore;
 
 import java.util.Objects;
 
-import org.springframework.data.annotation.Id;
+import com.google.cloud.firestore.annotation.DocumentId;
 
 /**
  * Sample entity for integration tests.
@@ -26,9 +26,9 @@ import org.springframework.data.annotation.Id;
  * @author Daniel Zou
  */
 //tag::class_definition[]
-@Entity(collectionName = "usersCollection")
+@Document(collectionName = "usersCollection")
 public class User {
-	@Id
+	@DocumentId
 	private String name;
 
 	private Integer age;

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -93,7 +93,8 @@ public class FirestoreRepositoryIntegrationTests {
 
 		assertThat(this.userRepository.count().block()).isEqualTo(2);
 		assertThat(this.userRepository.findByAge(22).collectList().block()).containsExactly(u1);
-		assertThat(this.userRepository.findByAgeAndName(22, "Cloud").collectList().block()).containsExactly(u1);
+		assertThat(this.userRepository.findByAgeGreaterThanAndAgeLessThan(20, 30).collectList().block())
+				.containsExactly(u1);
 		assertThat(this.userRepository.findByAgeGreaterThan(10).collectList().block()).containsExactlyInAnyOrder(u1,
 				u2);
 	}

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/UserRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/UserRepository.java
@@ -32,7 +32,7 @@ import org.springframework.data.domain.Pageable;
 public interface UserRepository extends FirestoreReactiveRepository<User> {
 	Flux<User> findByAge(Integer age);
 
-	Flux<User> findByAgeAndName(Integer age, String name);
+	Flux<User> findByAgeGreaterThanAndAgeLessThan(Integer age1, Integer age2);
 
 	Flux<User> findByAgeGreaterThan(Integer age);
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/mapping/FirestorePersistentEntityImplTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.gcp.data.firestore.mapping;
 
 import org.junit.Test;
 
-import org.springframework.cloud.gcp.data.firestore.Entity;
+import org.springframework.cloud.gcp.data.firestore.Document;
 import org.springframework.data.util.ClassTypeInformation;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,11 +44,11 @@ public class FirestorePersistentEntityImplTests {
 		assertThat(firestorePersistentEntity.collectionName()).isEqualTo("employee_table");
 	}
 
-	@Entity
+	@Document
 	private static class Student {
 	}
 
-	@Entity(collectionName = "employee_table")
+	@Document(collectionName = "employee_table")
 	private static class Employee {
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/User.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/User.java
@@ -16,18 +16,19 @@
 
 package com.example;
 
-import org.springframework.cloud.gcp.data.firestore.Entity;
-import org.springframework.data.annotation.Id;
+import com.google.cloud.firestore.annotation.DocumentId;
+
+import org.springframework.cloud.gcp.data.firestore.Document;
 
 /**
  * Example POJO to demonstrate Spring Cloud GCP Spring Data Firestore operations.
  *
  * @author Daniel Zou
  */
-@Entity(collectionName = "users")
+@Document(collectionName = "users")
 public class User {
 
-	@Id
+	@DocumentId
 	String name;
 
 	int age;


### PR DESCRIPTION
fixes #1935 
Also renames `@Entity` to `@Document` to make terminology compatible with Firestore