### PR TITLE
Detailed docs on acking/nacking in Spring Integration

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -51,6 +51,27 @@ Pub/Sub credentials | No | https://www.googleapis.com/auth/pubsub
 | `spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period` | The maximum period a message ack deadline will be extended, in seconds | No | 0
 | `spring.cloud.gcp.pubsub.subscriber.pull-endpoint` | The endpoint for synchronous pulling messages | No | pubsub.googleapis.com:443
 | `spring.cloud.gcp.pubsub.[subscriber,publisher].executor-threads` | Number of threads used by `Subscriber` instances created by `SubscriberFactory` | No | 4
+| `spring.cloud.gcp.pubsub.[subscriber,publisher.batching].flow-control.max-outstanding-element-count`|
+Maximum number of outstanding elements to keep in memory before enforcing flow control.|No | unlimited
+| `spring.cloud.gcp.pubsub.[subscriber,publisher.batching].flow-control.max-outstanding-request-bytes`|
+Maximum number of outstanding bytes to keep in memory before enforcing flow control.|No | unlimited
+| `spring.cloud.gcp.pubsub.[subscriber,publisher.batching].flow-control.limit-exceeded-behavior`|
+The behavior when the specified limits are exceeded.|No | Block
+| `spring.cloud.gcp.pubsub.publisher.batching.element-count-threshold`|
+The element count threshold to use for batching.|No | unset (threshold does not apply)
+| `spring.cloud.gcp.pubsub.publisher.batching.request-byte-threshold`|
+The request byte threshold to use for batching.|No | unset (threshold does not apply)
+| `spring.cloud.gcp.pubsub.publisher.batching.delay-threshold-seconds`|
+The delay threshold to use for batching.
+After this amount of time has elapsed (counting from the first element added), the elements will be wrapped up in a batch and sent.|No | unset (threshold does not apply)
+| `spring.cloud.gcp.pubsub.publisher.batching.enabled`|
+Enables batching.|No | false
+|===
+
+The following properties are available to control retry in case of fixable failures during the gRPC call to Cloud Pub/Sub server.
+They do *not* control message redelivery; only message acknowledgement deadline can be used to extend or shorten the amount of time until Pub/Sub attempts redelivery.
+
+|===
 | `spring.cloud.gcp.pubsub.[subscriber,publisher].retry.total-timeout-seconds`|
 TotalTimeout has ultimate control over how long the logic should keep trying the remote call until it gives up completely.
 The higher the total timeout, the more retries can be attempted. |No | 0
@@ -76,21 +97,6 @@ The timeout of the previous call is multiplied by the RpcTimeoutMultiplier to ca
 | `spring.cloud.gcp.pubsub.[subscriber,publisher].retry.max-rpc-timeout-seconds`|
 MaxRpcTimeout puts a limit on the value of the RPC timeout, so that the RpcTimeoutMultiplier
 can't increase the RPC timeout higher than this amount.|No | 0
-| `spring.cloud.gcp.pubsub.[subscriber,publisher.batching].flow-control.max-outstanding-element-count`|
-Maximum number of outstanding elements to keep in memory before enforcing flow control.|No | unlimited
-| `spring.cloud.gcp.pubsub.[subscriber,publisher.batching].flow-control.max-outstanding-request-bytes`|
-Maximum number of outstanding bytes to keep in memory before enforcing flow control.|No | unlimited
-| `spring.cloud.gcp.pubsub.[subscriber,publisher.batching].flow-control.limit-exceeded-behavior`|
-The behavior when the specified limits are exceeded.|No | Block
-| `spring.cloud.gcp.pubsub.publisher.batching.element-count-threshold`|
-The element count threshold to use for batching.|No | unset (threshold does not apply)
-| `spring.cloud.gcp.pubsub.publisher.batching.request-byte-threshold`|
-The request byte threshold to use for batching.|No | unset (threshold does not apply)
-| `spring.cloud.gcp.pubsub.publisher.batching.delay-threshold-seconds`|
-The delay threshold to use for batching.
-After this amount of time has elapsed (counting from the first element added), the elements will be wrapped up in a batch and sent.|No | unset (threshold does not apply)
-| `spring.cloud.gcp.pubsub.publisher.batching.enabled`|
-Enables batching.|No | false
 |===
 
 === Spring Boot Actuator Support

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -71,6 +71,7 @@ Then, we declare a `PubSubInboundChannelAdapter` bean.
 It requires the channel we just created and a `SubscriberFactory`, which creates `Subscriber` objects from the Google Cloud Java Client for Pub/Sub.
 The Spring Boot starter for GCP Pub/Sub provides a configured `PubSubSubscriberOperations` object.
 
