### PR TITLE
Provide additional info about javadocs in the repo documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,12 +2,12 @@
 
 = Spring Framework on Google Cloud Platform
 
-This project makes it easy for Spring users to run their applications on Google Cloud Platform.
-You can check our project website https://cloud.spring.io/spring-cloud-gcp[here].
+The Spring Cloud GCP project makes it easy for Spring users to run their applications on Google Cloud Platform.
+You can check our https://github.com/spring-cloud/spring-cloud-gcp/blob/master/README.adoc[project website] for more information.
 
-For a deep dive into the project, refer to the https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.2.0.RELEASE/reference/html/[Spring Cloud GCP 1.2 Reference Document].
+For a deep dive into the project, refer to the https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.2.0.RELEASE/reference/html/[Spring Cloud GCP 1.2 Reference Document] and https://googleapis.dev/java/spring-cloud-gcp/1.2.2.BUILD-SNAPSHOT/index.html[Javadocs].
 
-If you prefer to learn by doing, try https://codelabs.developers.google.com/spring[Spring on GCP codelabs].
+If you prefer to learn by doing, try taking a look at the https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples[Spring Cloud GCP sample applications] or the https://codelabs.developers.google.com/spring[Spring on GCP codelabs].
 
 Currently, this repository provides support for:
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 The Spring Cloud GCP project makes it easy for Spring users to run their applications on Google Cloud Platform.
 You can check our https://github.com/spring-cloud/spring-cloud-gcp/blob/master/README.adoc[project website] for more information.
 
-For a deep dive into the project, refer to the https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.2.0.RELEASE/reference/html/[Spring Cloud GCP 1.2 Reference Document] and https://googleapis.dev/java/spring-cloud-gcp/1.2.2.BUILD-SNAPSHOT/index.html[Javadocs].
+For a deep dive into the project, refer to the https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.2.1.RELEASE/reference/html/[Spring Cloud GCP 1.2 Reference Document] and https://googleapis.dev/java/spring-cloud-gcp/1.2.1.RELEASE/index.html[Javadocs].
 
 If you prefer to learn by doing, try taking a look at the https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples[Spring Cloud GCP sample applications] or the https://codelabs.developers.google.com/spring[Spring on GCP codelabs].
 

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -53,3 +53,6 @@ https://googleapis.dev/java/spring-cloud-gcp/{BRANCH_VERSION_NAME}/index.html
 +
 Example: If you published the javadocs for version `1.3.0.BUILD-SNAPSHOT`, then the URL would be: https://googleapis.dev/java/spring-cloud-gcp/1.3.0.BUILD-SNAPSHOT/index.html
 
+5. For GA releases, ask on the https://gitter.im/spring-cloud-gcp/Lobby[Spring Cloud GCP Gitter] for the Spring team to update the https://spring.io/projects/spring-cloud-gcp#learn[API Documentation link] to point to the published Javadocs.
+
+6. Update the Javadoc link in the https://github.com/spring-cloud/spring-cloud-gcp/blob/master/README.adoc[Github homepage documentation].


### PR DESCRIPTION
Adds some additional information to the main documentation about javadocs.

- Add a link to the root docs.
- Add instructions to message gitter.im after release to release docs.