### PR TITLE
Enable usage of projections within Slice repository queries

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/AbstractDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/AbstractDatastoreQuery.java
@@ -85,7 +85,7 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
 						: converted.get(0).getClass(), converted.size()));
 	}
 
-	Object processRawObjectForProjection(T object) {
+	Object processRawObjectForProjection(Object object) {
 		return this.queryMethod.getResultProcessor().processResult(object);
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/PartTreeDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/PartTreeDatastoreQuery.java
@@ -244,8 +244,11 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 		StructuredQuery queryNext = applyQueryBody(parameters, builderNext, false, true, resultList.getCursor());
 		List datastoreResultsList = this.datastoreTemplate.query(queryNext, x -> x);
 
-		return new SliceImpl(StreamSupport.stream(resultList.spliterator(), false).collect(Collectors.toList()),
-				pageable, !datastoreResultsList.isEmpty());
+		List<Object> result =
+				StreamSupport.stream(resultList.spliterator(), false).collect(Collectors.toList());
+
+		return (Slice) this.processRawObjectForProjection(
+				new SliceImpl(result, pageable, !datastoreResultsList.isEmpty()));
 	}
 
 	Object convertResultCollection(Object result, Class<?> collectionType) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -796,12 +796,8 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 
 	@Test
 	public void testSlicedEntityProjections() {
-		testEntityRepository.saveAll(this.allTestEntities);
-		testEntityRepository.save(new TestEntity(123L, "red", 1L, Shape.CIRCLE, null));
-		testEntityRepository.save(new TestEntity(456L, "blue", 2L, Shape.CIRCLE, null));
-
 		Slice<TestEntityProjection> testEntityProjectionSlice =
-				testEntityRepository.findBySize(1L, PageRequest.of(0, 1));
+				testEntityRepository.findBySize(2L, PageRequest.of(0, 1));
 
 		List<TestEntityProjection> testEntityProjections =
 				testEntityProjectionSlice.get().collect(Collectors.toList());
@@ -809,6 +805,9 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(testEntityProjections).hasSize(1);
 		assertThat(testEntityProjections.get(0)).isInstanceOf(TestEntityProjection.class);
 		assertThat(testEntityProjections.get(0)).isNotInstanceOf(TestEntity.class);
+
+		// Verifies that the projection method call works.
+		assertThat(testEntityProjections.get(0).getColor()).isEqualTo("blue");
 	}
 }
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -793,6 +793,23 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(readCompany.leaders).hasSize(1);
 		assertThat(readCompany.leaders.get(0).id).isEqualTo(entity1.id);
 	}
+
+	@Test
+	public void testSlicedEntityProjections() {
+		testEntityRepository.saveAll(this.allTestEntities);
+		testEntityRepository.save(new TestEntity(123L, "red", 1L, Shape.CIRCLE, null));
+		testEntityRepository.save(new TestEntity(456L, "blue", 2L, Shape.CIRCLE, null));
+
+		Slice<TestEntityProjection> testEntityProjectionSlice =
+				testEntityRepository.findBySize(1L, PageRequest.of(0, 1));
+
+		List<TestEntityProjection> testEntityProjections =
+				testEntityProjectionSlice.get().collect(Collectors.toList());
+
+		assertThat(testEntityProjections).hasSize(1);
+		assertThat(testEntityProjections.get(0)).isInstanceOf(TestEntityProjection.class);
+		assertThat(testEntityProjections.get(0)).isNotInstanceOf(TestEntity.class);
+	}
 }
 
 /**

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TestEntityRepository.java
@@ -107,7 +107,7 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 	@Query("select * from  test_entities_ci where size = @size")
 	TestEntityProjection getBySize(@Param("size") long size);
 
-	Slice<TestEntityProjection> findBySize(@Param("size") long size, Pageable pageable);
+	Slice<TestEntityProjection> findBySize(long size, Pageable pageable);
 
 	Page<TestEntity> findByShape(Shape shape, Pageable pageable);
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TestEntityRepository.java
@@ -107,6 +107,8 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 	@Query("select * from  test_entities_ci where size = @size")
 	TestEntityProjection getBySize(@Param("size") long size);
 
+	Slice<TestEntityProjection> findBySize(@Param("size") long size, Pageable pageable);
+
 	Page<TestEntity> findByShape(Shape shape, Pageable pageable);
 
 	Slice<TestEntity> findByColor(String color, Pageable pageable);


### PR DESCRIPTION
This fixes the typing issue with projections so you can now use projection objects within your repositories queries that use Slice. i.e.

```
Slice<TestEntityProjection> findByName(String name, Pageable pageable)
```

Fixes #2133.

I think there is a bigger enhancement to make here -- I found that right now there is no performance benefit from using projections since when we issue the query to datastore, we don't restrict the query to only contain the necessary fields of the projection (we still just get everything). Filed #2145 to track.

cc/ @Flexy-recruitment-backend 