+===== Acknowledging messages and handling failures
 The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `AckMode.AUTO` being the default value:
 
 * Automatic acking and nacking (`AckMode.AUTO`)
@@ -79,7 +80,7 @@ The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `Ac
 
 ===== Acking
 
-In `AUTO` and `AUTO_ACK` modes, a message acknowledgement is automatically sent to Cloud Pub/Sub if the message was successfully sent into the Spring Integration channel and processed with no exceptions.
+In `AUTO` and `AUTO_ACK` modes, a message acknowledgement is automatically sent to Cloud Pub/Sub if the message was successfully processed with no exceptions.
 
 In `MANUAL` mode, your application logic needs to manually acknowledge each message.
 If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/Sub will attempt redelivery.

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -71,28 +71,21 @@ Then, we declare a `PubSubInboundChannelAdapter` bean.
 It requires the channel we just created and a `SubscriberFactory`, which creates `Subscriber` objects from the Google Cloud Java Client for Pub/Sub.
 The Spring Boot starter for GCP Pub/Sub provides a configured `PubSubSubscriberOperations` object.
 
-The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `AckMode.AUTO` being the default value;
+The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `AckMode.AUTO` being the default value:
 
-Automatic acking (`AckMode.AUTO`)
+* Automatic acking and nacking (`AckMode.AUTO`)
+* Automatic acking only (`AckMode.AUTO_ACK`)
+* Manual acking and nacking (`AckMode.MANUAL`)
 
-A message is acked with GCP Pub/Sub if the adapter sent it to the channel and no exceptions were thrown.
+===== Acking
 
-If a `RuntimeException` is thrown while the message is processed, then the message is handled in the following way:
+In `AUTO` and `AUTO_ACK` modes, a message acknowledgement is automatically sent to Cloud Pub/Sub if the message was successfully sent into the Spring Integration channel and processed with no exceptions.
 
-* If an error channel is configured for the adapter (`pubSubInboundChannelAdapater.getErrorChannel() != null`) then the message will be acked and forwarded with the error to the error channel.
-* If no error channel is configured for the adapter, then the message is nacked.
-
-Automatic acking OK (`AckMode.AUTO_ACK`)
-
-A message is acked with GCP Pub/Sub if the adapter sent it to the channel and no exceptions were thrown.
-If a `RuntimeException` is thrown while the message is processed, then the message is neither acked / nor nacked.
-
-This is useful when using the subscription's ack deadline timeout as a retry delivery backoff mechanism.
-
-Manually acking (`AckMode.MANUAL`)
+In `MANUAL` mode, your application logic needs to manually acknowledge each message.
+If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/Sub will attempt redelivery.
 
 The adapter attaches a `BasicAcknowledgeablePubsubMessage` object to the `Message` headers.
-Users can extract the `BasicAcknowledgeablePubsubMessage` using the `GcpPubSubHeaders.ORIGINAL_MESSAGE` key and use it to (n)ack a message.
+Users can extract the `BasicAcknowledgeablePubsubMessage` using the `GcpPubSubHeaders.ORIGINAL_MESSAGE` key and use it to ack (or nack) a message.
 
 [source,java]
 ----
@@ -107,6 +100,68 @@ public MessageHandler messageReceiver() {
     };
 }
 ----
+
+===== Nacking
+In the context of Cloud Pub/Sub, nacking simply means instructing the message to be redelivered immediately.
+This could be useful in a load balanced architecture, where one of the subscribers is having issues but others are available to process messages.
+
+In `AUTO` mode, a message is nacked if processing causes any unchecked exceptions.
+
+In `AUTO_ACK` and `MANUAL` modes, behavior depends on whether an error channel was configured on the `PubSubInboundChannelAdapter`:
+
+* If an error channel is present (see <<#Error-Handling>> for how to configure one), the message is neither acked nor nacked.
+Instead, it is forwarded, together with the error, to the error channel.
+This is useful when using the subscription's ack deadline timeout as a retry delivery backoff mechanism or when manual control over nacking is needed.
+* If there is no error channel, the exception will be caught by the Cloud Pub/Sub client library and automatically nacked, causing instant redelivery.
+
+===== Error Handling
+
+If you want to have more control over message processing in case of an error, you need to associate the `PubSubInboundChannelAdapter` with a Spring Integration error channel and specify the behavior to be invoked with `@ServiceActivator`.
+
+If you don't explicitly ack or nack the message in `AUTO_ACK` and `MANUAL` modes, the message will get redelivered after its `ackDeadline` passes.
+
+[source,java]
+----
+@Bean
+public MessageChannel pubsubInputChannel() {
+    return new PublishSubscribeChannel();
+}
+
+@Bean
+public PubSubInboundChannelAdapter messageChannelAdapter(
+    @Qualifier("pubsubInputChannel") MessageChannel inputChannel,
+    SubscriberFactory subscriberFactory) {
+    PubSubInboundChannelAdapter adapter =
+        new PubSubInboundChannelAdapter(subscriberFactory, "subscriptionName");
+    adapter.setOutputChannel(inputChannel);
+    adapter.setAckMode(AckMode.AUTO_ACK);
+    adapter.setErrorChannelName("pubsubErrors");
+
+    return adapter;
+}
+
+@ServiceActivator(inputChannel =  "pubsubErrors")
+public void pubsubErrorHandler(Message<MessagingException> message) {
+	LOGGER.warn("This message is neither acked nor nacked; ack deadline will determine redelivery");
+}
+----
+
+If you would prefer to manually ack or nack the message, you can do it by retrieving the header of exception payload:
+
+----
+
+@ServiceActivator(inputChannel =  "pubsubErrors")
+public void pubsubErrorHandler(Message<MessagingException> exceptionMessage) {
+
+	BasicAcknowledgeablePubsubMessage originalMessage =
+	  (BasicAcknowledgeablePubsubMessage)exceptionMessage.getPayload().getFailedMessage()
+	    .getHeaders().get(GcpPubSubHeaders.ORIGINAL_MESSAGE);
+
+	originalMessage.nack();
+}
+----
+
+
 
 ==== Pollable Message Source (using Pub/Sub Synchronous Pull)
 

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -74,20 +74,25 @@ The Spring Boot starter for GCP Pub/Sub provides a configured `PubSubSubscriberO
 ===== Acknowledging messages and handling failures
 The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `AckMode.AUTO` being the default value:
 
