### PR TITLE
Fix acking behavior of PubSub stream binder

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -159,13 +159,7 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 			if (this.ackMode == AckMode.AUTO) {
 				message.nack();
 			}
-
-			if (this.ackMode == AckMode.AUTO_ACK) {
-				LOGGER.warn("Sending Spring message failed.", re);
-			}
-			else {
-				throw new PubSubException("Sending Spring message failed.", re);
-			}
+			throw new PubSubException("Sending Spring message failed.", re);
 		}
 	}
 

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -123,8 +123,13 @@ public class PubSubInboundChannelAdapterTests {
 		when(this.mockMessageChannel.send(any())).thenThrow(new RuntimeException(EXCEPTION_MESSAGE));
 
 		this.adapter.setAckMode(AckMode.AUTO_ACK);
-		this.adapter.start();
 
+		assertThatThrownBy(() -> {
+			this.adapter.start();
+		}).hasMessageContaining(EXCEPTION_MESSAGE);
+
+		// When exception thrown, verify that neither ack() nor nack() is called.
+		verify(mockAcknowledgeableMessage, times(0)).ack();
 		verify(mockAcknowledgeableMessage, times(0)).nack();
 	}
 

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -123,10 +123,7 @@ public class PubSubInboundChannelAdapterTests {
 		when(this.mockMessageChannel.send(any())).thenThrow(new RuntimeException(EXCEPTION_MESSAGE));
 
 		this.adapter.setAckMode(AckMode.AUTO_ACK);
-
-		assertThatThrownBy(() -> {
-			this.adapter.start();
-		}).hasMessageContaining(EXCEPTION_MESSAGE);
+		this.adapter.start();
 
 		verify(mockAcknowledgeableMessage, times(0)).nack();
 	}


### PR DESCRIPTION
Fixes a regression in the Pub/Sub stream channel adapter AUTO_ACK mode in which messages were being ACKed even though an exception was thrown.

Contributes to #2074. 

cc/ @radivojen