### PR TITLE
Fix Datastore Projections for GQL Queries

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQuery.java
@@ -150,7 +150,7 @@ public class GqlDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 					new ParametersParameterAccessor(getQueryMethod().getParameters(), parameters).getPageable();
 			List resultsList = found == null ? Collections.emptyList()
 					: this.datastoreTemplate.getDatastoreEntityConverter().getConversions()
-							.convertOnRead(found, List.class, returnedItemType);
+							.convertOnRead(applyProjection(found), List.class, returnedItemType);
 
 			if (isPageQuery()) {
 				result = buildPage(pageableParam, parsedQueryWithTagsAndValues, found.getCursor(), resultsList);

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -809,6 +809,20 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		// Verifies that the projection method call works.
 		assertThat(testEntityProjections.get(0).getColor()).isEqualTo("blue");
 	}
+
+	@Test
+	public void testPageableGqlEntityProjections() {
+	  Page<TestEntityProjection> page =
+				testEntityRepository.getBySize(2L, PageRequest.of(0, 3));
+
+		List<TestEntityProjection> testEntityProjections =
+				page.get().collect(Collectors.toList());
+
+		assertThat(testEntityProjections).hasSize(1);
+		assertThat(testEntityProjections.get(0)).isInstanceOf(TestEntityProjection.class);
+		assertThat(testEntityProjections.get(0)).isNotInstanceOf(TestEntity.class);
+		assertThat(testEntityProjections.get(0).getColor()).isEqualTo("blue");
+	}
 }
 
 /**

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -812,7 +812,7 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 
 	@Test
 	public void testPageableGqlEntityProjections() {
-	  Page<TestEntityProjection> page =
+		Page<TestEntityProjection> page =
 				testEntityRepository.getBySize(2L, PageRequest.of(0, 3));
 
 		List<TestEntityProjection> testEntityProjections =

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/TestEntityRepository.java
@@ -107,6 +107,9 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 	@Query("select * from  test_entities_ci where size = @size")
 	TestEntityProjection getBySize(@Param("size") long size);
 
+	@Query("select * from test_entities_ci where size = @size")
+	Page<TestEntityProjection> getBySize(@Param("size") long size, Pageable pageable);
+
 	Slice<TestEntityProjection> findBySize(long size, Pageable pageable);
 
 	Page<TestEntity> findByShape(Shape shape, Pageable pageable);


### PR DESCRIPTION
This PR enables the usage of Projections in Paged GQL queries.

Fixes #2139.