-* Automatic acking and nacking (`AckMode.AUTO`)
-* Automatic acking only (`AckMode.AUTO_ACK`)
-* Manual acking and nacking (`AckMode.MANUAL`)
+* Automatic acking and nacking (`AckMode.AUTO`) +
+If the message was successfully processed with no exceptions, an acknowledgement is automatically sent to Cloud Pub/Sub.
+In case of processing failure, a nack (request for immediate redelivery) is automatically sent to Cloud Pub/Sub.
 
-===== Acking
-
-In `AUTO` and `AUTO_ACK` modes, a message acknowledgement is automatically sent to Cloud Pub/Sub if the message was successfully processed with no exceptions.
-
-In `MANUAL` mode, your application logic needs to manually acknowledge each message.
+* Automatic acking only (`AckMode.AUTO_ACK`) +
+If the message was successfully processed with no exceptions, an acknowledgement is automatically sent to Cloud Pub/Sub.
+In case of processing failure, the adapter neither acks nor nacks the message, resulting in the same behavior as `MANUAL` mode.
 If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/Sub will attempt redelivery.
 
+* Manual acking and nacking (`AckMode.MANUAL`) +
+Your application logic needs to manually acknowledge each message.
+If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/Sub will attempt redelivery.
++
+NOTE: The Pub/Sub client library this adapter is based on will attempt to extend the acknowledgement deadline for an hour by default.
+To override this behavior, use the `spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period` property.
++
 The adapter attaches a `BasicAcknowledgeablePubsubMessage` object to the `Message` headers.
 Users can extract the `BasicAcknowledgeablePubsubMessage` using the `GcpPubSubHeaders.ORIGINAL_MESSAGE` key and use it to ack (or nack) a message.
