### PR TITLE
HealthIndicator implementation for PubSub. Fixes #2030

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.DefaultGcpEnvironmentProvider;
@@ -42,6 +43,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Chengyuan Zhao
  */
 @Configuration
+@ConditionalOnProperty(value = "spring.cloud.gcp.core.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(GcpProperties.class)
 public class GcpContextAutoConfiguration {
 	private static final Log LOGGER = LogFactory.getLog(GcpContextAutoConfiguration.class);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
@@ -24,6 +24,7 @@ import com.google.api.gax.rpc.StatusCode;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.util.Assert;
 
 /**
  * Default implemenation of
@@ -42,6 +43,7 @@ public class PubSubHealthIndicator extends AbstractHealthIndicator {
 
 	public PubSubHealthIndicator(PubSubTemplate pubSubTemplate) {
 		super("Failed to connect to Pub/Sub APIs. Check your credentials and verify you have proper access to the service.");
+		Assert.notNull(pubSubTemplate, "PubSubTemplate can't be null");
 		this.pubSubTemplate = pubSubTemplate;
 	}
 
@@ -55,11 +57,11 @@ public class PubSubHealthIndicator extends AbstractHealthIndicator {
 				builder.up();
 			}
 			else {
-				builder.down();
+				builder.withException(aex).down();
 			}
 		}
 		catch (Exception e) {
-			builder.down();
+			builder.withException(e).down();
 		}
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.pubsub.health;
+
+import java.util.UUID;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+
+/**
+ * Default implemenation of
+ * {@link org.springframework.boot.actuate.health.HealthIndicator} for Pub/Sub. Validates
+ * if connection is successful by looking for a random generated subscription name that
+ * won't be found. If no subscription is found we know the client is able to connect to
+ * GCP Pub/Sub APIs.
+ *
+ * @author Vinicius Carvalho
+ *
+ * @since 1.2
+ */
+public class PubSubHealthIndicator extends AbstractHealthIndicator {
+
+	private final PubSubTemplate pubSubTemplate;
+
+	public PubSubHealthIndicator(PubSubTemplate pubSubTemplate) {
+		super("Failed to connect to Pub/Sub APIs. Check your credentials and verify you have proper access to the service.");
+		this.pubSubTemplate = pubSubTemplate;
+	}
+
+	@Override
+	protected void doHealthCheck(Health.Builder builder) throws Exception {
+		try {
+			this.pubSubTemplate.pull("subscription-" + UUID.randomUUID().toString(), 1, true);
+		}
+		catch (ApiException aex) {
+			if (aex.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
+				builder.up();
+			}
+			else {
+				builder.down();
+			}
+		}
+		catch (Exception e) {
+			builder.down();
+		}
+	}
+
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
@@ -34,7 +34,7 @@ import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
  *
  * @author Vinicius Carvalho
  *
- * @since 1.2
+ * @since 1.3
  */
 public class PubSubHealthIndicator extends AbstractHealthIndicator {
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -47,7 +47,6 @@ public class PubSubHealthIndicatorAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public PubSubHealthIndicator pubSubHealthIndicator(PubSubTemplate pubSubTemplate) {
-		Assert.notNull(pubSubTemplate, "PubSubTemplate can't be null");
 		return new PubSubHealthIndicator(pubSubTemplate);
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -29,10 +29,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- *
+ * {@link HealthContributorAutoConfiguration Auto-configuration} for
+ * {@link PubSubHealthIndicator}.
+ * 
  * @author Vinicius Carvalho
  *
- * @since 1.2
+ * @since 1.3
  */
 
 @Configuration

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfigura
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.Assert;
 
 /**
  * {@link HealthContributorAutoConfiguration Auto-configuration} for

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * {@link HealthContributorAutoConfiguration Auto-configuration} for
  * {@link PubSubHealthIndicator}.
- * 
+ *
  * @author Vinicius Carvalho
  *
  * @since 1.3

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -36,7 +36,6 @@ import org.springframework.context.annotation.Configuration;
  *
  * @since 1.3
  */
-
 @Configuration
 @ConditionalOnClass(HealthIndicator.class)
 @ConditionalOnEnabledHealthIndicator("pubsub")

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfigura
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
 
 /**
  * {@link HealthContributorAutoConfiguration Auto-configuration} for
@@ -46,6 +47,7 @@ public class PubSubHealthIndicatorAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public PubSubHealthIndicator pubSubHealthIndicator(PubSubTemplate pubSubTemplate) {
+		Assert.notNull(pubSubTemplate, "PubSubTemplate can't be null");
 		return new PubSubHealthIndicator(pubSubTemplate);
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.pubsub.health;
+
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ *
+ * @author Vinicius Carvalho
+ *
+ * @since 1.2
+ */
+
+@Configuration
+@ConditionalOnClass(HealthIndicator.class)
+@ConditionalOnEnabledHealthIndicator("pubsub")
+@AutoConfigureBefore(HealthContributorAutoConfiguration.class)
+@AutoConfigureAfter(GcpPubSubAutoConfiguration.class)
+public class PubSubHealthIndicatorAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PubSubHealthIndicator pubSubHealthIndicator(PubSubTemplate pubSubTemplate) {
+		return new PubSubHealthIndicator(pubSubTemplate);
+	}
+
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/package-info.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Auto-configuration for Spring Data Cloud Pub/Sub Health module.
+ */
+package org.springframework.cloud.gcp.autoconfigure.pubsub.health;

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -18,7 +18,8 @@ org.springframework.cloud.gcp.autoconfigure.vision.CloudVisionAutoConfiguration,
 org.springframework.cloud.gcp.autoconfigure.datastore.GcpDatastoreEmulatorAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.bigquery.GcpBigQueryAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.datastore.DatastoreTransactionManagerAutoConfiguration,\
-org.springframework.cloud.gcp.autoconfigure.firestore.FirestoreRepositoriesAutoConfiguration
+org.springframework.cloud.gcp.autoconfigure.firestore.FirestoreRepositoriesAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration  
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.gcp.autoconfigure.config.GcpConfigBootstrapConfiguration

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicator;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.context.annotation.Bean;
 
@@ -40,8 +42,8 @@ public class GcpPubSubAutoConfigurationTests {
 	@Test
 	public void keepAliveValue_default() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
-			.withUserConfiguration(TestConfig.class);
+				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class);
 
 		contextRunner.run(ctx -> {
 			GcpPubSubProperties props = ctx.getBean(GcpPubSubProperties.class);
@@ -49,16 +51,16 @@ public class GcpPubSubAutoConfigurationTests {
 
 			TransportChannelProvider tcp = ctx.getBean(TransportChannelProvider.class);
 			assertThat(((InstantiatingGrpcChannelProvider) tcp).getKeepAliveTime().toMinutes())
-				.isEqualTo(5);
+					.isEqualTo(5);
 		});
 	}
 
 	@Test
 	public void keepAliveValue_custom() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
-			.withUserConfiguration(TestConfig.class)
-			.withPropertyValues("spring.cloud.gcp.pubsub.keepAliveIntervalMinutes=2");
+				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class)
+				.withPropertyValues("spring.cloud.gcp.pubsub.keepAliveIntervalMinutes=2");
 
 		contextRunner.run(ctx -> {
 			GcpPubSubProperties props = ctx.getBean(GcpPubSubProperties.class);
@@ -66,7 +68,21 @@ public class GcpPubSubAutoConfigurationTests {
 
 			TransportChannelProvider tcp = ctx.getBean(TransportChannelProvider.class);
 			assertThat(((InstantiatingGrpcChannelProvider) tcp).getKeepAliveTime().toMinutes())
-				.isEqualTo(2);
+					.isEqualTo(2);
+		});
+	}
+
+	@Test
+	public void healthIndicatorPresent() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(PubSubHealthIndicatorAutoConfiguration.class,
+						GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class)
+				.withPropertyValues("spring.cloud.gcp.datastore.project-id=test-project",
+						"management.health.pubsub.enabled=true");
+		contextRunner.run(ctx -> {
+			PubSubHealthIndicator healthIndicator = ctx.getBean(PubSubHealthIndicator.class);
+			assertThat(healthIndicator).isNotNull();
 		});
 	}
 
@@ -81,7 +97,6 @@ public class GcpPubSubAutoConfigurationTests {
 		public CredentialsProvider googleCredentials() {
 			return () -> mock(Credentials.class);
 		}
-
 
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/PubSubHealthIndicatorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/PubSubHealthIndicatorTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.pubsub;
+
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.ApiException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicator;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the PubSub Health Indicator.
+ *
+ * @author Vinicius Carvalho
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PubSubHealthIndicatorTests {
+
+	@Mock
+	private PubSubTemplate pubSubTemplate;
+
+	@Test
+	public void healthUp() throws Exception {
+		when(pubSubTemplate.pull(anyString(), anyInt(), anyBoolean())).thenThrow(new ApiException(
+				new IllegalStateException("Illegal State"), GrpcStatusCode.of(io.grpc.Status.Code.NOT_FOUND), false));
+		PubSubHealthIndicator healthIndicator = new PubSubHealthIndicator(pubSubTemplate);
+		assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.UP);
+	}
+
+	@Test
+	public void healthDown() {
+		when(pubSubTemplate.pull(anyString(), anyInt(), anyBoolean()))
+				.thenThrow(new ApiException(new IllegalStateException("Illegal State"),
+						GrpcStatusCode.of(io.grpc.Status.Code.INVALID_ARGUMENT), false));
+		PubSubHealthIndicator healthIndicator = new PubSubHealthIndicator(pubSubTemplate);
+		assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);
+	}
+
+	@Test
+	public void healthDownGenericException() {
+		when(pubSubTemplate.pull(anyString(), anyInt(), anyBoolean()))
+				.thenThrow(new IllegalStateException("Illegal State"));
+		PubSubHealthIndicator healthIndicator = new PubSubHealthIndicator(pubSubTemplate);
+		assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);
+	}
+
+}


### PR DESCRIPTION
Fixes #2030 

Adds a simple PubSubHealthIndicator, if the credentials used to connect to GCP lack the proper roles for Pubsub the health indicator will now indicate it as down.

@meltsufin Will follow up with a Binder implementation that lists all destinations as details (something the kafka health indicator also does) on a different PR if it's ok by you.

PS: I did not squash commits, at least back on my time we used to do it during the merge, can squash them if needed.