### PR TITLE
Add Javadoc Configuration for Project

### DIFF
--- a/.kokoro/publish_javadoc.cfg
+++ b/.kokoro/publish_javadoc.cfg
@@ -1,3 +1,12 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 build_file: "spring-cloud-gcp/.kokoro/publish_javadoc.sh"
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}

--- a/.kokoro/publish_javadoc.cfg
+++ b/.kokoro/publish_javadoc.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "spring-cloud-gcp/.kokoro/publish_javadoc.sh"

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./mvnw install -DskipTests

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 set -eo pipefail
 
-pwd
-
+# Get into the spring-cloud-gcp repo directory
 dir=$(dirname "$0")
-
 pushd $dir/../
-pwd
-popd
-
-pwd
 
 # install docuploader package
-python3 -m pip install gcp-docuploader
+python3 -m pip install --user gcp-docuploader
+
+
+
+popd
+

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -9,7 +9,7 @@ pushd $dir/../
 PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
 
 # install docuploader package
-python3 -m pip install --user gcp-docuploader
+python3.6 -m pip install --user gcp-docuploader
 
 # Build the javadocs
 ./mvnw clean javadoc:aggregate

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -11,19 +11,23 @@ pushd $dir/../
 # Compute the project version.
 PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
 
-# install docuploader package
+# Install docuploader package
 python3 -m pip install --user gcp-docuploader
 
 # Build the javadocs
-# ./mvnw clean javadoc:aggregate
+./mvnw clean javadoc:aggregate
 
 # Move into generated docs directory
-# pushd target/site/apidocs/
+pushd target/site/apidocs/
 
 python3 -m docuploader create-metadata \
     --name spring-cloud-gcp \
     --version ${PROJECT_VERSION} \
     --language java
 
-# popd
+python3 -m docuploader upload . \
+    --credentials . \
+    --staging-bucket docs-staging
+
+popd
 popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -6,10 +6,10 @@ pwd
 dir=$(dirname "$0")
 
 pushd $dir/../
-./mvnw clean javadoc:aggregate
 pwd
 popd
 
 pwd
+
 # install docuploader package
 python3 -m pip install gcp-docuploader

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -8,6 +8,9 @@ fi
 # Set the version of python to 3.6
 pyenv global 3.6.1
 
+gcloud auth activate-service-account --key-file=${CREDENTIALS}
+gsutil rm gs://docs-staging/java-spring-cloud-gcp-1.3.0.BUILD-SNAPSHOT.tar.gz
+
 # Get into the spring-cloud-gcp repo directory
 dir=$(dirname "$0")
 pushd $dir/../

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -eo pipefail
 
+if [[ -z "${CREDENTIALS}" ]]; then
+  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
+fi
+
+#if [[ -z "${STAGING_BUCKET}" ]]; then
+#  echo "Need to set STAGING_BUCKET environment variable"
+#  exit 1
+#fi
+
 # Set the version of python to 3.6
 pyenv global 3.6.1
 
@@ -26,7 +35,7 @@ python3 -m docuploader create-metadata \
     --language java
 
 python3 -m docuploader upload . \
-    --credentials . \
+    --credentials ${CREDENTIALS} \
     --staging-bucket docs-staging
 
 popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,11 +5,6 @@ if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
-#if [[ -z "${STAGING_BUCKET}" ]]; then
-#  echo "Need to set STAGING_BUCKET environment variable"
-#  exit 1
-#fi
-
 # Set the version of python to 3.6
 pyenv global 3.6.1
 

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,10 +5,22 @@ set -eo pipefail
 dir=$(dirname "$0")
 pushd $dir/../
 
+# Compute the project version.
+PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+
 # install docuploader package
 python3 -m pip install --user gcp-docuploader
 
+# Build the javadocs
+./mvnw clean javadoc:aggregate
 
+# Move into generated docs directory
+pushd target/site/apidocs/
+
+python3 -m docuploader create-metadata \
+    --name spring-cloud-gcp \
+    --version ${PROJECT_VERSION} \
+    --language java
 
 popd
-
+popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -eo pipefail
 
+pwd
+
 dir=$(dirname "$0")
 
 pushd $dir/../
-./mvnw install -DskipTests
+./mvnw clean javadoc:aggregate
+pwd
 popd
