### PR TITLE
Fixes the Document OCR Vision integration tests

### DIFF
--- a/spring-cloud-gcp-vision/src/main/java/org/springframework/cloud/gcp/vision/OcrPageRange.java
+++ b/spring-cloud-gcp-vision/src/main/java/org/springframework/cloud/gcp/vision/OcrPageRange.java
@@ -97,7 +97,7 @@ final class OcrPageRange {
 
 		AnnotateFileResponse.Builder annotateFileResponseBuilder = AnnotateFileResponse.newBuilder();
 		String jsonContent = new String(blob.getContent());
-		JsonFormat.parser().merge(jsonContent, annotateFileResponseBuilder);
+		JsonFormat.parser().ignoringUnknownFields().merge(jsonContent, annotateFileResponseBuilder);
 
 		AnnotateFileResponse annotateFileResponse = annotateFileResponseBuilder.build();
 


### PR DESCRIPTION
This fixes the Document OCR integration tests by adding the `.ignoringUnknownFields()` parameter.

This is useful moving forward too in order to maintain backwards-compatability; i.e. if in the event the API changes server-side and our protos are not at the newest version.

Fixes #1984.