### PR TITLE
Fix Trace sample not to generate 'async' traces

### DIFF
--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -91,7 +91,10 @@ For example, when you are testing to see the traces are going through, you can s
 ----
 spring.sleuth.sampler.probability=1                     # Send 100% of the request traces to Stackdriver.
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)  # Ignore some URL paths.
+spring.sleuth.scheduled.enabled=false                   # disable executor 'async' traces
 ----
+
+WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which causes many traces with the name `async` to appear in Stackdriver Trace. This is especially a problem because our starter comes with an executor. To avoid this noise, please disable automatic instrumentation of executors via `spring.sleuth.async.enabled=false` in your application configuration.
 
 Spring Cloud GCP Trace does override some Sleuth configurations:
 

--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -94,7 +94,7 @@ spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)  # Ignore some URL paths.
 spring.sleuth.scheduled.enabled=false                   # disable executor 'async' traces
 ----
 
-WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which causes many traces with the name `async` to appear in Stackdriver Trace. This is especially a problem because our starter comes with an executor. To avoid this noise, please disable automatic instrumentation of executors via `spring.sleuth.async.enabled=false` in your application configuration.
+WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which causes many traces with the name `async` to appear in Stackdriver Trace. This is especially a problem because our starter comes with an executor. To avoid this noise, please disable automatic instrumentation of executors via `spring.sleuth.scheduled.enabled=false` in your application configuration.
 
 Spring Cloud GCP Trace does override some Sleuth configurations:
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.sleuth.sampler.probability=1.0
 
 # To ignore some frequently used URL patterns that are not useful in trace
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)
+
+# disable instrumentation of executors to avoid the 'async' traces noise
+spring.sleuth.scheduled.enabled=false


### PR DESCRIPTION
Also document the use of `spring.sleuth.scheduled.enabled=false`, which
is used to disable automatic instrumentation of executors by Sleuth.

Fixes: #1978.