### PR TITLE
Upgrade to fix some security vulnerabilities

### DIFF
--- a/spring-cloud-gcp-kotlin-samples/pom.xml
+++ b/spring-cloud-gcp-kotlin-samples/pom.xml
@@ -7,7 +7,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -50,8 +50,7 @@
 		<module>spring-cloud-gcp-data-firestore-sample</module>
 		<module>spring-cloud-gcp-bigquery-sample</module>
 		<module>spring-cloud-gcp-pubsub-stream-binder-functional-sample</module>
-    <module>storage-test-real</module>
-  </modules>
+	</modules>
 
 	<!-- Checkstyle on samples invoked during CI or manually when running locally. -->
 	<profiles>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 
@@ -50,7 +50,8 @@
 		<module>spring-cloud-gcp-data-firestore-sample</module>
 		<module>spring-cloud-gcp-bigquery-sample</module>
 		<module>spring-cloud-gcp-pubsub-stream-binder-functional-sample</module>
-	</modules>
+    <module>storage-test-real</module>
+  </modules>
 
 	<!-- Checkstyle on samples invoked during CI or manually when running locally. -->
 	<profiles>


### PR DESCRIPTION
Snyk identified a potential [privilege escalation](https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-538490) that affects our samples.

Updating to the latest spring-boot-parent should fix it.