### PR TITLE
Fix the Datastore Ancestor Key Query

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
@@ -645,10 +645,20 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 					Class descendantType = descendantPersistentProperty
 							.getComponentType();
 
+					Key entityKey = (Key) entity.getKey();
+
+					Key.Builder ancestorLookupKey;
+					if (entityKey.hasName()) {
+						ancestorLookupKey = Key.newBuilder(entityKey.getProjectId(), entityKey.getKind(), entityKey.getName());
+					} else {
+						ancestorLookupKey = Key.newBuilder(entityKey.getProjectId(), entityKey.getKind(), entityKey.getId());
+					}
+					ancestorLookupKey.setNamespace(entityKey.getNamespace());
+
 					EntityQuery descendantQuery = Query.newEntityQueryBuilder()
 							.setKind(this.datastoreMappingContext
 									.getPersistentEntity(descendantType).kindName())
-							.setFilter(PropertyFilter.hasAncestor((Key) entity.getKey()))
+							.setFilter(PropertyFilter.hasAncestor(ancestorLookupKey.build()))
 							.build();
 
 					List entities = convertEntitiesForRead(


### PR DESCRIPTION
Fixes the Datastore ancestor key query to correctly use entity keys with the path set to the entity itself (omit the fully-qualified path in the key passed into the ancestor query).

Fixes #1999 