### PR TITLE
Show image on text extraction page in Vision Sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/java/com/example/VisionController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/java/com/example/VisionController.java
@@ -73,10 +73,13 @@ public class VisionController {
 	}
 
 	@GetMapping("/extractText")
-	public String extractText(String imageUrl) {
-		String textFromImage = this.cloudVisionTemplate.extractTextFromImage(
+	public ModelAndView extractText(String imageUrl, ModelMap map) {
+		String text = this.cloudVisionTemplate.extractTextFromImage(
 				this.resourceLoader.getResource(imageUrl));
-		return "Text from image: " + textFromImage;
-	}
 
+		map.addAttribute("text", text);
+		map.addAttribute("imageUrl", imageUrl);
+
+		return new ModelAndView("result", map);
+	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/resources/templates/result.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/resources/templates/result.html
@@ -4,18 +4,39 @@
   <title>Google Cloud Vision Results</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
+
+<style>
+  .extracted_text {
+    width: 30em;
+    min-height: 20em;
+    font-family: "Lucida Console", Monaco, monospace;
+    background-color: #f2f2f2;
+  }
+</style>
+
 <body>
-  <h1>Annotations Produced for the Image</h1>
-  <table border="1">
-    <tr>
-      <th>Description</th>
-      <th>Score</th>
-    </tr>
-    <tr th:each="entry : ${annotations}">
-      <td>[[${entry.getDescription()}]]</td>
-      <td>[[${entry.getScore()}]]</td>
-    </tr>
-  </table>
+  <h1>Image Analysis Results</h1>
+
+  <div th:if="${annotations}">
+    <h3>We think your image is...</h3>
+    <table border="1">
+      <tr>
+        <th>Description</th>
+        <th>Score</th>
+      </tr>
+      <tr th:each="entry : ${annotations}">
+        <td>[[${entry.getDescription()}]]</td>
+        <td>[[${entry.getScore()}]]</td>
+      </tr>
+    </table>
+  </div>
+
+  <div th:if="${text}">
+    <h3>We think the text inside the image is...</h3>
+    <div class="extracted_text">
+      [[${text}]]
+    </div>
+  </div>
 
   <p>
     <img style="max-width: 500px" th:src="${imageUrl}"/>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/test/java/com/example/VisionApiSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/test/java/com/example/VisionApiSampleApplicationTests.java
@@ -66,8 +66,9 @@ public class VisionApiSampleApplicationTests {
 	public void testExtractTextFromImage() throws Exception {
 		this.mockMvc.perform(get(TEXT_IMAGE_URL))
 				.andDo((response) -> {
-					String textImageResponse = response.getResponse().getContentAsString();
-					assertThat(textImageResponse).isEqualTo("Text from image: STOP\n");
+					ModelAndView result = response.getModelAndView();
+					String textFromImage = ((String) result.getModelMap().get("text")).trim();
+					assertThat(textFromImage).isEqualTo("STOP");
 				});
 	}
 


### PR DESCRIPTION
This modifies the Vision Sample so it shows the image that got processed for text extraction instead of just displaying the extracted text.