### PR TITLE
GCP Libraries-bom 4.0.0

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,19 +16,13 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<gcp-libraries-bom.version>3.4.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>4.0.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.0.15</cloud-sql-socket-factory.version>
 		<java-cfenv.version>1.1.1.RELEASE</java-cfenv.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
-			<dependency>
-				<!-- temporary solution for https://github.com/spring-cloud/spring-cloud-gcp/issues/2142 -->
-				<groupId>com.google.cloud</groupId>
-				<artifactId>google-cloud-core</artifactId>
-				<version>1.92.2</version>
-			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-gcp-core</artifactId>


### PR DESCRIPTION
GCP Libraries-bom 4.0.0.

- This BOM has google-cloud-core 1.92.4. 
  This does not need the workaround of https://github.com/spring-cloud/spring-cloud-gcp/issues/2142 any more.