### PR TITLE
Add required Project Reactor dependency

### DIFF
--- a/spring-cloud-gcp-data-firestore/pom.xml
+++ b/spring-cloud-gcp-data-firestore/pom.xml
@@ -53,6 +53,11 @@
 
         <dependency>
             <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Firestore is a reactive-only module, so the dependency is required.