### PR TITLE
Make all thread pools create daemon threads

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -116,6 +116,7 @@ public class GcpPubSubAutoConfiguration {
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.setPoolSize(this.gcpPubSubProperties.getPublisher().getExecutorThreads());
 		scheduler.setThreadNamePrefix("gcp-pubsub-publisher");
+		scheduler.setDaemon(true);
 		return scheduler;
 	}
 
@@ -132,6 +133,7 @@ public class GcpPubSubAutoConfiguration {
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.setPoolSize(this.gcpPubSubProperties.getSubscriber().getExecutorThreads());
 		scheduler.setThreadNamePrefix("gcp-pubsub-subscriber");
+		scheduler.setDaemon(true);
 		return scheduler;
 	}
 
@@ -157,6 +159,7 @@ public class GcpPubSubAutoConfiguration {
 		ThreadPoolTaskExecutor ackExecutor = new ThreadPoolTaskExecutor();
 		ackExecutor.setMaxPoolSize(this.gcpPubSubProperties.getSubscriber().getMaxAcknowledgementThreads());
 		ackExecutor.setThreadNamePrefix("gcp-pubsub-ack-executor");
+		ackExecutor.setDaemon(true);
 		return ackExecutor;
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -127,6 +127,7 @@ public class StackdriverTraceAutoConfiguration {
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.setPoolSize(traceProperties.getNumExecutorThreads());
 		scheduler.setThreadNamePrefix("gcp-trace-sender");
+		scheduler.setDaemon(true);
 		return scheduler;
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/vision/CloudVisionAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/vision/CloudVisionAutoConfiguration.java
@@ -102,6 +102,7 @@ public class CloudVisionAutoConfiguration {
 		ThreadPoolTaskExecutor ackExecutor = new ThreadPoolTaskExecutor();
 		ackExecutor.setMaxPoolSize(this.cloudVisionProperties.getExecutorThreadsCount());
 		ackExecutor.setThreadNamePrefix("gcp-cloud-vision-ocr-executor");
+		ackExecutor.setDaemon(true);
 		return ackExecutor;
 	}
 


### PR DESCRIPTION
Currently the thread pool for Pub/Sub's `SubscriberStub` keeps JVM from shutting down, causing non-web application to "hang".

This PR makes all Spring Cloud GCP threads daemon threads that do not prevent a Spring application from stopping.

This is a change in behavior for Pub/Sub-dependent command line applications that subscribe to a Pub/Sub topic with `PubSubTemplate.subscribe()`, and expect the application to run until externally terminated.

Fixes #2005.
