### PR TITLE
delete subscription before deleting topic

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/README.adoc
@@ -59,6 +59,7 @@ You should see the following message logged:
 Message received from exampleSubscription subscription: Hello world!
 ----
 
-5. Delete topic `exampleTopic`.
+5. Delete subscription `exampleSubscription`.
 
-6. Delete topic `exampleSubscription`.
+6. Delete topic `exampleTopic`.
+

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationTests.java
@@ -17,7 +17,6 @@
 package com.example;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -36,7 +35,6 @@ import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
-import org.awaitility.Awaitility;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -68,6 +66,7 @@ import static org.junit.Assume.assumeThat;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { PubSubApplication.class })
 public class PubSubSampleApplicationTests {
 
+	/** Output capture for validating that message was received. */
 	@Rule
 	public OutputCaptureRule output = new OutputCaptureRule();
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationTests.java
@@ -36,15 +36,18 @@ import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
+import org.awaitility.Awaitility;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.system.OutputCaptureRule;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
@@ -64,6 +67,9 @@ import static org.junit.Assume.assumeThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { PubSubApplication.class })
 public class PubSubSampleApplicationTests {
+
+	@Rule
+	public OutputCaptureRule output = new OutputCaptureRule();
 
 	private static final int PUBSUB_CLIENT_TIMEOUT_SECONDS = 60;
 
@@ -129,41 +135,19 @@ public class PubSubSampleApplicationTests {
 
 	@AfterClass
 	public static void cleanupPubsubClients() {
-		if (topicAdminClient != null) {
-			List<String> testTopics = Arrays.asList(
-					SAMPLE_TEST_TOPIC,
-					SAMPLE_TEST_TOPIC2,
-					SAMPLE_TEST_TOPIC_DELETE);
-
-			for (String topicName : testTopics) {
-				List<String> projectTopics = getTopicNamesFromProject();
-				String testTopicName = ProjectTopicName.format(projectName, topicName);
-				if (projectTopics.contains(testTopicName)) {
-					topicAdminClient.deleteTopic(testTopicName);
-				}
-			}
-
-			topicAdminClient.close();
-		}
 
 		if (subscriptionAdminClient != null) {
-			List<String> testSubscriptions = Arrays.asList(
-					SAMPLE_TEST_SUBSCRIPTION1,
-					SAMPLE_TEST_SUBSCRIPTION2,
-					SAMPLE_TEST_SUBSCRIPTION3,
-					SAMPLE_TEST_SUBSCRIPTION_DELETE);
-
-			for (String testSubscription : testSubscriptions) {
-				String testSubscriptionName = ProjectSubscriptionName.format(
-						projectName, testSubscription);
-				List<String> projectSubscriptions = getSubscriptionNamesFromProject();
-				if (projectSubscriptions.contains(testSubscriptionName)) {
-					subscriptionAdminClient.deleteSubscription(testSubscriptionName);
-				}
-			}
+			deleteSubscriptions(SAMPLE_TEST_SUBSCRIPTION1, SAMPLE_TEST_SUBSCRIPTION2,
+					SAMPLE_TEST_SUBSCRIPTION3, SAMPLE_TEST_SUBSCRIPTION_DELETE);
 
 			subscriptionAdminClient.close();
 		}
+
+		if (topicAdminClient != null) {
+			deleteTopics(SAMPLE_TEST_TOPIC, SAMPLE_TEST_TOPIC2, SAMPLE_TEST_TOPIC_DELETE);
+			topicAdminClient.close();
+		}
+
 	}
 
 	@Before
@@ -181,16 +165,21 @@ public class PubSubSampleApplicationTests {
 	}
 
 	@Test
-	public void testReceiveMessage() {
+	public void testReceiveMessageByPull() {
 		postMessage("HelloWorld-Pull", SAMPLE_TEST_TOPIC);
 		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
 				() -> assertThat(getMessagesFromSubscription(SAMPLE_TEST_SUBSCRIPTION1))
 						.containsExactly("HelloWorld-Pull"));
+	}
 
-		// After subscribing, the message will be acked by the application and no longer be present.
+	@Test
+	public void testReceiveMessagesBySubscribe() {
+		postMessage("HelloWorld-Subscribe", SAMPLE_TEST_TOPIC);
+
 		subscribe(SAMPLE_TEST_SUBSCRIPTION1);
-		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilAsserted(
-				() -> assertThat(getMessagesFromSubscription(SAMPLE_TEST_SUBSCRIPTION1)).isEmpty());
+		await().atMost(PUBSUB_CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+				.until(() -> this.output.getOut().contains(
+						"Message received from " + SAMPLE_TEST_SUBSCRIPTION1 + " subscription: HelloWorld-Pull"));
 	}
 
 	@Test
@@ -325,4 +314,26 @@ public class PubSubSampleApplicationTests {
 				.map(Subscription::getName)
 				.collect(Collectors.toList());
 	}
+
+	private static void deleteTopics(String... testTopics) {
+		for (String topicName : testTopics) {
+			List<String> projectTopics = getTopicNamesFromProject();
+			String testTopicName = ProjectTopicName.format(projectName, topicName);
+			if (projectTopics.contains(testTopicName)) {
+				topicAdminClient.deleteTopic(testTopicName);
+			}
+		}
+	}
+
+	private static void deleteSubscriptions(String... testSubscriptions) {
+		for (String testSubscription : testSubscriptions) {
+			String testSubscriptionName = ProjectSubscriptionName.format(
+					projectName, testSubscription);
+			List<String> projectSubscriptions = getSubscriptionNamesFromProject();
+			if (projectSubscriptions.contains(testSubscriptionName)) {
+				subscriptionAdminClient.deleteSubscription(testSubscriptionName);
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Cloud Pub/Sub recommends deleting all subscriptions for a topic before deleting the topic. Updated integration test and the recommended flow in README.

There is a bit of yak shaving included in the PR -- after changing the order, `testReceiveMessage()` subscription ended up picking up the message after the cleanup was done because the "is empty" condition triggered before any messages arrived. The test then completed, cleanup was in process, and THEN a message was detected from the subscription.

Follow-up to #2024.

CC: @anguillanneuf 