### PR TITLE
Fix the logger in the datastore auto-configuration

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -68,7 +68,7 @@ import org.springframework.data.rest.webmvc.spi.BackendIdConverter;
 @EnableConfigurationProperties(GcpDatastoreProperties.class)
 public class GcpDatastoreAutoConfiguration {
 
-	private static final Log LOGGER = LogFactory.getLog(GcpDatastoreEmulatorAutoConfiguration.class);
+	private static final Log LOGGER = LogFactory.getLog(GcpDatastoreAutoConfiguration.class);
 
 	private final String projectId;
 


### PR DESCRIPTION
This is a really minor bug, but it cost me a half hour when I thought I had some dependencies issues as I couldn't find the log in the reported class.