### PR TITLE
Add overloaded `createBlob()` method accepting initial file contents.…

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/org/springframework/cloud/gcp/storage/GoogleStorageResource.java
@@ -200,7 +200,6 @@ public class GoogleStorageResource implements WritableResource {
 	 * @throws StorageException if any errors during blob creation arise,
 	 * such as if the blob already exists
 	 * @throws IllegalStateException if the resource reference is to a bucket, and not a blob.
-	 * @since 1.3
 	 */
 	public Blob createBlob(byte[] contents) throws StorageException {
 		return this.storage.create(BlobInfo.newBuilder(getBlobId()).build(), contents);

--- a/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/it/GoogleStorageIntegrationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/org/springframework/cloud/gcp/storage/it/GoogleStorageIntegrationTests.java
@@ -102,6 +102,20 @@ public class GoogleStorageIntegrationTests {
 
 		String message = "test message";
 
+		thisResource().createBlob(message.getBytes());
+
+		assertThat(this.resource.exists()).isTrue();
+
+		try (InputStream is = this.resource.getInputStream()) {
+			assertThat(StreamUtils.copyToString(is, Charset.defaultCharset())).isEqualTo(message);
+		}
+	}
+
+	@Test
+	public void createWithContent() throws IOException {
+
+		String message = "test message";
+
 		try (OutputStream os = thisResource().getOutputStream()) {
 			os.write(message.getBytes());
 		}
@@ -126,6 +140,7 @@ public class GoogleStorageIntegrationTests {
 			assertThat(StreamUtils.copyToString(is, Charset.defaultCharset())).isEqualTo(message);
 		}
 	}
+
 
 	/**
 	 * Spring config for the tests.


### PR DESCRIPTION
Backporting the fix to 1.2.x branch.

* Add overloaded `createBlob()` method accepting initial file contents.
* changed getOutputStream() to not pre-create the file

Follow-up to #2097.
Fixes #2102.