+
+pwd
+# install docuploader package
+python3 -m pip install gcp-docuploader

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -12,15 +12,15 @@ PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceSt
 python3.6 -m pip install --user gcp-docuploader
 
 # Build the javadocs
-./mvnw clean javadoc:aggregate
+# ./mvnw clean javadoc:aggregate
 
 # Move into generated docs directory
-pushd target/site/apidocs/
+# pushd target/site/apidocs/
 
-python3 -m docuploader create-metadata \
+python3.6 -m docuploader create-metadata \
     --name spring-cloud-gcp \
     --version ${PROJECT_VERSION} \
     --language java
 
-popd
+# popd
 popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -36,7 +36,7 @@ python3 -m docuploader create-metadata \
 
 python3 -m docuploader upload . \
     --credentials ${CREDENTIALS} \
-    --staging-bucket docs-staging
+    --staging-bucket test-docs-staging
 
 popd
 popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -36,7 +36,7 @@ python3 -m docuploader create-metadata \
 
 python3 -m docuploader upload . \
     --credentials ${CREDENTIALS} \
-    --staging-bucket test-docs-staging
+    --staging-bucket docs-staging
 
 popd
 popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -8,9 +8,6 @@ fi
 # Set the version of python to 3.6
 pyenv global 3.6.1
 
-gcloud auth activate-service-account --key-file=${CREDENTIALS}
-gsutil rm gs://docs-staging/java-spring-cloud-gcp-1.3.0.BUILD-SNAPSHOT.tar.gz
-
 # Get into the spring-cloud-gcp repo directory
 dir=$(dirname "$0")
 pushd $dir/../

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
+# Set the version of python to 3.6
+pyenv global 3.6.1
+
 # Get into the spring-cloud-gcp repo directory
 dir=$(dirname "$0")
 pushd $dir/../
@@ -9,7 +12,7 @@ pushd $dir/../
 PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
 
 # install docuploader package
-python3.6 -m pip install --user gcp-docuploader
+python3 -m pip install --user gcp-docuploader
 
 # Build the javadocs
 # ./mvnw clean javadoc:aggregate
@@ -17,7 +20,7 @@ python3.6 -m pip install --user gcp-docuploader
 # Move into generated docs directory
 # pushd target/site/apidocs/
 
-python3.6 -m docuploader create-metadata \
+python3 -m docuploader create-metadata \
     --name spring-cloud-gcp \
     --version ${PROJECT_VERSION} \
     --language java

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -1,2 +1,8 @@
 #!/bin/bash
+set -eo pipefail
+
+dir=$(dirname "$0")
+
+pushd $dir/../
 ./mvnw install -DskipTests
+popd

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,23 @@
 				<artifactId>appengine-maven-plugin</artifactId>
 				<version>${app-engine-maven-plugin.version}</version>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<excludePackageNames>
+						com.example,
+						com.example.*,
+						<!-- Exclude samples and classes in the Firestore Google Client library packages -->
+						com.google.cloud.firestore
+					</excludePackageNames>
+					<links>
+						<link>https://googleapis.dev/java/google-cloud-vision/latest/</link>
+						<link>https://googleapis.dev/java/google-cloud-spanner/latest/</link>
+						<link>https://googleapis.dev/java/google-cloud-clients/latest/</link>
+					</links>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/java/com/example/ExampleController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/java/com/example/ExampleController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Sample REST Controller to demonstrate Spring Cloud Sleuth & Stackdriver Trace.
+ * Sample REST Controller to demonstrate Spring Cloud Sleuth and Stackdriver Trace.
  *
  * @author Ray Tsang
  * @author Mike Eltsufin

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/java/com/example/VisionController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/java/com/example/VisionController.java
@@ -56,7 +56,8 @@ public class VisionController {
 	 * @param imageUrl the URL of the image
 	 * @param map the model map to use
 	 * @return a string with the list of labels and percentage of certainty
-	 * @throws CloudVisionTemplate if the Vision API call produces an error
+	 * @throws org.springframework.cloud.gcp.vision.CloudVisionException if the Vision API call
+	 *    produces an error
 	 */
 	@GetMapping("/extractLabels")
 	public ModelAndView extractLabels(String imageUrl, ModelMap map) {


### PR DESCRIPTION
Adds Javadoc generation scripts for spring-cloud-gcp.

This provides the Kokoro scripts which upload the javadocs to:
https://googleapis.dev/java/spring-cloud-gcp/latest/index.html