### PR TITLE
Add instructions to uploading javadocs for Spring Cloud GCP

### DIFF
--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -41,6 +41,7 @@ https://googleapis.dev/java/spring-cloud-gcp/latest/index.html
 2. Add a new Github SCM and fill out the following parameters:
 
     - SCM Name: Set this to `spring-cloud-gcp`
-    - Committish: Set this to the name of the new release branch that you want to publish javadocs for (like `1.2.x`).
+    - Committish: Set this to the name of the new release branch or tag that you want to publish javadocs for (like `1.2.x` or `v1.2.1.RELEASE`).
+      Note that you must already have the `.kokoro/` scripts in the branch that you wish to publish javadocs for.
 
 3. Run the job.

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -26,6 +26,7 @@ For GA releases this should be configured under the `central` Maven profile.
 == Uploading Javadocs
 
 After releasing a new version of Spring Cloud GCP, you will need to upload the javadocs for the released version.
+By this point, we assume that a new release branch has been created for project (such as `1.1.x`, `1.2.x`, etc.).
 
 All javadocs are uploaded to the following URL:
 ```

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -32,6 +32,9 @@ All javadocs are uploaded to the following URL:
 https://googleapis.dev/java/spring-cloud-gcp/${LIBRARY_VERSION}/index.html
 ```
 
+The latest version of the docs can be accessed at the `latest/` url:
+https://googleapis.dev/java/spring-cloud-gcp/latest/index.html
+
 1. Locate and open the `prod:cloud-java-frameworks/spring-cloud-gcp/publish_javadoc` Kokoro job.
 
 2. Add a new Github SCM and fill out the following parameters:

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -22,3 +22,21 @@ For GA releases this should be configured under the `central` Maven profile.
 . Make sure that the release tag was automatically added by the release process.
 
 . Make sure that the link:https://github.com/spring-io/initializr/blob/master/initializr-service/src/main/resources/application.yml[Spring Boot Initializr] is updated to support the new version of Spring Cloud GCP.
+
+== Uploading Javadocs
+
+After releasing a new version of Spring Cloud GCP, you will need to upload the javadocs for the released version.
+
+All javadocs are uploaded to the following URL:
+```
+https://googleapis.dev/java/spring-cloud-gcp/${LIBRARY_VERSION}/index.html
+```
+
+1. Locate and open the `prod:cloud-java-frameworks/spring-cloud-gcp/publish_javadoc` Kokoro job.
+
+2. Add a new Github SCM and fill out the following parameters:
+
+    - SCM Name: Set this to `spring-cloud-gcp`
+    - Committish: Set this to the name of the new release branch that you want to publish javadocs for (like `1.2.x`).
+
+3. Run the job.

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -5,17 +5,20 @@ In order to simplify that process, here is a list of prerequisites to be perform
 
 . Ensure that modules that shouldn't be released have the `maven-deploy-plugin` configuration set to `<skip>true</skip>`.
 For GA releases this should be configured under the `central` Maven profile.
-
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
++
+[source,xml]
+----
+<build>
+    <plugins>
+        <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+----
 
 . Wait for the release scripts to have been run by the release admin.
 
@@ -27,11 +30,6 @@ For GA releases this should be configured under the `central` Maven profile.
 
 After releasing a new version of Spring Cloud GCP, you will need to upload the javadocs for the released version.
 By this point, we assume that a new release branch has been created for project (such as `1.1.x`, `1.2.x`, etc.).
-
-All javadocs are uploaded to the following URL:
-```
-https://googleapis.dev/java/spring-cloud-gcp/${LIBRARY_VERSION}/index.html
-```
 
 The latest version of the docs can be accessed at the `latest/` url:
 https://googleapis.dev/java/spring-cloud-gcp/latest/index.html
@@ -45,3 +43,13 @@ https://googleapis.dev/java/spring-cloud-gcp/latest/index.html
       Note that you must already have the `.kokoro/` scripts in the branch that you wish to publish javadocs for.
 
 3. Run the job.
+
+4. Verify that the javadocs are published.
+All uploaded javadocs will be published under the following URL:
++
+----
+https://googleapis.dev/java/spring-cloud-gcp/{BRANCH_VERSION_NAME}/index.html
+----
++
+Example: If you published the javadocs for version `1.3.0.BUILD-SNAPSHOT`, then the URL would be: https://googleapis.dev/java/spring-cloud-gcp/1.3.0.BUILD-SNAPSHOT/index.html
+


### PR DESCRIPTION
This adds instructions for how to upload javadocs in the release notes for Spring Cloud GCP.