-
++
 [source,java]
 ----
 @Bean
@@ -102,7 +107,7 @@ public MessageHandler messageReceiver() {
 }
 ----
 
-===== Nacking
+====== Nacking
 In the context of Cloud Pub/Sub, nacking simply means instructing the message to be redelivered immediately.
 This could be useful in a load balanced architecture, where one of the subscribers is having issues but others are available to process messages.
 
@@ -119,7 +124,8 @@ This is useful when using the subscription's ack deadline timeout as a retry del
 
 If you want to have more control over message processing in case of an error, you need to associate the `PubSubInboundChannelAdapter` with a Spring Integration error channel and specify the behavior to be invoked with `@ServiceActivator`.
 
-If you don't explicitly ack or nack the message in `AUTO_ACK` and `MANUAL` modes, the message will get redelivered after its `ackDeadline` passes.
+NOTE: In order to activate default (neither acking nor nacking) behavior in `AUTO_ACK` and `MANUAL` modes, your error handler has to throw an exception.
+Otherwise, the adapter will assume that processing completed successfully and will ack the message.
 
 [source,java]
 ----
@@ -143,12 +149,13 @@ public PubSubInboundChannelAdapter messageChannelAdapter(
 
 @ServiceActivator(inputChannel =  "pubsubErrors")
 public void pubsubErrorHandler(Message<MessagingException> message) {
-	LOGGER.warn("This message is neither acked nor nacked; ack deadline will determine redelivery");
+	LOGGER.warn("This message will be automatically acked because error handler completes successfully");
 }
 ----
 
 If you would prefer to manually ack or nack the message, you can do it by retrieving the header of exception payload:
 
+[source,java]
 ----
 
 @ServiceActivator(inputChannel =  "pubsubErrors")
@@ -159,6 +166,10 @@ public void pubsubErrorHandler(Message<MessagingException> exceptionMessage) {
 	    .getHeaders().get(GcpPubSubHeaders.ORIGINAL_MESSAGE);
 
 	originalMessage.nack();
+
+    // retrow to let the adapter know something went wrong.
+    // this will prevent the message from being automatically acknowledged.
+    throw message.getPayload();
 }
 ----
 

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -112,7 +112,7 @@ The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `Ac
 {empty}* <no action> means that the message will be neither acked nor nacked.
 Cloud Pub/Sub will attempt redelivery according to subscription `ackDeadline` setting and the `max-ack-extension-period` client library setting.
 
-{empty}** For the adapter, "success" means the full Spring Integration flow processed without raising an exception, so successful message processing and the successful completion of an error handler both result in the same behavior (message will be acknowledged).
+{empty}** For the adapter, "success" means the Spring Integration flow processed without raising an exception, so successful message processing and the successful completion of an error handler both result in the same behavior (message will be acknowledged).
 To trigger default error behavior (nacking in `AUTO` mode; neither acking nor nacking in `AUTO_ACK` mode), propagate the error back to the adapter by throwing an exception from the error handler.
 
 ===== Manual acking/nacking

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -115,7 +115,7 @@ public MessageHandler messageReceiver() {
 In the context of Cloud Pub/Sub, nacking simply means instructing the message to be redelivered immediately.
 This could be useful in a load balanced architecture, where one of the subscribers is having issues but others are available to process messages.
 
-In `AUTO` mode, a message is nacked if processing causes any unchecked exceptions.
+In `AUTO` mode, a message is nacked if processing causes any unhandled exceptions.
 
 In `AUTO_ACK` and `MANUAL` modes, behavior depends on whether an error channel was configured on the `PubSubInboundChannelAdapter`:
 

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -91,8 +91,8 @@ If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/
 Your application logic needs to manually acknowledge each message.
 If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/Sub will attempt redelivery.
 +
-NOTE: The Pub/Sub client library this adapter is based on will attempt to extend the acknowledgement deadline for an hour by default.
-To override this behavior, use the `spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period` property.
+NOTE: While the Pub/Sub client library by default attempts to extend the acknowledgement deadline for an hour, Spring Cloud GCP disables the auto-extension behavior.
+Use the `spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period` property to re-enable auto-extending acknowledgement deadline until the message processing completes, fails or until the extension period elapses.
 +
 The adapter attaches a `BasicAcknowledgeablePubsubMessage` object to the `Message` headers.
 Users can extract the `BasicAcknowledgeablePubsubMessage` using the `GcpPubSubHeaders.ORIGINAL_MESSAGE` key and use it to ack (or nack) a message.

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -80,7 +80,7 @@ The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `Ac
 
 * Automatic acking and nacking (`AckMode.AUTO`) +
 If the message was successfully processed with no exceptions, an acknowledgement is automatically sent to Cloud Pub/Sub.
-In case of processing failure, a nack (request for immediate redelivery) is automatically sent to Cloud Pub/Sub.
+In case of a processing failure, a nack (request for immediate redelivery) is automatically sent to Cloud Pub/Sub.
 
 * Automatic acking only (`AckMode.AUTO_ACK`) +
 If the message was successfully processed with no exceptions, an acknowledgement is automatically sent to Cloud Pub/Sub.

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -84,7 +84,7 @@ In case of a processing failure, a nack (request for immediate redelivery) is au
 
 * Automatic acking only (`AckMode.AUTO_ACK`) +
 If the message was successfully processed with no exceptions, an acknowledgement is automatically sent to Cloud Pub/Sub.
-In case of processing failure, the adapter neither acks nor nacks the message, resulting in the same behavior as `MANUAL` mode.
+In case of a processing failure, the adapter neither acks nor nacks the message, resulting in the same behavior as `MANUAL` mode, where the the application logic can decide to nack manually or allow for eventual redelivery.
 If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/Sub will attempt redelivery.
 
 * Manual acking and nacking (`AckMode.MANUAL`) +

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -72,6 +72,10 @@ It requires the channel we just created and a `SubscriberFactory`, which creates
 The Spring Boot starter for GCP Pub/Sub provides a configured `PubSubSubscriberOperations` object.
 
 ===== Acknowledging messages and handling failures
+When working with Cloud Pub/Sub, it is important to understand the concept of `ackDeadline` -- the amount of time Cloud Pub/Sub will wait until attempting redelivery of an outstanding message.
+While acknowledging (acking) a message removes it from Pub/Sub's known outstanding messages, nacking a message simply means resetting its acknowledgement deadline to 0, forcing immediate redelivery.
+A global `ackDeadline` exists on each subscription. Additionally, the Cloud Pub/Sub client library can extend each streamed message's `ackDeadline` up to `spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period` seconds (in `spring-cloud-gcp`, this is set to 0, which prevents automatic deadline extension, but in a standalone client library, the default is 60 minutes).
+
 The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `AckMode.AUTO` being the default value:
 
 * Automatic acking and nacking (`AckMode.AUTO`) +

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -3,7 +3,7 @@
 The channel adapters for Google Cloud Pub/Sub connect your Spring https://docs.spring.io/spring-integration/reference/html/messaging-channels-section.html#channel[`MessageChannels`] to Google Cloud Pub/Sub topics and subscriptions.
 This enables messaging between different processes, applications or micro-services backed up by Google Cloud Pub/Sub.
 
-The Spring Integration Channel Adapters for Google Cloud Pub/Sub are included in the `spring-cloud-gcp-pubsub` module.
+The Spring Integration Channel Adapters for Google Cloud Pub/Sub are included in the `spring-cloud-gcp-pubsub` module and can be autoconfigured by using the `spring-cloud-gcp-starter-pubsub` module in combination with a Spring Integration dependency.
 
 Maven coordinates, using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
 
@@ -11,7 +11,7 @@ Maven coordinates, using <<getting-started.adoc#_bill_of_materials, Spring Cloud
 ----
 <dependency>
     <groupId>org.springframework.cloud</groupId>
-    <artifactId>spring-cloud-gcp-pubsub</artifactId>
+    <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
 </dependency>
 <dependency>
     <groupId>org.springframework.integration</groupId>
@@ -24,7 +24,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-pubsub'
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub'
     compile group: 'org.springframework.integration', name: 'spring-integration-core'
 }
 ----
