### PR TITLE
Explicitly add dns scheme to grpc channel addresses

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -154,7 +154,7 @@ public class GcpFirestoreAutoConfiguration {
 		@ConditionalOnMissingBean
 		public ManagedChannel firestoreManagedChannel() {
 			return ManagedChannelBuilder
-					.forTarget(GcpFirestoreAutoConfiguration.this.hostPort)
+					.forTarget("dns:///" + GcpFirestoreAutoConfiguration.this.hostPort)
 					.userAgent(USER_AGENT_HEADER_PROVIDER.getUserAgent())
 					.build();
 		}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
@@ -45,7 +45,7 @@ public class GcpPubSubEmulatorAutoConfiguration {
 	@ConditionalOnMissingBean
 	public TransportChannelProvider transportChannelProvider(GcpPubSubProperties gcpPubSubProperties) {
 		ManagedChannel channel = ManagedChannelBuilder
-				.forTarget(gcpPubSubProperties.getEmulatorHost())
+				.forTarget("dns:///" + gcpPubSubProperties.getEmulatorHost())
 				.usePlaintext(true)
 				.build();
 		return FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -140,7 +140,7 @@ public class StackdriverTraceAutoConfiguration {
 	@Bean(destroyMethod = "shutdownNow")
 	@ConditionalOnMissingBean(name = "stackdriverSenderChannel")
 	public ManagedChannel stackdriverSenderChannel() {
-		return ManagedChannelBuilder.forTarget("cloudtrace.googleapis.com")
+		return ManagedChannelBuilder.forTarget("dns:///cloudtrace.googleapis.com")
 				.userAgent(this.headerProvider.getUserAgent())
 				.build();
 	}

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
@@ -57,7 +57,7 @@ public class FirestoreIntegrationTestsConfiguration {
 
 		// Create a channel
 		ManagedChannel channel = ManagedChannelBuilder
-				.forAddress("firestore.googleapis.com", 443)
+				.forTarget("dns:///firestore.googleapis.com:443")
 				.build();
 		return FirestoreGrpc.newStub(channel).withCallCredentials(callCredentials);
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
@@ -107,7 +107,7 @@ public class TraceSampleApplicationTests {
 				.getService();
 
 		ManagedChannel channel = ManagedChannelBuilder
-				.forTarget("cloudtrace.googleapis.com")
+				.forTarget("dns:///cloudtrace.googleapis.com")
 				.build();
 
 		this.traceServiceStub = TraceServiceGrpc.newBlockingStub(channel)


### PR DESCRIPTION
Improves compatibility with libraries that provide additional grpc `NameResolver`s

See also: https://github.com/grpc/grpc-java/pull/6499

yidongnan/grpc-spring-boot-starter#268
yidongnan/grpc-spring-boot-starter#304