### PR TITLE
Downgrading samples back to SB 2.2

### DIFF
--- a/spring-cloud-gcp-kotlin-samples/pom.xml
+++ b/spring-cloud-gcp-kotlin-samples/pom.xml
@@ -7,7 +7,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
This will align the samples to the same version of Spring Boot as the rest of the project.
Currently, spring-cloud-build only supports Spring Boot 2.2.