### PR TITLE
Add project URL to the root pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 	<packaging>pom</packaging>
 	<name>Spring Cloud GCP</name>
 	<description>Spring Cloud GCP</description>
+	<url>https://spring.io/projects/spring-cloud-gcp</url>
 
 	<scm>
 		<url>https://github.com/spring-cloud/spring-cloud-gcp</url>


### PR DESCRIPTION
Adds the `<url>` tag for spring-cloud-gcp project. This metadata was requested by the DRIFT team for gathering data about our libraries.