### PR TITLE
Add overloaded `createBlob()` method accepting initial file contents.

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -195,6 +195,7 @@ public class GoogleStorageResource implements WritableResource {
 	/**
 	 * Creates the blob that this {@link GoogleStorageResource} represents in Google Cloud
 	 * Storage and fills it with provided content.
+	 * @param contents the initial file contents to write
 	 * @return the created blob object
 	 * @throws StorageException if any errors during blob creation arise,
 	 * such as if the blob already exists

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -310,19 +310,15 @@ public class GoogleStorageResource implements WritableResource {
 			throw new IllegalStateException(
 					"Cannot open an output stream to a bucket: '" + getURI() + "'");
 		}
-		else {
-			Blob blob = getBlob();
 
-			if (blob == null || !blob.exists()) {
-				if (!this.autoCreateFiles) {
-					throw new FileNotFoundException("The blob was not found: " + getURI());
-				}
+		Blob blob = getBlob();
 
-				blob = createBlob();
-			}
-
-			return Channels.newOutputStream(blob.writer());
+		if ((blob == null || !blob.exists()) && !this.autoCreateFiles) {
+			throw new FileNotFoundException("The blob was not found: " + getURI());
 		}
+
+		return Channels.newOutputStream(this.storage.writer(BlobInfo.newBuilder(getBlobId()).build()));
+
 	}
 
 	/**

--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Chengyuan Zhao
  * @author João André Martins
  * @author Daniel Zou
+ * @author Elena Felder
  */
 public class GoogleStorageResource implements WritableResource {
 
@@ -189,6 +190,19 @@ public class GoogleStorageResource implements WritableResource {
 	 */
 	public Blob createBlob() throws StorageException {
 		return this.storage.create(BlobInfo.newBuilder(getBlobId()).build());
+	}
+
+	/**
+	 * Creates the blob that this {@link GoogleStorageResource} represents in Google Cloud
+	 * Storage and fills it with provided content.
+	 * @return the created blob object
+	 * @throws StorageException if any errors during blob creation arise,
+	 * such as if the blob already exists
+	 * @throws IllegalStateException if the resource reference is to a bucket, and not a blob.
+	 * @since 1.3
+	 */
+	public Blob createBlob(byte[] contents) throws StorageException {
+		return this.storage.create(BlobInfo.newBuilder(getBlobId()).build(), contents);
 	}
 
 	/**

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -273,6 +273,20 @@ public class GoogleStorageTests {
 	}
 
 	@Test
+	public void testCreateBlobWithContents() {
+		Storage mockStorage = mock(Storage.class);
+		String location = "gs://test-bucket/filename";
+		byte[] contentBytes = "test contents".getBytes();
+
+		GoogleStorageResource resource = new GoogleStorageResource(mockStorage, location);
+		resource.createBlob(contentBytes);
+
+		verify(mockStorage).create(
+				BlobInfo.newBuilder("test-bucket", "filename").build(),
+				contentBytes);
+	}
+
+	@Test
 	public void testGetInputStreamOnNullBlob() throws Exception {
 		this.expectedEx.expect(FileNotFoundException.class);
 		this.expectedEx.expectMessage("The blob was not found: gs://test-spring/test");

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/GoogleStorageTests.java
@@ -82,30 +82,39 @@ public class GoogleStorageTests {
 	private Resource bucketResource;
 
 	@Autowired
-	private Storage storage;
+	private Storage mockStorage;
 
 	@Test
 	public void testEmptyPath() {
 		this.expectedEx.expect(IllegalArgumentException.class);
 		this.expectedEx.expectMessage("Invalid location: gs://");
-		new GoogleStorageResource(this.storage, "gs://", false);
+		new GoogleStorageResource(this.mockStorage, "gs://", false);
 	}
 
 	@Test
 	public void testSlashPath() {
 		this.expectedEx.expect(IllegalArgumentException.class);
 		this.expectedEx.expectMessage("No bucket specified in the location: gs:///");
-		new GoogleStorageResource(this.storage, "gs:///", false);
+		new GoogleStorageResource(this.mockStorage, "gs:///", false);
 	}
 
 	@Test
 	public void testValidObject() throws Exception {
+		BlobId validBlobId = BlobId.of("test-spring", "images/spring.png");
+		Blob mockedBlob = mock(Blob.class);
+		when(mockedBlob.getSize()).thenReturn(4096L);
+		when(this.mockStorage.get(eq(validBlobId))).thenReturn(mockedBlob);
+
 		Assert.assertTrue(this.remoteResource.exists());
 		Assert.assertEquals(4096L, this.remoteResource.contentLength());
 	}
 
 	@Test
 	public void testValidObjectWithUnderscore() throws Exception {
+		BlobId validBlobWithUnderscore = BlobId.of("test_spring", "images/spring.png");
+		Blob mockedBlob = mock(Blob.class);
+		when(mockStorage.get(eq(validBlobWithUnderscore))).thenReturn(mockedBlob);
+
 		Assert.assertTrue(this.remoteResourceWithUnderscore.exists());
 	}
 
@@ -128,14 +137,20 @@ public class GoogleStorageTests {
 
 	@Test
 	public void testBucketNotEndingInSlash() {
-		Assert.assertTrue(new GoogleStorageResource(this.storage, "gs://test-spring").isBucket());
+		Assert.assertTrue(new GoogleStorageResource(this.mockStorage, "gs://test-spring").isBucket());
 	}
 
 	@Test
 	public void testSpecifyBucketCorrect() {
+
+		Bucket mockedBucket = mock(Bucket.class);
+		when(this.mockStorage.get("test-spring")).thenReturn(mockedBucket);
+		when(mockedBucket.exists()).thenReturn(true);
+		when(mockedBucket.getName()).thenReturn("test-spring");
+
 		GoogleStorageLocation location = GoogleStorageLocation.forBucket("test-spring");
 		GoogleStorageResource googleStorageResource = new GoogleStorageResource(
-				this.storage, location, false);
+				this.mockStorage, location, false);
 
 		Assert.assertTrue(googleStorageResource.isBucket());
 		Assert.assertEquals("test-spring", googleStorageResource.getBucketName());
@@ -145,8 +160,12 @@ public class GoogleStorageTests {
 
 	@Test
 	public void testSpecifyPathCorrect() {
+		BlobId validBlobId = BlobId.of("test-spring", "images/spring.png");
+		Blob mockedBlob = mock(Blob.class);
+		when(this.mockStorage.get(eq(validBlobId))).thenReturn(mockedBlob);
+
 		GoogleStorageResource googleStorageResource = new GoogleStorageResource(
-				this.storage, "gs://test-spring/images/spring.png", false);
+				this.mockStorage, "gs://test-spring/images/spring.png", false);
 
 		Assert.assertTrue(googleStorageResource.exists());
 	}
@@ -198,6 +217,9 @@ public class GoogleStorageTests {
 
 	@Test
 	public void testWritable() throws Exception {
+		WriteChannel writeChannel = mock(WriteChannel.class);
+		when(this.mockStorage.writer(any(BlobInfo.class))).thenReturn(writeChannel);
+
 		Assert.assertTrue(this.remoteResource instanceof WritableResource);
 		WritableResource writableResource = (WritableResource) this.remoteResource;
 		Assert.assertTrue(writableResource.isWritable());
@@ -207,14 +229,13 @@ public class GoogleStorageTests {
 	@Test
 	public void testWritableOutputStream() throws Exception {
 		String location = "gs://test-spring/test";
-		Storage storage = mock(Storage.class);
 		Blob blob = mock(Blob.class);
 		WriteChannel writeChannel = mock(WriteChannel.class);
 		when(blob.writer()).thenReturn(writeChannel);
 		when(blob.exists()).thenReturn(true);
-		when(storage.get(BlobId.of("test-spring", "test"))).thenReturn(blob);
+		when(this.mockStorage.get(BlobId.of("test-spring", "test"))).thenReturn(blob);
 
-		GoogleStorageResource resource = new GoogleStorageResource(storage, location);
+		GoogleStorageResource resource = new GoogleStorageResource(this.mockStorage, location);
 		OutputStream os = resource.getOutputStream();
 		Assert.assertNotNull(os);
 	}
@@ -224,10 +245,9 @@ public class GoogleStorageTests {
 		this.expectedEx.expect(FileNotFoundException.class);
 		this.expectedEx.expectMessage("The blob was not found: gs://test-spring/test");
 		String location = "gs://test-spring/test";
-		Storage storage = mock(Storage.class);
-		when(storage.get(BlobId.of("test-spring", "test"))).thenReturn(null);
+		when(this.mockStorage.get(BlobId.of("test-spring", "test"))).thenReturn(null);
 
-		GoogleStorageResource resource = new GoogleStorageResource(storage, location,
+		GoogleStorageResource resource = new GoogleStorageResource(this.mockStorage, location,
 				false);
 		resource.getOutputStream();
 	}
@@ -235,16 +255,15 @@ public class GoogleStorageTests {
 	@Test
 	public void testWritableOutputStreamWithAutoCreateOnNullBlob() throws Exception {
 		String location = "gs://test-spring/test";
-		Storage storage = mock(Storage.class);
 		BlobId blobId = BlobId.of("test-spring", "test");
-		when(storage.get(blobId)).thenReturn(null);
+		when(this.mockStorage.get(blobId)).thenReturn(null);
 		BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 		WriteChannel writeChannel = mock(WriteChannel.class);
 		Blob blob = mock(Blob.class);
 		when(blob.writer()).thenReturn(writeChannel);
-		when(storage.create(blobInfo)).thenReturn(blob);
+		when(this.mockStorage.create(blobInfo)).thenReturn(blob);
 
-		GoogleStorageResource resource = new GoogleStorageResource(storage, location);
+		GoogleStorageResource resource = new GoogleStorageResource(this.mockStorage, location);
 		GoogleStorageResource spyResource = spy(resource);
 		OutputStream os = spyResource.getOutputStream();
 		Assert.assertNotNull(os);
@@ -254,19 +273,18 @@ public class GoogleStorageTests {
 	public void testWritableOutputStreamWithAutoCreateOnNonExistantBlob()
 			throws Exception {
 		String location = "gs://test-spring/test";
-		Storage storage = mock(Storage.class);
 		BlobId blobId = BlobId.of("test-spring", "test");
 		Blob nonExistantBlob = mock(Blob.class);
 		when(nonExistantBlob.exists()).thenReturn(false);
-		when(storage.get(blobId)).thenReturn(nonExistantBlob);
+		when(this.mockStorage.get(blobId)).thenReturn(nonExistantBlob);
 		BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 		WriteChannel writeChannel = mock(WriteChannel.class);
 		Blob blob = mock(Blob.class);
 		when(blob.writer()).thenReturn(writeChannel);
-		when(storage.create(blobInfo)).thenReturn(blob);
+		when(this.mockStorage.create(blobInfo)).thenReturn(blob);
 
 
-		GoogleStorageResource resource = new GoogleStorageResource(storage, location);
+		GoogleStorageResource resource = new GoogleStorageResource(this.mockStorage, location);
 		GoogleStorageResource spyResource = spy(resource);
 		OutputStream os = spyResource.getOutputStream();
 		Assert.assertNotNull(os);
@@ -369,7 +387,11 @@ public class GoogleStorageTests {
 
 	@Test
 	public void testBucketDoesNotExist() {
-		GoogleStorageResource bucket = new GoogleStorageResource(this.storage, "gs://non-existing/");
+		Bucket mockedBucket = mock(Bucket.class);
+		when(this.mockStorage.create(BucketInfo.newBuilder("non-existing").build())).thenReturn(mockedBucket);
+		when(mockedBucket.getName()).thenReturn("test-spring");
+
+		GoogleStorageResource bucket = new GoogleStorageResource(this.mockStorage, "gs://non-existing/");
 		Assert.assertFalse(bucket.bucketExists());
 		Assert.assertFalse(bucket.exists());
 
@@ -378,7 +400,12 @@ public class GoogleStorageTests {
 
 	@Test
 	public void testBucketExistsButResourceDoesNot() {
-		GoogleStorageResource resource = new GoogleStorageResource(this.storage, "gs://test-spring/file1");
+		GoogleStorageResource resource = new GoogleStorageResource(this.mockStorage, "gs://test-spring/file1");
+
+		Bucket mockedBucket = mock(Bucket.class);
+		when(this.mockStorage.get("test-spring")).thenReturn(mockedBucket);
+		when(mockedBucket.exists()).thenReturn(true);
+
 		Assert.assertTrue(resource.bucketExists());
 		Assert.assertFalse(resource.exists());
 	}
@@ -392,22 +419,7 @@ public class GoogleStorageTests {
 
 		@Bean
 		public static Storage mockStorage() throws Exception {
-			Storage storage = mock(Storage.class);
-			BlobId validBlob = BlobId.of("test-spring", "images/spring.png");
-			BlobId validBlobWithUnderscore = BlobId.of("test_spring", "images/spring.png");
-			Bucket mockedBucket = mock(Bucket.class);
-			Blob mockedBlob = mock(Blob.class);
-			WriteChannel writeChannel = mock(WriteChannel.class);
-			when(mockedBlob.exists()).thenReturn(true);
-			when(mockedBucket.exists()).thenReturn(true);
-			when(mockedBlob.getSize()).thenReturn(4096L);
-			when(storage.get(eq(validBlob))).thenReturn(mockedBlob);
-			when(storage.get(eq(validBlobWithUnderscore))).thenReturn(mockedBlob);
-			when(storage.get("test-spring")).thenReturn(mockedBucket);
-			when(storage.create(BucketInfo.newBuilder("non-existing").build())).thenReturn(mockedBucket);
-			when(mockedBucket.getName()).thenReturn("test-spring");
-			when(mockedBlob.writer()).thenReturn(writeChannel);
-			return storage;
+			return mock(Storage.class);
 		}
 
 		@Bean

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/it/GoogleStorageIntegrationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/it/GoogleStorageIntegrationTests.java
@@ -102,6 +102,20 @@ public class GoogleStorageIntegrationTests {
 
 		String message = "test message";
 
+		thisResource().createBlob(message.getBytes());
+
+		assertThat(this.resource.exists()).isTrue();
+
+		try (InputStream is = this.resource.getInputStream()) {
+			assertThat(StreamUtils.copyToString(is, Charset.defaultCharset())).isEqualTo(message);
+		}
+	}
+
+	@Test
+	public void createWithContent() throws IOException {
+
+		String message = "test message";
+
 		try (OutputStream os = thisResource().getOutputStream()) {
 			os.write(message.getBytes());
 		}
@@ -126,6 +140,7 @@ public class GoogleStorageIntegrationTests {
 			assertThat(StreamUtils.copyToString(is, Charset.defaultCharset())).isEqualTo(message);
 		}
 	}
+
 
 	/**
 	 * Spring config for the tests.


### PR DESCRIPTION
Fixes #2097.