@@ -73,30 +73,53 @@ The Spring Boot starter for GCP Pub/Sub provides a configured `PubSubSubscriberO
 
 ===== Acknowledging messages and handling failures
 When working with Cloud Pub/Sub, it is important to understand the concept of `ackDeadline` -- the amount of time Cloud Pub/Sub will wait until attempting redelivery of an outstanding message.
-While acknowledging (acking) a message removes it from Pub/Sub's known outstanding messages, nacking a message simply means resetting its acknowledgement deadline to 0, forcing immediate redelivery.
-A global `ackDeadline` exists on each subscription. Additionally, the Cloud Pub/Sub client library can extend each streamed message's `ackDeadline` up to `spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period` seconds (in `spring-cloud-gcp`, this is set to 0, which prevents automatic deadline extension, but in a standalone client library, the default is 60 minutes).
+Each subscription has a default `ackDeadline` applied to all messages sent to it.
+Additionally, the Cloud Pub/Sub client library can extend each streamed message's `ackDeadline` until the message processing completes, fails or until the maximum extension period elapses.
 
-The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `AckMode.AUTO` being the default value:
+NOTE: In Pub/Sub client library, default maximum extension period is an hour. However, Spring Cloud GCP disables this auto-extension behavior.
+Use the `spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period` property to re-enable it.
 
-* Automatic acking and nacking (`AckMode.AUTO`) +
-If the message was successfully processed with no exceptions, an acknowledgement is automatically sent to Cloud Pub/Sub.
-In case of a processing failure, a nack (request for immediate redelivery) is automatically sent to Cloud Pub/Sub.
+Acknowledging (acking) a message removes it from Pub/Sub's known outstanding messages. Nacking a message resets its acknowledgement deadline to 0, forcing immediate redelivery.
+This could be useful in a load balanced architecture, where one of the subscribers is having issues but others are available to process messages.
 
-* Automatic acking only (`AckMode.AUTO_ACK`) +
-If the message was successfully processed with no exceptions, an acknowledgement is automatically sent to Cloud Pub/Sub.
-In case of a processing failure, the adapter neither acks nor nacks the message, resulting in the same behavior as `MANUAL` mode, where the the application logic can decide to nack manually or allow for eventual redelivery.
-If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/Sub will attempt redelivery.
+The `PubSubInboundChannelAdapter` supports three acknowledgement modes, with `AckMode.AUTO` being the default value: `AckMode.AUTO` (automatic acking and nacking), `AckMode.AUTO_ACK` (automatic acking only) and `AckMode.MANUAL` (manual acking and nacking).
 
-* Manual acking and nacking (`AckMode.MANUAL`) +
-Your application logic needs to manually acknowledge each message.
-If a message is not acknowledged within the applicable `ackDeadline`, Cloud Pub/Sub will attempt redelivery.
-+
-NOTE: While the Pub/Sub client library by default attempts to extend the acknowledgement deadline for an hour, Spring Cloud GCP disables the auto-extension behavior.
-Use the `spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period` property to re-enable auto-extending acknowledgement deadline until the message processing completes, fails or until the extension period elapses.
-+
+.Acknowledgement mode behavior
+|===
+| |AUTO |AUTO_ACK |MANUAL
+
+| Message processing completes successfully
+| ack, no redelivery
+| ack, no redelivery
+| <no action>*
+
+|Message processing fails, but error handler completes successfully**
+| ack, no redelivery
+| ack, no redelivery
+| <no action>*
+
+|Message processing fails; no error handler present
+| nack, immediate redelivery
+| <no action>*
+| <no action>*
+
+|Message processing fails, and error handler throws an exception
+| nack, immediate redelivery
+| <no action>*
+| <no action>*
+|===
+
+{empty}* <no action> means that the message will be neither acked nor nacked.
+Cloud Pub/Sub will attempt redelivery according to subscription `ackDeadline` setting and the `max-ack-extension-period` client library setting.
+
+{empty}** For the adapter, "success" means the full Spring Integration flow processed without raising an exception, so successful message processing and the successful completion of an error handler both result in the same behavior (message will be acknowledged).
+To trigger default error behavior (nacking in `AUTO` mode; neither acking nor nacking in `AUTO_ACK` mode), propagate the error back to the adapter by throwing an exception from the error handler.
+
+===== Manual acking/nacking
+
 The adapter attaches a `BasicAcknowledgeablePubsubMessage` object to the `Message` headers.
 Users can extract the `BasicAcknowledgeablePubsubMessage` using the `GcpPubSubHeaders.ORIGINAL_MESSAGE` key and use it to ack (or nack) a message.
-+
+
 [source,java]
 ----
 @Bean
@@ -111,24 +134,11 @@ public MessageHandler messageReceiver() {
 }
 ----
 
-====== Nacking
-In the context of Cloud Pub/Sub, nacking simply means instructing the message to be redelivered immediately.
-This could be useful in a load balanced architecture, where one of the subscribers is having issues but others are available to process messages.
-
-In `AUTO` mode, a message is nacked if processing causes any unhandled exceptions.
-
-In `AUTO_ACK` and `MANUAL` modes, behavior depends on whether an error channel was configured on the `PubSubInboundChannelAdapter`:
-
-* If an error channel is present (see <<#Error-Handling>> for how to configure one), the message is neither acked nor nacked.
-Instead, it is forwarded, together with the error, to the error channel.
-This is useful when using the subscription's ack deadline timeout as a retry delivery backoff mechanism or when manual control over nacking is needed.
-* If there is no error channel, the exception will be caught by the Cloud Pub/Sub client library and automatically nacked, causing instant redelivery.
-
 ===== Error Handling
 
 If you want to have more control over message processing in case of an error, you need to associate the `PubSubInboundChannelAdapter` with a Spring Integration error channel and specify the behavior to be invoked with `@ServiceActivator`.
 
-NOTE: In order to activate default (neither acking nor nacking) behavior in `AUTO_ACK` and `MANUAL` modes, your error handler has to throw an exception.
+NOTE: In order to activate the default behavior (nacking in `AUTO` mode; neither acking nor nacking in `AUTO_ACK` mode), your error handler has to throw an exception.
 Otherwise, the adapter will assume that processing completed successfully and will ack the message.
 
 [source,java]


### PR DESCRIPTION
Corrects documentation about what happens if processing fails.
Adds more detail on acking/nacking and error handling.
Replaces straight Pub/Sub module with starter, which is more useful as it provides autoconfigured templates.

Follow up to #2075 and #2074 .