### PR TITLE
Simplify Vision API sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/java/com/example/VisionController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/java/com/example/VisionController.java
@@ -16,8 +16,7 @@
 
 package com.example;
 
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.List;
 
 import com.google.cloud.vision.v1.AnnotateImageResponse;
 import com.google.cloud.vision.v1.EntityAnnotation;
@@ -64,13 +63,10 @@ public class VisionController {
 		AnnotateImageResponse response = this.cloudVisionTemplate.analyzeImage(
 				this.resourceLoader.getResource(imageUrl), Type.LABEL_DETECTION);
 
-		Map<String, Float> imageLabels =
-				response.getLabelAnnotationsList()
-						.stream()
-						.collect(Collectors.toMap(
-								EntityAnnotation::getDescription, EntityAnnotation::getScore));
+		// This gets the annotations of the image from the response object.
+		List<EntityAnnotation> annotations = response.getLabelAnnotationsList();
 
-		map.addAttribute("annotations", imageLabels);
+		map.addAttribute("annotations", annotations);
 		map.addAttribute("imageUrl", imageUrl);
 
 		return new ModelAndView("result", map);

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/resources/static/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/resources/static/index.html
@@ -10,7 +10,12 @@
     <h1>Image Label Annotations</h1>
     <p>Returns labels classifying the content of the image:</p>
     <form action="/extractLabels">
-        Web URL of image to analyze: <input type="text" name="imageUrl"/> <input type="submit"/>
+        Web URL of image to analyze:
+        <input type="text"
+               name="imageUrl"
+               value="https://upload.wikimedia.org/wikipedia/commons/d/d7/Boston-terrier-carlos-de.JPG"/>
+
+        <input type="submit"/>
     </form>
 </div>
 
@@ -18,7 +23,11 @@
     <h1>Text Extraction</h1>
     <p>Read and extract the text from the image:</p>
     <form action="/extractText">
-        Web URL of image to analyze: <input type="text" name="imageUrl"/> <input type="submit" />
+        Web URL of image to analyze:
+        <input type="text"
+               name="imageUrl"
+               value="https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png" />
+        <input type="submit" />
     </form>
 </div>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/resources/templates/result.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/resources/templates/result.html
@@ -12,13 +12,13 @@
       <th>Score</th>
     </tr>
     <tr th:each="entry : ${annotations}">
-      <td>[[${entry.key}]]</td>
-      <td>[[${entry.value}]]</td>
+      <td>[[${entry.getDescription()}]]</td>
+      <td>[[${entry.getScore()}]]</td>
     </tr>
   </table>
 
   <p>
-    <img th:src="${imageUrl}"/>
+    <img style="max-width: 500px" th:src="${imageUrl}"/>
   </p>
 </body>
 </html>


### PR DESCRIPTION
Simplifies the Vision API sample.

* Simplifies how image annotations are extracted from the results - this now leaves them in sorted order.
* Add some prefilled links to the inputs.