### PR TITLE
Add @ConditionalOnProperty to GcpContextAutoConfiguration

### DIFF
--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -24,6 +24,15 @@ dependencies {
 }
 ----
 
+=== Configuration
+
+The following options may be configured with Spring Cloud core.
+
+|===========================================================================
+| Name | Description | Required | Default value
+| `spring.cloud.gcp.core.enabled` | Enables or disables GCP core auto configuration | No | `true`
+|===========================================================================
+
 === Project ID
 
 `GcpProjectIdProvider` is a functional interface that returns a GCP project ID string.

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfiguration.java
@@ -31,10 +31,10 @@ import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+
 /**
- * Base starter for Google Cloud Projects. Provides defaults for
- * {@link com.google.auth.oauth2.GoogleCredentials}. Binds properties from
- * {@link GcpProperties}.
+ * Base starter for Google Cloud Projects. Provides defaults for {@link com.google.auth.oauth2.GoogleCredentials}.
+ * Binds properties from {@link GcpProperties}.
  *
  * @author Vinicius Carvalho
  * @author João André Martins
@@ -63,15 +63,16 @@ public class GcpContextAutoConfiguration {
 
 	/**
 	 * Get a GCP project ID provider.
-	 * @return a {@link GcpProjectIdProvider} that returns the project ID in the properties
-	 * or, if none, the project ID from the GOOGLE_CLOUD_PROJECT envvar and Metadata Server
+	 * @return a {@link GcpProjectIdProvider} that returns the project ID in the properties or, if
+	 * none, the project ID from the GOOGLE_CLOUD_PROJECT envvar and Metadata Server
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public GcpProjectIdProvider gcpProjectIdProvider() {
-		GcpProjectIdProvider projectIdProvider = (this.gcpProperties.getProjectId() != null)
-				? () -> this.gcpProperties.getProjectId()
-				: new DefaultGcpProjectIdProvider();
+		GcpProjectIdProvider projectIdProvider =
+				(this.gcpProperties.getProjectId() != null)
+						? () -> this.gcpProperties.getProjectId()
+						: new DefaultGcpProjectIdProvider();
 
 		if (LOGGER.isInfoEnabled()) {
 			LOGGER.info("The default project ID is " + projectIdProvider.getProjectId());
@@ -81,8 +82,8 @@ public class GcpContextAutoConfiguration {
 	}
 
 	/**
-	 * Provides default implementation for determining GCP environment. Can be overridden to
-	 * avoid interacting with real environment.
+	 * Provides default implementation for determining GCP environment.
+	 * Can be overridden to avoid interacting with real environment.
 	 * @since 1.1
 	 * @return a GCP environment provider
 	 */

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.DefaultGcpEnvironmentProvider;
@@ -30,18 +31,20 @@ import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-
 /**
- * Base starter for Google Cloud Projects. Provides defaults for {@link com.google.auth.oauth2.GoogleCredentials}.
- * Binds properties from {@link GcpProperties}.
+ * Base starter for Google Cloud Projects. Provides defaults for
+ * {@link com.google.auth.oauth2.GoogleCredentials}. Binds properties from
+ * {@link GcpProperties}.
  *
  * @author Vinicius Carvalho
  * @author João André Martins
  * @author Mike Eltsufin
  * @author Elena Felder
  * @author Chengyuan Zhao
+ * @author Serhat Soydan
  */
 @Configuration
+@ConditionalOnProperty(name = "spring.cloud.gcp.core.enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(GcpProperties.class)
 public class GcpContextAutoConfiguration {
 	private static final Log LOGGER = LogFactory.getLog(GcpContextAutoConfiguration.class);
@@ -60,16 +63,15 @@ public class GcpContextAutoConfiguration {
 
 	/**
 	 * Get a GCP project ID provider.
-	 * @return a {@link GcpProjectIdProvider} that returns the project ID in the properties or, if
-	 * none, the project ID from the GOOGLE_CLOUD_PROJECT envvar and Metadata Server
+	 * @return a {@link GcpProjectIdProvider} that returns the project ID in the properties
+	 * or, if none, the project ID from the GOOGLE_CLOUD_PROJECT envvar and Metadata Server
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public GcpProjectIdProvider gcpProjectIdProvider() {
-		GcpProjectIdProvider projectIdProvider =
-				(this.gcpProperties.getProjectId() != null)
-						? () -> this.gcpProperties.getProjectId()
-						: new DefaultGcpProjectIdProvider();
+		GcpProjectIdProvider projectIdProvider = (this.gcpProperties.getProjectId() != null)
+				? () -> this.gcpProperties.getProjectId()
+				: new DefaultGcpProjectIdProvider();
 
 		if (LOGGER.isInfoEnabled()) {
 			LOGGER.info("The default project ID is " + projectIdProvider.getProjectId());
@@ -79,8 +81,8 @@ public class GcpContextAutoConfiguration {
 	}
 
 	/**
-	 * Provides default implementation for determining GCP environment.
-	 * Can be overridden to avoid interacting with real environment.
+	 * Provides default implementation for determining GCP environment. Can be overridden to
+	 * avoid interacting with real environment.
 	 * @since 1.1
 	 * @return a GCP environment provider
 	 */

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -71,6 +71,12 @@
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud Vision components.",
       "defaultValue": true
+    },
+    {
+      "name": "spring.cloud.gcp.core.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud Core components.",
+      "defaultValue": true
     }
   ]
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfigurationTests.java
@@ -44,16 +44,18 @@ public class GcpContextAutoConfigurationTests {
 	@Test
 	public void testGetProjectIdProvider_withGcpProperties() {
 		this.contextRunner.withPropertyValues("spring.cloud.gcp.projectId=tonberry")
-				.run(context -> {
-					GcpProjectIdProvider projectIdProvider = context.getBean(GcpProjectIdProvider.class);
+				.run((context) -> {
+					GcpProjectIdProvider projectIdProvider =
+							context.getBean(GcpProjectIdProvider.class);
 					assertThat(projectIdProvider.getProjectId()).isEqualTo("tonberry");
 				});
 	}
 
 	@Test
 	public void testGetProjectIdProvider_withoutGcpProperties() {
-		this.contextRunner.run(context -> {
-			GcpProjectIdProvider projectIdProvider = context.getBean(GcpProjectIdProvider.class);
+		this.contextRunner.run((context) -> {
+			GcpProjectIdProvider projectIdProvider =
+					context.getBean(GcpProjectIdProvider.class);
 			assertThat(projectIdProvider).isInstanceOf(DefaultGcpProjectIdProvider.class);
 		});
 	}
@@ -61,7 +63,7 @@ public class GcpContextAutoConfigurationTests {
 	@Test
 	public void testEnvironmentProvider() {
 		this.contextRunner
-				.run(context -> {
+				.run((context) -> {
 					GcpEnvironmentProvider environmentProvider = context.getBean(GcpEnvironmentProvider.class);
 					assertThat(environmentProvider).isNotNull();
 					assertThat(environmentProvider).isInstanceOf(DefaultGcpEnvironmentProvider.class);


### PR DESCRIPTION
Add conditional property to GCP core auto configuration.
"spring.cloud.gcp.core.enabled" property enables/disables the GCP core auto configuration.

Related document is updated. Unit tests are added.
Implemented for #2147 