### PR TITLE
bump spring boot starter parent

### DIFF
--- a/spring-cloud-gcp-kotlin-samples/pom.xml
+++ b/spring-cloud-gcp-kotlin-samples/pom.xml
@@ -7,7 +7,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.5.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.5.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
We fell behind the starter patch upgrades, and there is a [tomcat security vulnerability](https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-551995) and a [spring-webmvc](https://app.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-542935) one.