### PR TITLE
Update spring-integration-pubsub.adoc

### DIFF
--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -53,9 +53,9 @@ public MessageChannel pubsubInputChannel() {
 @Bean
 public PubSubInboundChannelAdapter messageChannelAdapter(
     @Qualifier("pubsubInputChannel") MessageChannel inputChannel,
-    SubscriberFactory subscriberFactory) {
+    PubSubSubscriberOperations subscriberOperations) {
     PubSubInboundChannelAdapter adapter =
-        new PubSubInboundChannelAdapter(subscriberFactory, "subscriptionName");
+        new PubSubInboundChannelAdapter(subscriberOperations, "subscriptionName");
     adapter.setOutputChannel(inputChannel);
     adapter.setAckMode(AckMode.MANUAL);
 


### PR DESCRIPTION
This has been wrong for two and a half years. I suppose people go to samples and not docs to copy/paste snippets.