### PR TITLE
Remove "useSSL=false" from Cloud SQL JDBC URL template

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/DatabaseType.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/sql/DatabaseType.java
@@ -28,16 +28,14 @@ public enum DatabaseType {
 	 */
 	MYSQL("com.mysql.jdbc.Driver", "jdbc:mysql://google/%s?"
 			+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
-			+ "&cloudSqlInstance=%s"
-			+ "&useSSL=false"),
+			+ "&cloudSqlInstance=%s"),
 
 	/**
 	 * Postgresql constants.
 	 */
 	POSTGRESQL("org.postgresql.Driver", "jdbc:postgresql://google/%s?"
 			+ "socketFactory=com.google.cloud.sql.postgres.SocketFactory"
-			+ "&cloudSqlInstance=%s"
-			+ "&useSSL=false");
+			+ "&cloudSqlInstance=%s");
 
 	private final String jdbcDriverName;
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfigurationMockTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfigurationMockTests.java
@@ -59,8 +59,7 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
 							"jdbc:mysql://google/test-database?"
 									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
-									+ "&cloudSqlInstance=tubular-bells:singapore:test-instance"
-									+ "&useSSL=false");
+									+ "&cloudSqlInstance=tubular-bells:singapore:test-instance");
 					assertThat(dataSource.getUsername()).matches("root");
 					assertThat(dataSource.getPassword()).isNull();
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
@@ -82,8 +81,7 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
 							"jdbc:mysql://google/test-database?"
 									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
-									+ "&cloudSqlInstance=tubular-bells:singapore:test-instance"
-									+ "&useSSL=false");
+									+ "&cloudSqlInstance=tubular-bells:singapore:test-instance");
 					assertThat(dataSource.getUsername()).matches("root");
 					assertThat(dataSource.getPassword()).isNull();
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
@@ -110,8 +108,7 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
 							"jdbc:mysql://google/test-database?"
 									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
-									+ "&cloudSqlInstance=tubular-bells:australia:test-instance"
-									+ "&useSSL=false");
+									+ "&cloudSqlInstance=tubular-bells:australia:test-instance");
 					assertThat(dataSource.getUsername()).matches("root");
 					assertThat(dataSource.getPassword()).isNull();
 				});
@@ -130,8 +127,7 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
 							"jdbc:mysql://google/test-database?"
 									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
-									+ "&cloudSqlInstance=proj:reg:test-instance"
-									+ "&useSSL=false");
+									+ "&cloudSqlInstance=proj:reg:test-instance");
 					assertThat(dataSource.getUsername()).matches("watchmaker");
 					assertThat(dataSource.getPassword()).matches("pass");
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
@@ -152,8 +148,7 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
 							"jdbc:mysql://google/test-database?"
 									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
-									+ "&cloudSqlInstance=proj:reg:test-instance"
-									+ "&useSSL=false");
+									+ "&cloudSqlInstance=proj:reg:test-instance");
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
 					assertThat(dataSource.getMaximumPoolSize()).isEqualTo(19);
 					assertThat(dataSource.getConnectionTestQuery()).matches("select 1");
@@ -170,8 +165,7 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
 							"jdbc:mysql://google/test-database?"
 									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
-									+ "&cloudSqlInstance=world:asia:japan"
-									+ "&useSSL=false");
+									+ "&cloudSqlInstance=world:asia:japan");
 					assertThat(urlProvider.getJdbcDriverClass()).matches("com.mysql.jdbc.Driver");
 				});
 	}
@@ -188,8 +182,7 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 					assertThat(urlProvider.getJdbcUrl()).isEqualTo(
 							"jdbc:postgresql://google/test-database?"
 									+ "socketFactory=com.google.cloud.sql.postgres.SocketFactory"
-									+ "&cloudSqlInstance=tubular-bells:singapore:test-instance"
-									+ "&useSSL=false");
+									+ "&cloudSqlInstance=tubular-bells:singapore:test-instance");
 					assertThat(urlProvider.getJdbcDriverClass()).matches("org.postgresql.Driver");
 				});
 	}


### PR DESCRIPTION
It's a no-op anyway.

See: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/173
Related to: #2206.