### PR TITLE
fix failing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<spring-cloud-stream.version>Fishtown.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.9.0</zipkin-gcp.version>
 		<!-- this is a temporary workaround until we upgrade to the latest zipkin-sender-stackdriver -->
-		<brave.version>5.8.0</brave.version>
+		<brave.version>5.9.2</brave.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
 	</properties>

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/core/environment/OnGcpEnvironmentConditionTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/core/environment/OnGcpEnvironmentConditionTests.java
@@ -89,8 +89,7 @@ public class OnGcpEnvironmentConditionTests {
 	public void testExceptionThrownWhenWrongAttributeType() {
 
 		this.expectedException.expect(ClassCastException.class);
-		this.expectedException.expectMessage("java.lang.String cannot be cast to " +
-				"[Lorg.springframework.cloud.gcp.core.GcpEnvironment;");
+		this.expectedException.expectMessage("java.lang.String cannot be cast");
 
 		setUpAnnotationValue("invalid type");
 		OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();


### PR DESCRIPTION
Needed a class from newer Brave, since Sleuth already upgraded.
And there is a Java 11 vs Java 8 runtime difference in the cast error message, might as well make it universal.