### PR TITLE
Spring Cloud Config sample: add git:// protocol to sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/README.adoc
@@ -84,7 +84,7 @@ image::bus_sample_github.png[]
 example.message = message from GitHub
 ----
 
-2. In configuration server's link:spring-cloud-gcp-pubsub-bus-config-sample-server-github/src/main/resources/application.properties[application.properties], set the value of `spring.cloud.config.server.git.uri` property to either HTTPS or SSH repository URI.
+2. In configuration server's link:spring-cloud-gcp-pubsub-bus-config-sample-server-github/src/main/resources/application.properties[application.properties], set the value of `spring.cloud.config.server.git.uri` property to a valid repository URI (Git protocol for unauthenticated connection; HTTPS or SSH otherwise).
 +
 If you opted for SSH, the keys stored in `~/.ssh` should work automatically.
 If the key registered with GitHub is passphrase protected, set `spring.cloud.config.server.git.passphrase` property.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-github/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-github/src/main/resources/application.properties
@@ -1,9 +1,13 @@
 server.port = 8888
 
-spring.cloud.config.server.git.uri = [GIT_REPOSITORY_URI]
+# git:// is the read-only, unauthenticated protocol
+spring.cloud.config.server.git.uri = git://github.com/[USERNAME]/[REPO].git
 
-# Uncomment and set if using passphrase protected SSH key.
-#spring.cloud.config.server.git.passphrase=[SSH_KEY_PASPHRASE]
+# Uncomment and set if using SSH certificate authentication
+#spring.cloud.config.server.git.uri = git@github.com:[USERNAME]/[REPO].git
+
+# Uncomment and set if using a passphrase protected SSH key.
+#spring.cloud.config.server.git.passphrase=
 
 # Uncomment and set if using web authentication
 #spring.cloud.config.server.git.username=[USERNAME]


### PR DESCRIPTION
Simplifies sample by providing git:// placeholder as default.