### PR TITLE
Switch to latest javadocs link in refdoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 The Spring Cloud GCP project makes it easy for Spring users to run their applications on Google Cloud Platform.
 You can check our https://github.com/spring-cloud/spring-cloud-gcp/blob/master/README.adoc[project website] for more information.
 
-For a deep dive into the project, refer to the https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.2.1.RELEASE/reference/html/[Spring Cloud GCP 1.2 Reference Document] and https://googleapis.dev/java/spring-cloud-gcp/1.2.1.RELEASE/index.html[Javadocs].
+For a deep dive into the project, refer to the https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.2.1.RELEASE/reference/html/[Spring Cloud GCP 1.2 Reference Document] or the https://googleapis.dev/java/spring-cloud-gcp/latest/index.html[latest Javadocs].
 
 If you prefer to learn by doing, try taking a look at the https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples[Spring Cloud GCP sample applications] or the https://codelabs.developers.google.com/spring[Spring on GCP codelabs].
 

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -53,6 +53,4 @@ https://googleapis.dev/java/spring-cloud-gcp/{BRANCH_VERSION_NAME}/index.html
 +
 Example: If you published the javadocs for version `1.3.0.BUILD-SNAPSHOT`, then the URL would be: https://googleapis.dev/java/spring-cloud-gcp/1.3.0.BUILD-SNAPSHOT/index.html
 
-5. For GA releases, ask on the https://gitter.im/spring-cloud-gcp/Lobby[Spring Cloud GCP Gitter] for the Spring team to update the https://spring.io/projects/spring-cloud-gcp#learn[API Documentation link] to point to the published Javadocs.
-
-6. Update the Javadoc link in the https://github.com/spring-cloud/spring-cloud-gcp/blob/master/README.adoc[Github homepage documentation].
+5. For GA releases, ask on the https://gitter.im/spring-cloud-gcp/Lobby[Spring Cloud GCP Gitter] for the Spring team to update the https://spring.io/projects/spring-cloud-gcp#learn[API Documentation link] to point to the published Javadocs of the correct version.


### PR DESCRIPTION
This changes the javadoc link to the `latest/` URL to reduce maintenance burden.