### PR TITLE
Allows the ACK_MODE to be configurable when using Stream Binders

### DIFF
--- a/docs/src/main/asciidoc/spring-stream.adoc
+++ b/docs/src/main/asciidoc/spring-stream.adoc
@@ -55,6 +55,18 @@ spring.cloud.stream.gcp.pubsub.bindings.events.producer.auto-create-resources=tr
 
 ==== Consumer Destination Configuration
 
+A `PubSubInboundChannelAdapter` will be configured for your consumer endpoint.
+You may adjust the `ACK_MODE` of the consumer endpoint which controls how messages will be acknowledged when they are successfully received through the `ack-mode` property.
+The three possible options are: `AUTO` (default), `AUTO_ACK`, and `MANUAL`.
+These options are described in detail in the <<inbound-channel-adapter-using-pubsub-streaming-pull, Pub/Sub channel adapter documentation>>.
+
+.application.properties
+[source]
+----
+# How to set the ACK mode of the consumer endpoint.
+spring.cloud.stream.gcp.pubsub.bindings.{CONSUMER_NAME}.consumer.ack-mode=AUTO_ACK
+----
+
 If automatic resource creation is turned ON and the subscription and/or the topic do not exist for a consumer, a subscription and potentially a topic will be created.
 The topic name will be the same as the destination name, and the subscription name will be the destination name followed by the consumer group name.
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -85,6 +85,7 @@ public class PubSubMessageChannelBinder
 
 		ErrorInfrastructure errorInfrastructure = registerErrorInfrastructure(destination, group, properties);
 		adapter.setErrorChannel(errorInfrastructure.getErrorChannel());
+		adapter.setAckMode(properties.getExtension().getAckMode());
 
 		return adapter;
 	}

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -28,13 +28,13 @@ import org.springframework.cloud.gcp.pubsub.integration.AckMode;
  */
 public class PubSubConsumerProperties extends PubSubCommonProperties {
 
-  private AckMode ackMode = AckMode.AUTO;
+	private AckMode ackMode = AckMode.AUTO;
 
-  public AckMode getAckMode() {
-    return ackMode;
-  }
+	public AckMode getAckMode() {
+		return ackMode;
+	}
 
-  public void setAckMode(AckMode ackMode) {
-    this.ackMode = ackMode;
-  }
+	public void setAckMode(AckMode ackMode) {
+		this.ackMode = ackMode;
+	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
+import org.springframework.cloud.gcp.pubsub.integration.AckMode;
+
 /**
  * Consumer properties for Pub/Sub.
  *
@@ -26,4 +28,13 @@ package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
  */
 public class PubSubConsumerProperties extends PubSubCommonProperties {
 
+  private AckMode ackMode = AckMode.AUTO;
+
+  public AckMode getAckMode() {
+    return ackMode;
+  }
+
+  public void setAckMode(AckMode ackMode) {
+    this.ackMode = ackMode;
+  }
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
 import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
 import com.google.pubsub.v1.Subscription;
@@ -23,13 +28,13 @@ import com.google.pubsub.v1.Topic;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.core.publisher.PubSubPublisherTemplate;
 import org.springframework.cloud.gcp.pubsub.core.subscriber.PubSubSubscriberTemplate;
+import org.springframework.cloud.gcp.pubsub.integration.AckMode;
 import org.springframework.cloud.gcp.pubsub.support.PublisherFactory;
 import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.cloud.gcp.stream.binder.pubsub.PubSubMessageChannelBinder;
@@ -47,11 +52,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-
 /**
  * Tests for extended binding properties.
  *
@@ -64,6 +64,7 @@ import static org.mockito.Mockito.when;
 				BindingServiceConfiguration.class
 		},
 		properties = {
+				"spring.cloud.stream.gcp.pubsub.bindings.input.consumer.ack-mode=AUTO_ACK",
 				"spring.cloud.stream.gcp.pubsub.bindings.input.consumer.auto-create-resources=true",
 				"spring.cloud.stream.gcp.pubsub.default.consumer.auto-create-resources=false"
 		})
@@ -80,6 +81,11 @@ public class PubSubExtendedBindingsPropertiesTests {
 
 		assertThat(binder.getExtendedConsumerProperties("custom-in").isAutoCreateResources()).isFalse();
 		assertThat(binder.getExtendedConsumerProperties("input").isAutoCreateResources()).isTrue();
+
+		assertThat(binder.getExtendedConsumerProperties("custom-in").getAckMode())
+				.isEqualTo(AckMode.AUTO);
+		assertThat(binder.getExtendedConsumerProperties("input").getAckMode())
+				.isEqualTo(AckMode.AUTO_ACK);
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
@@ -16,11 +16,6 @@
 
 package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-
 import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
 import com.google.pubsub.v1.Subscription;
@@ -28,6 +23,7 @@ import com.google.pubsub.v1.Topic;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gcp.pubsub.PubSubAdmin;
@@ -52,22 +48,25 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
 /**
  * Tests for extended binding properties.
  *
  * @author Daniel Zou
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		classes = {
-				PubSubBindingsTestConfiguration.class,
-				BindingServiceConfiguration.class
-		},
-		properties = {
-				"spring.cloud.stream.gcp.pubsub.bindings.input.consumer.ack-mode=AUTO_ACK",
-				"spring.cloud.stream.gcp.pubsub.bindings.input.consumer.auto-create-resources=true",
-				"spring.cloud.stream.gcp.pubsub.default.consumer.auto-create-resources=false"
-		})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = {
+		PubSubBindingsTestConfiguration.class,
+		BindingServiceConfiguration.class
+}, properties = {
+		"spring.cloud.stream.gcp.pubsub.bindings.input.consumer.ack-mode=AUTO_ACK",
+		"spring.cloud.stream.gcp.pubsub.bindings.input.consumer.auto-create-resources=true",
+		"spring.cloud.stream.gcp.pubsub.default.consumer.auto-create-resources=false"
+})
 public class PubSubExtendedBindingsPropertiesTests {
 
 	@Autowired
@@ -142,4 +141,3 @@ public class PubSubExtendedBindingsPropertiesTests {
 		}
 	}
 }
-


### PR DESCRIPTION
This allows the user to configure the ACK_MODE when using the Pub/Sub Spring Cloud Stream binder.

Fixes #2079