### PR TITLE
Adding original message to the throwble for Pub/Sub publish failures.

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubDeliveryException.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubDeliveryException.java
@@ -33,8 +33,8 @@ public class PubSubDeliveryException extends PubSubException {
 	@Nullable
 	private final PubsubMessage failedMessage;
 
-	public PubSubDeliveryException(PubsubMessage pubsubMessage, Throwable cause) {
-		super(null, cause);
+	public PubSubDeliveryException(PubsubMessage pubsubMessage, String description, Throwable cause) {
+		super(description, cause);
 		this.failedMessage = pubsubMessage;
 	}
 
@@ -42,10 +42,4 @@ public class PubSubDeliveryException extends PubSubException {
 		return this.failedMessage;
 	}
 
-	@Override
-	public String toString() {
-
-		return super.toString() + (this.failedMessage == null ? ""
-				: (", failedMessage=" + this.failedMessage));
-	}
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubDeliveryException.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubDeliveryException.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.pubsub.core;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * The Spring Google Cloud Pub/Sub specific {@link PubSubException}.
+ * Handles failures while publishing events to Pub/Sub.
+ *
+ * @author SateeshKumar Kota
+ *
+ * @since 1.2
+ */
+public class PubSubDeliveryException extends PubSubException {
+
+	@Nullable
+	private final PubsubMessage failedMessage;
+
+	public PubSubDeliveryException(PubsubMessage pubsubMessage) {
+		super(null, null);
+		this.failedMessage = pubsubMessage;
+	}
+
+	public PubSubDeliveryException(String description) {
+		super(description);
+		this.failedMessage = null;
+	}
+
+	public PubSubDeliveryException(@Nullable String description, @Nullable Throwable cause) {
+		super(description, cause);
+		this.failedMessage = null;
+	}
+
+	public PubSubDeliveryException(PubsubMessage pubsubMessage, String description) {
+		super(description);
+		this.failedMessage = pubsubMessage;
+	}
+
+	public PubSubDeliveryException(PubsubMessage pubsubMessage, Throwable cause) {
+		super(null, cause);
+		this.failedMessage = pubsubMessage;
+	}
+
+	public PubSubDeliveryException(PubsubMessage pubsubMessage, @Nullable String description, @Nullable Throwable cause) {
+		super(description, cause);
+		this.failedMessage = pubsubMessage;
+	}
+
+	public PubsubMessage getFailedMessage() {
+		return this.failedMessage;
+	}
+
+	@Override
+	public String toString() {
+
+		return super.toString() + (this.failedMessage == null ? ""
+				: (", failedMessage=" + this.failedMessage));
+	}
+}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubDeliveryException.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubDeliveryException.java
@@ -33,44 +33,13 @@ public class PubSubDeliveryException extends PubSubException {
 	@Nullable
 	private final PubsubMessage failedMessage;
 
-	public PubSubDeliveryException(PubsubMessage pubsubMessage) {
-		super(null, null);
-		this.failedMessage = pubsubMessage;
-	}
-
-	public PubSubDeliveryException(String description) {
-		super(description);
-		this.failedMessage = null;
-	}
-
-	public PubSubDeliveryException(@Nullable String description, @Nullable Throwable cause) {
-		super(description, cause);
-		this.failedMessage = null;
-	}
-
-	public PubSubDeliveryException(PubsubMessage pubsubMessage, String description) {
-		super(description);
-		this.failedMessage = pubsubMessage;
-	}
-
 	public PubSubDeliveryException(PubsubMessage pubsubMessage, Throwable cause) {
 		super(null, cause);
-		this.failedMessage = pubsubMessage;
-	}
-
-	public PubSubDeliveryException(PubsubMessage pubsubMessage, @Nullable String description, @Nullable Throwable cause) {
-		super(description, cause);
 		this.failedMessage = pubsubMessage;
 	}
 
 	public PubsubMessage getFailedMessage() {
 		return this.failedMessage;
 	}
-
-	@Override
-	public String toString() {
-
-		return super.toString() + (this.failedMessage == null ? ""
-				: (", failedMessage=" + this.failedMessage));
-	}
+	
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubDeliveryException.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubDeliveryException.java
@@ -41,5 +41,11 @@ public class PubSubDeliveryException extends PubSubException {
 	public PubsubMessage getFailedMessage() {
 		return this.failedMessage;
 	}
-	
+
+	@Override
+	public String toString() {
+
+		return super.toString() + (this.failedMessage == null ? ""
+				: (", failedMessage=" + this.failedMessage));
+	}
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
@@ -25,12 +25,10 @@ import com.google.pubsub.v1.PubsubMessage;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.cloud.gcp.pubsub.core.PubSubDeliveryException;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.converter.PubSubMessageConverter;
 import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
@@ -44,6 +42,7 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  * @author Doug Hoard
+ * @author SateeshKumar Kota
  *
  * @since 1.1
  */
@@ -106,10 +105,8 @@ public class PubSubPublisherTemplate implements PubSubPublisherOperations {
 			@Override
 			public void onFailure(Throwable throwable) {
 				LOGGER.warn("Publishing to " + topic + " topic failed.", throwable);
-				Message<?> originalMessage = MessageBuilder.withPayload(pubsubMessage).build();
-				MessageHandlingException messageHandlingException = new MessageHandlingException(
-						originalMessage, throwable);
-				settableFuture.setException(messageHandlingException);
+				PubSubDeliveryException pubSubDeliveryException = new PubSubDeliveryException(pubsubMessage, throwable);
+				settableFuture.setException(pubSubDeliveryException);
 			}
 
 			@Override

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
@@ -104,8 +104,9 @@ public class PubSubPublisherTemplate implements PubSubPublisherOperations {
 
 			@Override
 			public void onFailure(Throwable throwable) {
-				LOGGER.warn("Publishing to " + topic + " topic failed.", throwable);
-				PubSubDeliveryException pubSubDeliveryException = new PubSubDeliveryException(pubsubMessage, throwable.getMessage(), throwable);
+				String errorMessage = "Publishing to " + topic + " topic failed.";
+				LOGGER.warn(errorMessage, throwable);
+				PubSubDeliveryException pubSubDeliveryException = new PubSubDeliveryException(pubsubMessage, errorMessage, throwable);
 				settableFuture.setException(pubSubDeliveryException);
 			}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
@@ -105,7 +105,7 @@ public class PubSubPublisherTemplate implements PubSubPublisherOperations {
 			@Override
 			public void onFailure(Throwable throwable) {
 				LOGGER.warn("Publishing to " + topic + " topic failed.", throwable);
-				PubSubDeliveryException pubSubDeliveryException = new PubSubDeliveryException(pubsubMessage, throwable);
+				PubSubDeliveryException pubSubDeliveryException = new PubSubDeliveryException(pubsubMessage, throwable.getMessage(), throwable);
 				settableFuture.setException(pubSubDeliveryException);
 			}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/publisher/PubSubPublisherTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,9 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.converter.PubSubMessageConverter;
 import org.springframework.cloud.gcp.pubsub.support.converter.SimplePubSubMessageConverter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
@@ -103,7 +106,10 @@ public class PubSubPublisherTemplate implements PubSubPublisherOperations {
 			@Override
 			public void onFailure(Throwable throwable) {
 				LOGGER.warn("Publishing to " + topic + " topic failed.", throwable);
-				settableFuture.setException(throwable);
+				Message<?> originalMessage = MessageBuilder.withPayload(pubsubMessage).build();
+				MessageHandlingException messageHandlingException = new MessageHandlingException(
+						originalMessage, throwable);
+				settableFuture.setException(messageHandlingException);
 			}
 
 			@Override

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
@@ -64,6 +64,7 @@ import static org.mockito.Mockito.when;
  * @author Chengyuan Zhao
  * @author Doug Hoard
  * @author Mike Eltsufin
+ * @author SateeshKumar Kota
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PubSubTemplateTests {

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
@@ -206,8 +206,9 @@ public class PubSubTemplateTests {
 	public void testPublish_onFailureWithPayload() {
 		ListenableFuture<String> future = this.pubSubTemplate.publish("testTopic", this.pubsubMessage);
 		this.settableApiFuture.setException(new Exception("Publish failed"));
-		assertThatThrownBy(() -> future.get()).isInstanceOf(ExecutionException.class).hasMessageContaining("permanating")
+		assertThatThrownBy(() -> future.get()).isInstanceOf(ExecutionException.class).hasCauseInstanceOf(PubSubDeliveryException.class)
 				.hasMessageContaining("Publish failed");
+
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,6 +199,14 @@ public class PubSubTemplateTests {
 		assertThatThrownBy(() -> future.get())
 				.isInstanceOf(ExecutionException.class)
 				.hasMessageContaining("future failed.");
+	}
+
+	@Test
+	public void testPublish_onFailureWithPayload() {
+		ListenableFuture<String> future = this.pubSubTemplate.publish("testTopic", this.pubsubMessage);
+		this.settableApiFuture.setException(new Exception("Publish failed"));
+		assertThatThrownBy(() -> future.get()).isInstanceOf(ExecutionException.class).hasMessageContaining("permanating")
+				.hasMessageContaining("Publish failed");
 	}
 
 	@Test


### PR DESCRIPTION
Adding original message to Future provided by Publisher if any failures to publish events to Pub/Sub.