### PR TITLE
Add Javadoc Configuration for Project (#2173)

### DIFF
--- a/.kokoro/publish_javadoc.cfg
+++ b/.kokoro/publish_javadoc.cfg
@@ -1,0 +1,12 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "spring-cloud-gcp/.kokoro/publish_javadoc.sh"
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -eo pipefail
+
+if [[ -z "${CREDENTIALS}" ]]; then
+  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
+fi
+
+# Set the version of python to 3.6
+pyenv global 3.6.1
+
+# Get into the spring-cloud-gcp repo directory
+dir=$(dirname "$0")
+pushd $dir/../
+
+# Compute the project version.
+PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+# Install docuploader package
+python3 -m pip install --user gcp-docuploader
+
+# Build the javadocs
+./mvnw clean javadoc:aggregate
+
+# Move into generated docs directory
+pushd target/site/apidocs/
+
+python3 -m docuploader create-metadata \
+    --name spring-cloud-gcp \
+    --version ${PROJECT_VERSION} \
+    --language java
+
+python3 -m docuploader upload . \
+    --credentials ${CREDENTIALS} \
+    --staging-bucket docs-staging
+
+popd
+popd

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,23 @@
 				<artifactId>appengine-maven-plugin</artifactId>
 				<version>${app-engine-maven-plugin.version}</version>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<excludePackageNames>
+						com.example,
+						com.example.*,
+						<!-- Exclude samples and classes in the Firestore Google Client library packages -->
+						com.google.cloud.firestore
+					</excludePackageNames>
+					<links>
+						<link>https://googleapis.dev/java/google-cloud-vision/latest/</link>
+						<link>https://googleapis.dev/java/google-cloud-spanner/latest/</link>
+						<link>https://googleapis.dev/java/google-cloud-clients/latest/</link>
+					</links>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/java/com/example/ExampleController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/java/com/example/ExampleController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Sample REST Controller to demonstrate Spring Cloud Sleuth & Stackdriver Trace.
+ * Sample REST Controller to demonstrate Spring Cloud Sleuth and Stackdriver Trace.
  *
  * @author Ray Tsang
  * @author Mike Eltsufin

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/java/com/example/VisionController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/main/java/com/example/VisionController.java
@@ -56,7 +56,8 @@ public class VisionController {
 	 * @param imageUrl the URL of the image
 	 * @param map the model map to use
 	 * @return a string with the list of labels and percentage of certainty
-	 * @throws CloudVisionTemplate if the Vision API call produces an error
+	 * @throws org.springframework.cloud.gcp.vision.CloudVisionException if the Vision API call
+	 *    produces an error
 	 */
 	@GetMapping("/extractLabels")
 	public ModelAndView extractLabels(String imageUrl, ModelMap map) {


### PR DESCRIPTION
For the 1.2.x branch:

Provides the Kokoro scripts which upload the javadocs to: https://googleapis.dev/java/spring-cloud-gcp/latest/index.html

(cherry picked from commit cbcaa2f2d8a34f2bf28f6d9243515147ff2b23dd)