### PR TITLE
Remove missing dependencies from BOM

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,7 +59,7 @@ This will allow you to not specify versions for any of the Maven dependencies an
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-dependencies</artifactId>
-            <version>1.1.2.RELEASE</version>
+            <version>1.2.1.RELEASE</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -36,6 +36,7 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>spring-cloud-gcp-starter-config</artifactId>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -5,15 +5,16 @@ Spring Cloud GCP makes it possible to use the https://cloud.google.com/deploymen
 The Spring Cloud GCP Config support is provided via its own Spring Boot starter.
 It enables the use of the Google Runtime Configuration API as a source for Spring Boot configuration properties.
 
-NOTE: The Google Cloud Runtime Configuration service is in beta status.
+NOTE: The Google Cloud Runtime Configuration service is in *Beta* status, and is only available in snapshot and milestone versions of the project. It's also not available in the Spring Cloud GCP BOM, unlike other modules.
 
-Maven coordinates, using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
+Maven coordinates:
 
-[source,xml]
+[source,xml,subs="normal"]
 ----
 <dependency>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-gcp-starter-config</artifactId>
+    <version>{project-version}</version>
 </dependency>
 ----
 
@@ -22,7 +23,9 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-config'
+    compile group: 'org.springframework.cloud',
+    name: 'spring-cloud-gcp-starter-config',
+    version: '{project-version}'
 }
 ----
 

--- a/docs/src/main/asciidoc/firestore.adoc
+++ b/docs/src/main/asciidoc/firestore.adoc
@@ -202,7 +202,7 @@ Read documents are locked until the transaction finishes with a commit or a roll
 If an `Exception` is thrown within a transaction, the rollback operation is executed.
 Otherwise, the commit operation is executed.
 
-===== Declarative Transactions with @Transactional Annotation
+==== Declarative Transactions with @Transactional Annotation
 
 This feature requires a bean of `SpannerTransactionManager`, which is provided when using `spring-cloud-gcp-starter-data-firestore`.
 

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -65,17 +65,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-gcp-trace</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-gcp-logging</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-gcp-config</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -153,11 +143,6 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-gcp-starter-sql-postgresql</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-gcp-starter-config</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/pom.xml
@@ -15,19 +15,6 @@
     <artifactId>spring-cloud-gcp-config-sample</artifactId>
     <name>Spring Cloud GCP Runtime Configuration Code Sample</name>
 
-    <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-gcp-dependencies</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -38,6 +25,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-config</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Optional dependency to enable configuration refresh runtime via /refresh endpoint -->


### PR DESCRIPTION
Removing `spring-cloud-gcp-trace` and `spring-cloud-gcp-config` from the
BOM because they don't exist.

Also, removing `spring-cloud-gcp-starter-config` because it's never
published to Maven Central.

Fixes: #2138.