### PR TITLE
Rename the secret namespace property for Secret Manager

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -98,6 +98,6 @@ public class GcpSecretManagerBootstrapConfiguration {
 	@Bean
 	public PropertySourceLocator secretManagerPropertySourceLocator(SecretManagerServiceClient client) {
 		return new SecretManagerPropertySourceLocator(
-				client, this.gcpProjectIdProvider, this.properties.getSecretPropertyNamespace());
+				client, this.gcpProjectIdProvider, this.properties.getSecretNamePrefix());
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerProperties.java
@@ -40,7 +40,7 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 	 * Defines a prefix String that will be prepended to the environment property names
 	 * of secrets in Secret Manager.
 	 */
-	private String secretPropertyNamespace = "";
+	private String secretNamePrefix = "";
 
 	public Credentials getCredentials() {
 		return credentials;
@@ -54,11 +54,11 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 		this.projectId = projectId;
 	}
 
-	public String getSecretPropertyNamespace() {
-		return secretPropertyNamespace;
+	public String getSecretNamePrefix() {
+		return secretNamePrefix;
 	}
 
-	public void setSecretPropertyNamespace(String secretPropertyNamespace) {
-		this.secretPropertyNamespace = secretPropertyNamespace;
+	public void setSecretNamePrefix(String secretNamePrefix) {
+		this.secretNamePrefix = secretNamePrefix;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySource.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySource.java
@@ -48,12 +48,12 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
 			String propertySourceName,
 			SecretManagerServiceClient client,
 			GcpProjectIdProvider projectIdProvider,
-			String secretsNamespace) {
+			String secretsPrefix) {
 
 		super(propertySourceName, client);
 
 		Map<String, Object> propertiesMap = createSecretsPropertiesMap(
-				client, projectIdProvider.getProjectId(), secretsNamespace);
+				client, projectIdProvider.getProjectId(), secretsPrefix);
 
 		this.properties = propertiesMap;
 		this.propertyNames = propertiesMap.keySet().toArray(new String[propertiesMap.size()]);
@@ -70,7 +70,7 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
 	}
 
 	private static Map<String, Object> createSecretsPropertiesMap(
-			SecretManagerServiceClient client, String projectId, String secretsNamespace) {
+			SecretManagerServiceClient client, String projectId, String secretsPrefix) {
 
 		ListSecretsPagedResponse response = client.listSecrets(ProjectName.of(projectId));
 
@@ -78,7 +78,7 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
 		for (Secret secret : response.iterateAll()) {
 			String secretId = extractSecretId(secret);
 			ByteString secretPayload = getSecretPayload(client, projectId, secretId);
-			secretsMap.put(secretsNamespace + secretId, secretPayload);
+			secretsMap.put(secretsPrefix + secretId, secretPayload);
 		}
 
 		return secretsMap;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySourceLocator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySourceLocator.java
@@ -38,15 +38,15 @@ public class SecretManagerPropertySourceLocator implements PropertySourceLocator
 
 	private final GcpProjectIdProvider projectIdProvider;
 
-	private final String secretsNamespace;
+	private final String secretsPrefix;
 
 	SecretManagerPropertySourceLocator(
 			SecretManagerServiceClient client,
 			GcpProjectIdProvider projectIdProvider,
-			String secretsNamespace) {
+			String secretsPrefix) {
 		this.client = client;
 		this.projectIdProvider = projectIdProvider;
-		this.secretsNamespace = secretsNamespace;
+		this.secretsPrefix = secretsPrefix;
 	}
 
 	@Override
@@ -55,6 +55,6 @@ public class SecretManagerPropertySourceLocator implements PropertySourceLocator
 				SECRET_MANAGER_NAME,
 				this.client,
 				this.projectIdProvider,
-				this.secretsNamespace);
+				this.secretsPrefix);
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
@@ -1,3 +1,3 @@
 # This optional setting adds a prefix to your secret names that get injected
 # into the application Environment.
-spring.cloud.gcp.secretmanager.secret-property-namespace=secrets.
+spring.cloud.gcp.secretmanager.secret-name-prefix=secrets.


### PR DESCRIPTION
Renames the property `secretPropertyNamespace` to `secretNamePrefix` which I think is simpler and more clear on how to set the property.