### PR TITLE
fix timstamp converter issue

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -85,6 +85,8 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 	static {
 		Map<Class<?>, BiFunction<ValueBinder, ?, ?>> map = new LinkedHashMap<>();
 
+		map.put(Timestamp.class,
+				(BiFunction<ValueBinder, Timestamp, ?>) ValueBinder::to);
 		map.put(Date.class, (BiFunction<ValueBinder, Date, ?>) ValueBinder::to);
 		map.put(Boolean.class, (BiFunction<ValueBinder, Boolean, ?>) ValueBinder::to);
 		map.put(Long.class, (BiFunction<ValueBinder, Long, ?>) ValueBinder::to);
@@ -92,8 +94,6 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 		map.put(Double.class, (BiFunction<ValueBinder, Double, ?>) ValueBinder::to);
 		map.put(double.class, (BiFunction<ValueBinder, Double, ?>) ValueBinder::to);
 		map.put(String.class, (BiFunction<ValueBinder, String, ?>) ValueBinder::to);
-		map.put(Timestamp.class,
-				(BiFunction<ValueBinder, Timestamp, ?>) ValueBinder::to);
 		map.put(ByteArray.class,
 				(BiFunction<ValueBinder, ByteArray, ?>) ValueBinder::to);
 		map.put(double[].class,


### PR DESCRIPTION
This change will fix the timestamp issue which I am currently using in my project as a temporary fix till your next release. The issue is when we are iterating over complex non-iterable target type, we first encounter com.google.cloud.Date and try to check if source type java.sql.Timestamp can be converted in com.google.cloud.Date type or not. While checking we check for entire source type hierarchy and as java.util.Date is parent of java.sql.Timestamp and we check if java.util.Date and com.google.cloud.Date are compatible or not, we return true for original source type java.sql.Timestamp as if java.sql.Timestamp is compatible with com.google.cloud.Date. Even though that is true, in database column type is TIMESTAMP which does not allow com.google.cloud.Date to pass through and throw the following exception.

Caused by: java.util.concurrent.ExecutionException: com.google.api.gax.rpc.FailedPreconditionException: io.grpc.StatusRuntimeException: FAILED_PRECONDITION: Invalid value for column CREATED_ON in table TEST: Expected TIMESTAMP.

Due to which I have changed the order of converter so that specific type comes first in the analysis of a perfect match between source type and target type before checking a hierarchy.