### PR TITLE
Fix acking behavior of PubSub stream binder

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -145,25 +145,21 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 			});
 		}
 
-		boolean messageNacked = false;
-
 		try {
 			sendMessage(getMessageBuilderFactory()
 					.withPayload(message.getPayload())
 					.copyHeaders(messageHeaders)
 					.build());
+
+			if (this.ackMode == AckMode.AUTO_ACK || this.ackMode == AckMode.AUTO) {
+				message.ack();
+			}
 		}
 		catch (RuntimeException re) {
 			if (this.ackMode == AckMode.AUTO) {
 				message.nack();
-				messageNacked = true;
 			}
 			throw new PubSubException("Sending Spring message failed.", re);
-		}
-		finally {
-			if (!messageNacked && (this.ackMode == AckMode.AUTO || this.ackMode == AckMode.AUTO_ACK)) {
-				message.ack();
-			}
 		}
 	}
 

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -128,6 +128,8 @@ public class PubSubInboundChannelAdapterTests {
 			this.adapter.start();
 		}).hasMessageContaining(EXCEPTION_MESSAGE);
 
+		// When exception thrown, verify that neither ack() nor nack() is called.
+		verify(mockAcknowledgeableMessage, times(0)).ack();
 		verify(mockAcknowledgeableMessage, times(0)).nack();
 	}
 


### PR DESCRIPTION
Fixes a regression in the Pub/Sub stream channel adapter AUTO_ACK mode in which messages were being ACKed even though an exception was thrown.

(cherry picked from commit 256f9a99f5abfea662197c153bc45a8b600f018f)

Notes: This applies the fix from #2075 to the 1.2.x branch.