### PR TITLE
Test for the functional stream binder sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/pom.xml
@@ -16,6 +16,7 @@
   <modules>
     <module>spring-cloud-gcp-pubsub-stream-binder-functional-sample-source</module>
     <module>spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink</module>
+    <module>spring-cloud-gcp-pubsub-stream-binder-functional-sample-test</module>
   </modules>
 
   <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>spring-cloud-gcp-pubsub-stream-binder-functional-sample</artifactId>
+    <groupId>org.springframework.cloud</groupId>
+    <version>1.2.0.BUILD-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>spring-cloud-gcp-pubsub-stream-binder-functional-sample-test</artifactId>
+  <name>Integration Test for Spring Cloud GCP Pub/Sub Stream Binder Functional Code Sample</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-gcp-pubsub-stream-binder-functional-sample-source</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+
+</project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/SampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/SampleAppIntegrationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.system.OutputCaptureRule;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assume.assumeThat;
+
+/**
+ * Integration test for the Pub/Sub functional stream binder sample app.
+ *
+ * @author Elena Felder
+ */
+public class SampleAppIntegrationTest {
+
+	/** Captures output to check that Sink application processed the message. */
+	@Rule
+	public OutputCaptureRule output = new OutputCaptureRule();
+
+	@BeforeClass
+	public static void prepare() {
+		assumeThat(
+				"PUB/SUB-sample integration tests are disabled. Please use '-Dit.pubsub=true' "
+						+ "to enable them. ",
+				System.getProperty("it.pubsub"), is("true"));
+	}
+
+	@Test
+	public void testSample() throws Exception {
+
+		// Run Source app
+		Map<String, Object> sourceProperties = new HashMap<>();
+		sourceProperties.put("spring.cloud.stream.bindings.generateUserMessages-out-0.destination", "my-topic");
+		sourceProperties.put("spring.cloud.function.definition", "generateUserMessages");
+
+		SpringApplicationBuilder sourceBuilder = new SpringApplicationBuilder(
+				FunctionalSourceApplication.class)
+				.resourceLoader(new PropertyRemovingResourceLoader())
+				.properties(sourceProperties);
+		sourceBuilder.run();
+
+
+		//Run Sink app
+		Map<String, Object> sinkProperties = new HashMap<>();
+		sinkProperties.put("spring.cloud.stream.function.bindings.logUserMessage-in-0", "input");
+		sinkProperties.put("spring.cloud.stream.bindings.input.destination", "my-topic");
+		sinkProperties.put("spring.cloud.function.definition", "logUserMessage");
+		sinkProperties.put("spring.cloud.stream.bindings.input.group", "my-group");
+		sinkProperties.put("server.port", "8081");
+
+		SpringApplicationBuilder sinkBuilder = new SpringApplicationBuilder(FunctionalSinkApplication.class)
+			.resourceLoader(new PropertyRemovingResourceLoader())
+			.properties(sinkProperties);
+		sinkBuilder.run();
+
+
+		// Post message to Source over HTTP.
+		MultiValueMap<String, Object> map = new LinkedMultiValueMap<>();
+		String message = "test message " + UUID.randomUUID();
+		map.add("messageBody", message);
+		map.add("username", "integration-test-user");
+
+		RestTemplate restTemplate = new RestTemplate();
+
+		URI redirect = restTemplate.postForLocation("http://localhost:8080/postMessage", map);
+		assertThat(redirect.toString()).isEqualTo("http://localhost:8080/index.html");
+
+		Awaitility.await().atMost(10, TimeUnit.SECONDS)
+				.until(() -> this.output.getOut()
+						.contains("New message received from integration-test-user: " + message));
+
+	}
+
+	/**
+	 * Removes both /application.properties files coming from the two apps.
+	 */
+	static class PropertyRemovingResourceLoader extends DefaultResourceLoader {
+		@Override
+		public Resource getResource(String location) {
+			if (location.contains("classpath:/application.properties")) {
+				return null;
+			}
+
+			return super.getResource(location);
+		}
+	}
+
+}


### PR DESCRIPTION
Because both source and sink application dependencies have `application.properties` files, these are excluded with a custom resource loader, and the properties are added back to each app programmatically.

Followup to #1990 .
Fixes #1974.