### PR TITLE
Update spring cloud parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.2.3.BUILD-SNAPSHOT</version>
 		<relativePath/><!-- lookup parent from repository -->
 	</parent>
 
@@ -52,9 +52,7 @@
 		<spring-cloud-commons.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-bus.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-bus.version>
 		<spring-cloud-sleuth.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
-<!--
 		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
--->
 		<zipkin-gcp.version>0.15.2</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 		<relativePath/><!-- lookup parent from repository -->
 	</parent>
 
@@ -52,7 +52,9 @@
 		<spring-cloud-commons.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-bus.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-bus.version>
 		<spring-cloud-sleuth.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
+<!--
 		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
+-->
 		<zipkin-gcp.version>0.15.2</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -35,6 +35,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
 import org.springframework.cloud.gcp.autoconfigure.datastore.health.DatastoreHealthIndicator;
 import org.springframework.cloud.gcp.autoconfigure.datastore.health.DatastoreHealthIndicatorAutoConfiguration;
+import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.cloud.gcp.data.datastore.core.DatastoreOperations;
 import org.springframework.cloud.gcp.data.datastore.core.DatastoreTransactionManager;
 import org.springframework.context.ApplicationContext;
@@ -76,24 +77,25 @@ public class GcpDatastoreAutoConfigurationTests {
 	@Test
 	public void testUserDatastoreBean() {
 		ApplicationContextRunner runner = new ApplicationContextRunner()
-				.withConfiguration(AutoConfigurations.of(GcpDatastoreAutoConfiguration.class,
-						GcpContextAutoConfiguration.class,
-						TestConfigurationWithDatastoreBean.class))
+				.withConfiguration(AutoConfigurations.of(GcpDatastoreAutoConfiguration.class))
+				.withUserConfiguration(TestConfigurationWithDatastoreBean.class)
 				.withPropertyValues("spring.cloud.gcp.datastore.project-id=test-project",
 						"spring.cloud.gcp.datastore.namespace=testNamespace",
 						"spring.cloud.gcp.datastore.host=localhost:8081",
 						"management.health.datastore.enabled=false");
 
-		runner.run(context -> assertThat(getDatastoreBean(context))
-				.isSameAs(TestConfigurationWithDatastoreBean.MOCK_CLIENT));
+		runner.run(context -> {
+			assertThat(getDatastoreBean(context))
+					.isSameAs(TestConfigurationWithDatastoreBean.MOCK_CLIENT);
+		});
 	}
 
 	@Test
 	public void testUserDatastoreBeanNamespace() {
 		ApplicationContextRunner runner = new ApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(GcpDatastoreAutoConfiguration.class,
-						GcpContextAutoConfiguration.class,
-						TestConfigurationWithDatastoreBeanNamespaceProvider.class))
+						GcpContextAutoConfiguration.class))
+				.withUserConfiguration(TestConfigurationWithDatastoreBeanNamespaceProvider.class)
 				.withPropertyValues("spring.cloud.gcp.datastore.project-id=test-project",
 						"spring.cloud.gcp.datastore.namespace=testNamespace",
 						"spring.cloud.gcp.datastore.host=localhost:8081",
@@ -194,6 +196,11 @@ public class GcpDatastoreAutoConfigurationTests {
 		@Bean
 		public CredentialsProvider credentialsProvider() {
 			return () -> mock(Credentials.class);
+		}
+
+		@Bean
+		public GcpProjectIdProvider gcpProjectIdProvider() {
+			return () -> "project123";
 		}
 
 		@Bean

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfigurationTests.java
@@ -88,9 +88,9 @@ public class StackdriverLoggingAutoConfigurationTests {
 	@Test
 	public void testWithSleuth() {
 		this.contextRunner
-				.withConfiguration(AutoConfigurations.of(Configuration.class,
-						StackdriverTraceAutoConfiguration.class,
+				.withConfiguration(AutoConfigurations.of(StackdriverTraceAutoConfiguration.class,
 						TraceAutoConfiguration.class))
+				.withUserConfiguration(Configuration.class)
 				.withPropertyValues("spring.cloud.gcp.project-id=pop-1")
 				.run((context) -> assertThat(context
 						.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class).size())

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfigurationMockTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/sql/GcpCloudSqlAutoConfigurationMockTests.java
@@ -42,8 +42,9 @@ public class GcpCloudSqlAutoConfigurationMockTests {
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withPropertyValues("spring.cloud.gcp.sql.databaseName=test-database")
 			.withConfiguration(AutoConfigurations.of(GcpCloudSqlAutoConfiguration.class,
-					GcpContextAutoConfiguration.class, GcpCloudSqlTestConfiguration.class,
-					DataSourceAutoConfiguration.class));
+					GcpContextAutoConfiguration.class,
+					DataSourceAutoConfiguration.class))
+			.withUserConfiguration(GcpCloudSqlTestConfiguration.class);
 
 	@Test
 	public void testCloudSqlDataSourceTest() {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -83,12 +83,12 @@ public class StackdriverTraceAutoConfigurationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(
-					StackdriverTraceAutoConfigurationTests.MockConfiguration.class,
 					StackdriverTraceAutoConfiguration.class,
 					GcpContextAutoConfiguration.class,
 					TraceAutoConfiguration.class,
 					SleuthLogAutoConfiguration.class,
 					RefreshAutoConfiguration.class))
+			.withUserConfiguration(StackdriverTraceAutoConfigurationTests.MockConfiguration.class)
 			.withPropertyValues("spring.cloud.gcp.project-id=proj",
 					"spring.sleuth.sampler.probability=1.0");
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -20,7 +20,7 @@
 
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
-		<spring-cloud-build-tools.version>3.0.0.BUILD-SNAPSHOT</spring-cloud-build-tools.version>
+		<spring-cloud-build-tools.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-build-tools.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -20,7 +20,7 @@
 
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
-		<spring-cloud-build-tools.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-build-tools.version>
+		<spring-cloud-build-tools.version>3.0.0.BUILD-SNAPSHOT</spring-cloud-build-tools.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Sticking strictly to Hoxton, not veering into Illford.

I updated a few tests that started having intermittent failures due to autoconfig order resolving differently. Although it might have been while I was experimenting with a 2.3 version of Spring Boot, the changes are still valid -- the custom test classes are user configuration, not autoconfiguration, and should always run first.