### PR TITLE
Nit: fix an error in the comment for `inputChannel`

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
@@ -46,8 +46,9 @@ public class SinkExample {
 				" at " + userMessage.getCreatedAt());
 	}
 
-	// Note that the error inputChannel is formatted as [Pub/Sub subscription name with group].[group name].errors
-	// If you change the topic name in application.properties, you also have to change the inputChannel below.
+	// Note that the error `inputChannel` is formatted as [Pub/Sub subscription name].errors 
+	// or the equivalent of [Pub/Sub topic name].[group name].errors. If you change the topic name in
+	// `application.properties`, you will also have to change the `inputChannel` below.
 	@ServiceActivator(inputChannel = "my-topic.my-group.errors")
 	public void error(Message<MessagingException> message) {
 		LOGGER.error("The message that was sent is now processed by the error handler.");

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/main/java/com/example/SinkExample.java
@@ -46,7 +46,7 @@ public class SinkExample {
 				" at " + userMessage.getCreatedAt());
 	}
 
-	// Note that the error `inputChannel` is formatted as [Pub/Sub subscription name].errors 
+	// Note that the error `inputChannel` is formatted as [Pub/Sub subscription name].errors
 	// or the equivalent of [Pub/Sub topic name].[group name].errors. If you change the topic name in
 	// `application.properties`, you will also have to change the `inputChannel` below.
 	@ServiceActivator(inputChannel = "my-topic.my-group.errors")


### PR DESCRIPTION
Unless the code is wrong, the comment has a mistake in it. 

The error `inputChannel` should be`[Pub/Sub topic name].[group name].error` = `[Pub/Sub subscription name].error`, but **not** `[Pub/Sub subscription name with group name].[group name].error` because the Pub/Sub subscription name is the Pub/Sub topic name dot the group name, if one is specified. 