### PR TITLE
stream binder functional sample: mention that explicit functional bean configuration is optional

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink/src/main/resources/application.properties
@@ -5,7 +5,8 @@
 spring.cloud.stream.function.bindings.logUserMessage-in-0=input
 spring.cloud.stream.bindings.input.destination=my-topic
 
-spring.cloud.function.definition=logUserMessage
+# Optional, as Spring Cloud Stream will autodiscover the correct functional bean.
+#spring.cloud.function.definition=logUserMessage
 
 # If group is specified, the Pub/Sub subscription name will be [PUBSUB_TOPIC_NAME].[PUBSUB_GROUP_NAME]
 spring.cloud.stream.bindings.input.group=my-group

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.cloud.stream.function.bindings.logUserMessage-in-0=input
 spring.cloud.stream.bindings.input.destination=my-topic
 
 # Optional, as Spring Cloud Stream will autodiscover the correct functional bean.
-#spring.cloud.function.definition=logUserMessage
+spring.cloud.function.definition=logUserMessage
 
 # If group is specified, the Pub/Sub subscription name will be [PUBSUB_TOPIC_NAME].[PUBSUB_GROUP_NAME]
 spring.cloud.stream.bindings.input.group=my-group

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 # Binding name is based on the Consumer function name.
 spring.cloud.stream.bindings.generateUserMessages-out-0.destination=my-topic
 
-spring.cloud.function.definition=generateUserMessages
+# Optional, as Spring Cloud Stream will autodiscover the correct functional bean.
+#spring.cloud.function.definition=generateUserMessages
 
 #spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
 #spring.cloud.gcp.credentials.location=file:[LOCAL_PATH_TO_CREDENTIALS]

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 spring.cloud.stream.bindings.generateUserMessages-out-0.destination=my-topic
 
 # Optional, as Spring Cloud Stream will autodiscover the correct functional bean.
-#spring.cloud.function.definition=generateUserMessages
+spring.cloud.function.definition=generateUserMessages
 
 #spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID]
 #spring.cloud.gcp.credentials.location=file:[LOCAL_PATH_TO_CREDENTIALS]

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/SampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/SampleAppIntegrationTest.java
@@ -62,14 +62,12 @@ public class SampleAppIntegrationTest {
 
 		// Run Source app
 		SpringApplicationBuilder sourceBuilder = new SpringApplicationBuilder(FunctionalSourceApplication.class)
-				.properties("spring.cloud.function.definition=generateUserMessages")
 				.resourceLoader(new PropertyRemovingResourceLoader("spring-cloud-gcp-pubsub-stream-binder-functional-sample-source"));
 		sourceBuilder.run();
 
 
 		//Run Sink app
 		SpringApplicationBuilder sinkBuilder = new SpringApplicationBuilder(FunctionalSinkApplication.class)
-				.properties("spring.cloud.function.definition=logUserMessage")
 			.resourceLoader(new PropertyRemovingResourceLoader("spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink"));
 		sinkBuilder.run();
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/SampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/SampleAppIntegrationTest.java
@@ -62,12 +62,14 @@ public class SampleAppIntegrationTest {
 
 		// Run Source app
 		SpringApplicationBuilder sourceBuilder = new SpringApplicationBuilder(FunctionalSourceApplication.class)
+				.properties("spring.cloud.function.definition=generateUserMessages")
 				.resourceLoader(new PropertyRemovingResourceLoader("spring-cloud-gcp-pubsub-stream-binder-functional-sample-source"));
 		sourceBuilder.run();
 
 
 		//Run Sink app
 		SpringApplicationBuilder sinkBuilder = new SpringApplicationBuilder(FunctionalSinkApplication.class)
+				.properties("spring.cloud.function.definition=logUserMessage")
 			.resourceLoader(new PropertyRemovingResourceLoader("spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink"));
 		sinkBuilder.run();
 


### PR DESCRIPTION
Follow up to #2013.

Explicit functional bean configuration is no longer required (since SCS will autodiscover when there is only one functional bean available).
Unfortunately, the integration test has both sink and source on its classpath, so it autodiscovers both beans, making explicit definition _in test_ necessary.