### PR TITLE
Spring Cloud Bus has a different release cycle than Spring Cloud Commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<spring-cloud-commons.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
-		<spring-cloud-bus.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-bus.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-bus.version>
 		<spring-cloud-sleuth.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.15.2</zipkin-gcp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<spring-cloud-commons.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-bus.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-sleuth.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.15.2</zipkin-gcp.version>
@@ -100,7 +101,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-bus</artifactId>
-				<version>${spring-cloud-commons.version}</version>
+				<version>${spring-cloud-bus.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Having two separate versions is required, otherwise the release will be broken.

With Hoxton.SR1 we have commons in version 2.2.1 and bus in 2.2.0.