### PR TITLE
Create AutoConfiguration for Secret Manager Template and extend sample

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -240,8 +240,8 @@
 
         <!-- Secret Manager -->
         <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-secretmanager</artifactId>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-secretmanager</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerAutoConfiguration.java
@@ -44,8 +44,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties(GcpSecretManagerProperties.class)
 @ConditionalOnClass(SecretManagerServiceClient.class)
-@ConditionalOnProperty(value = "spring.cloud.gcp.secretmanager.template.enabled", matchIfMissing = true)
-public class GcpSecretManagerTemplateConfiguration {
+@ConditionalOnProperty(value = "spring.cloud.gcp.secretmanager.enabled", matchIfMissing = true)
+public class GcpSecretManagerAutoConfiguration {
 
 	private final GcpSecretManagerProperties properties;
 
@@ -53,7 +53,7 @@ public class GcpSecretManagerTemplateConfiguration {
 
 	private final GcpProjectIdProvider gcpProjectIdProvider;
 
-	public GcpSecretManagerTemplateConfiguration(
+	public GcpSecretManagerAutoConfiguration(
 			GcpSecretManagerProperties properties) throws IOException {
 		this.properties = properties;
 		this.credentialsProvider = new DefaultCredentialsProvider(properties);
@@ -68,7 +68,7 @@ public class GcpSecretManagerTemplateConfiguration {
 		SecretManagerServiceSettings settings = SecretManagerServiceSettings.newBuilder()
 				.setCredentialsProvider(this.credentialsProvider)
 				.setHeaderProvider(
-						new UserAgentHeaderProvider(GcpSecretManagerTemplateConfiguration.class))
+						new UserAgentHeaderProvider(GcpSecretManagerAutoConfiguration.class))
 				.build();
 
 		return SecretManagerServiceClient.create(settings);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -47,7 +47,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 @Configuration
 @EnableConfigurationProperties(GcpSecretManagerProperties.class)
 @ConditionalOnClass(SecretManagerServiceClient.class)
-@ConditionalOnProperty(value = "spring.cloud.gcp.secretmanager.bootstrap.enabled", matchIfMissing = true)
+@ConditionalOnProperty("spring.cloud.gcp.secretmanager.bootstrap.enabled")
 public class GcpSecretManagerBootstrapConfiguration {
 
 	private final GcpSecretManagerProperties properties;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerTemplateConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerTemplateConfiguration.java
@@ -21,25 +21,22 @@ import java.io.IOException;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceSettings;
-import com.google.protobuf.ByteString;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.UserAgentHeaderProvider;
+import org.springframework.cloud.gcp.secretmanager.SecretManagerTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
- * Bootstrap Autoconfiguration for GCP Secret Manager which enables loading secrets as
- * properties into the application {@link org.springframework.core.env.Environment}.
+ * Autoconfiguration for GCP Secret Manager which provides an instance of the
+ * {@link SecretManagerTemplate}.
  *
  * @author Daniel Zou
  * @since 1.2.2
@@ -47,8 +44,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
 @Configuration
 @EnableConfigurationProperties(GcpSecretManagerProperties.class)
 @ConditionalOnClass(SecretManagerServiceClient.class)
-@ConditionalOnProperty(value = "spring.cloud.gcp.secretmanager.bootstrap.enabled", matchIfMissing = true)
-public class GcpSecretManagerBootstrapConfiguration {
+@ConditionalOnProperty(value = "spring.cloud.gcp.secretmanager.template.enabled", matchIfMissing = true)
+public class GcpSecretManagerTemplateConfiguration {
 
 	private final GcpSecretManagerProperties properties;
 
@@ -56,32 +53,13 @@ public class GcpSecretManagerBootstrapConfiguration {
 
 	private final GcpProjectIdProvider gcpProjectIdProvider;
 
-	public GcpSecretManagerBootstrapConfiguration(
-			GcpSecretManagerProperties properties,
-			ConfigurableEnvironment configurableEnvironment) throws IOException {
-
+	public GcpSecretManagerTemplateConfiguration(
+			GcpSecretManagerProperties properties) throws IOException {
 		this.properties = properties;
 		this.credentialsProvider = new DefaultCredentialsProvider(properties);
 		this.gcpProjectIdProvider = properties.getProjectId() != null
 				? properties::getProjectId
 				: new DefaultGcpProjectIdProvider();
-
-		// Registers {@link ByteString} type converters to convert to String and byte[].
-		configurableEnvironment.getConversionService().addConverter(
-				new Converter<ByteString, String>() {
-					@Override
-					public String convert(ByteString source) {
-						return source.toStringUtf8();
-					}
-				});
-
-		configurableEnvironment.getConversionService().addConverter(
-				new Converter<ByteString, byte[]>() {
-					@Override
-					public byte[] convert(ByteString source) {
-						return source.toByteArray();
-					}
-				});
 	}
 
 	@Bean
@@ -89,15 +67,16 @@ public class GcpSecretManagerBootstrapConfiguration {
 	public SecretManagerServiceClient secretManagerClient() throws IOException {
 		SecretManagerServiceSettings settings = SecretManagerServiceSettings.newBuilder()
 				.setCredentialsProvider(this.credentialsProvider)
-				.setHeaderProvider(new UserAgentHeaderProvider(GcpSecretManagerBootstrapConfiguration.class))
+				.setHeaderProvider(
+						new UserAgentHeaderProvider(GcpSecretManagerTemplateConfiguration.class))
 				.build();
 
 		return SecretManagerServiceClient.create(settings);
 	}
 
 	@Bean
-	public PropertySourceLocator secretManagerPropertySourceLocator(SecretManagerServiceClient client) {
-		return new SecretManagerPropertySourceLocator(
-				client, this.gcpProjectIdProvider, this.properties.getSecretNamePrefix());
+	@ConditionalOnMissingBean
+	public SecretManagerTemplate secretManagerTemplate(SecretManagerServiceClient client) {
+		return new SecretManagerTemplate(client, this.gcpProjectIdProvider);
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -21,7 +21,7 @@ org.springframework.cloud.gcp.autoconfigure.bigquery.GcpBigQueryAutoConfiguratio
 org.springframework.cloud.gcp.autoconfigure.datastore.DatastoreTransactionManagerAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.firestore.FirestoreRepositoriesAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration,\
-org.springframework.cloud.gcp.autoconfigure.secretmanager.GcpSecretManagerTemplateConfiguration
+org.springframework.cloud.gcp.autoconfigure.secretmanager.GcpSecretManagerAutoConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.gcp.autoconfigure.config.GcpConfigBootstrapConfiguration,\

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -20,7 +20,8 @@ org.springframework.cloud.gcp.autoconfigure.datastore.GcpDatastoreEmulatorAutoCo
 org.springframework.cloud.gcp.autoconfigure.bigquery.GcpBigQueryAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.datastore.DatastoreTransactionManagerAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.firestore.FirestoreRepositoriesAutoConfiguration,\
-org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration  
+org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.secretmanager.GcpSecretManagerTemplateConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.gcp.autoconfigure.config.GcpConfigBootstrapConfiguration,\

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
@@ -66,6 +66,7 @@ public class SecretManagerIntegrationTests {
 		this.context = new SpringApplicationBuilder()
 				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
 				.web(WebApplicationType.NONE)
+				.properties("spring.cloud.gcp.secretmanager.bootstrap.enabled=true")
 				.run();
 
 		this.projectIdProvider = this.context.getBeanFactory().getBean(GcpProjectIdProvider.class);

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -93,6 +93,11 @@
 				<artifactId>spring-cloud-gcp-security-firebase</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-gcp-secretmanager</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 
 			<!--Starters-->
 			<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/README.adoc
@@ -31,8 +31,12 @@ Instructions for using the Secret Manager UI can be found in the https://cloud.g
 Your secret value is injected into your application through the `WebController` and you will see it displayed.
 +
 ```
-The secret property is: Hello world.
-You can also access secrets using @Value: Hello world.
+applicationSecret: Hello world.
 ```
++
+You will also see some web forms that allow you to create, read, and update secrets in Secret Manager.
+This is done by using the `SecretManagerTemplate`.
++
+Finally, you can view all of your secrets using the https://console.cloud.google.com/security/secret-manager[Secret Manager Cloud Console UI], which is the source of truth for all of your secrets in Secret Manager.
 
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/pom.xml
@@ -21,6 +21,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-secretmanager</artifactId>
     </dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerApplication.java
@@ -22,8 +22,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 @SpringBootApplication
 @EnableConfigurationProperties(MyAppProperties.class)
-public class Application {
+public class SecretManagerApplication {
 	public static void main(String[] args) {
-		SpringApplication.run(Application.class, args);
+		SpringApplication.run(SecretManagerApplication.class, args);
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
-public class WebController {
+public class SecretManagerWebController {
 
 	@Autowired
 	private Environment environment;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -56,12 +56,16 @@ public class SecretManagerWebController {
 	@ResponseBody
 	public String getSecret(@RequestParam String secretId, ModelMap map) {
 		String secretPayload = this.secretManagerTemplate.getSecretString(secretId);
-		return "Secret ID: " + secretId + " | Value: " + secretPayload;
+		return "Secret ID: " + secretId + " | Value: " + secretPayload
+				+ "<br/><br/><a href='/'>Go back</a>";
 	}
 
 	@PostMapping("/createSecret")
-	public String createSecret(@RequestParam String secretId, @RequestParam String secretPayload) {
+	public ModelAndView createSecret(
+			@RequestParam String secretId, @RequestParam String secretPayload, ModelMap map) {
 		this.secretManagerTemplate.createSecret(secretId, secretPayload);
-		return "redirect:/";
+		map.put("applicationSecret", this.applicationSecretValue);
+		map.put("message", "Secret created!");
+		return new ModelAndView("index.html", map);
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
@@ -1,3 +1,7 @@
-# This optional setting adds a prefix to your secret names that get injected
-# into the application Environment.
+# Set this setting to true if you want to load your GCP secrets as a
+# property source for your application.
+spring.cloud.gcp.secretmanager.bootstrap.enabled=true
+
+# This optional setting adds a prefix to your secret property names that get
+# injected into the application Environment.
 spring.cloud.gcp.secretmanager.secret-name-prefix=secrets.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
@@ -1,0 +1,97 @@
+<html>
+
+<style>
+  html * {
+    font-family: Roboto, Verdana, sans-serif;
+  }
+
+  body {
+    max-width: 50em;
+  }
+
+  li {
+    padding: 0.25em;
+  }
+
+  .panel {
+    margin: 1em;
+    padding: 1em;
+    border: 1px solid black;
+    border-radius: 5px;
+  }
+
+  .highlight {
+    background-color: #d6f5d6;
+  }
+
+
+</style>
+
+<head>
+  <title>Google Cloud Secret Manager Demo</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <link type="text/css" href="css/style.css" rel="stylesheet"/>
+</head>
+
+<body>
+<h1>Secret Manager Demo with Spring Cloud GCP</h1>
+
+<div class="panel">
+  <h3>Secret Manager Property Source</h3>
+  At the bootstrap phase, we loaded the following secret into the application context:
+  <br/>application-secret: [[${applicationSecret}]]
+</div>
+
+<div class="panel">
+  <h2>Create, Read, and Update Secrets</h2>
+
+  <p>
+    Using the form below, you can create/update secrets in Secret Manager and also read them.
+    In the controller code, the <i>SecretManagerTemplate</i> is being used to do this operations.
+  </p>
+
+  <p>
+    <b>NOTE: </b> In practice, you never want to allow your secrets to be visible as plaintext.
+    This is just a demonstration!
+  </p>
+
+  <div class="panel highlight">
+    <h3>Get Secret by Secret ID</h3>
+    <p>
+      Get a secret by secret ID from Secret Manager. You will receive an error if you
+      try to get a secret ID that does not already exist.
+    </p>
+    <form method="GET" action="/getSecret">
+      <ol>
+        <li>Secret ID: <input type="text" name="secretId"/></li>
+        <li><input type="submit" value="Get Secret"/></li>
+      </ol>
+    </form>
+  </div>
+
+  <div class="panel highlight">
+    <h3>Create/Update Secret</h3>
+    <p>
+      This will create a secret if the provided secret ID does not exists.
+      Otherwise it will create version under the provided secret ID.
+    </p>
+    <form method="POST" action="/createSecret">
+      <ol>
+        <li>Secret ID: <input type="text" name="secretId"/></li>
+        <li>Secret Payload: <input type="text" name="secretPayload"/></li>
+        <li><input type="submit" value="Create/Update Secret"/></li>
+      </ol>
+    </form>
+  </div>
+</div>
+
+<div class="panel">
+  <p>
+    You can also view your secrets in the
+    <a href="https://console.cloud.google.com/security/secret-manager">Secret Manager UI in Google
+      Cloud Console</a>.
+  </p>
+</div>
+
+</body>
+</html>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
@@ -1,4 +1,4 @@
-<html>
+<html xmlns:th="https://www.thymeleaf.org">
 
 <style>
   html * {
@@ -39,7 +39,9 @@
 <div class="panel">
   <h3>Secret Manager Property Source</h3>
   At the bootstrap phase, we loaded the following secret into the application context:
-  <br/>application-secret: [[${applicationSecret}]]
+  <br/>
+  <br/>
+  <b>application-secret:</b> <i>[[${applicationSecret}]]</i>
 </div>
 
 <div class="panel">
@@ -82,6 +84,10 @@
         <li><input type="submit" value="Create/Update Secret"/></li>
       </ol>
     </form>
+
+    <h3 th:if="${message}">
+      [[${message}]]
+    </h3>
   </div>
 </div>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
@@ -47,7 +47,7 @@
 
   <p>
     Using the form below, you can create/update secrets in Secret Manager and also read them.
-    In the controller code, the <i>SecretManagerTemplate</i> is being used to do this operations.
+    In the controller code, the <i>SecretManagerTemplate</i> is being used to do these operations.
   </p>
 
   <p>
@@ -88,8 +88,9 @@
 <div class="panel">
   <p>
     You can also view your secrets in the
-    <a href="https://console.cloud.google.com/security/secret-manager">Secret Manager UI in Google
-      Cloud Console</a>.
+    <a href="https://console.cloud.google.com/security/secret-manager">
+      Secret Manager UI in Google Cloud Console
+    </a>.
   </p>
 </div>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleTests.java
@@ -35,7 +35,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assume.assumeThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class)
+@SpringBootTest(
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = SecretManagerApplication.class,
+		properties = {"spring.cloud.gcp.secretmanager.bootstrap.enabled=true"})
 public class SecretManagerSampleTests {
 
 	@Autowired

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleTests.java
@@ -56,7 +56,7 @@ public class SecretManagerSampleTests {
 	public void testApplicationStartup() {
 		ResponseEntity<String> response = this.testRestTemplate.getForEntity("/", String.class);
 		assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-		assertThat(response.getBody()).contains("application-secret: Hello world.");
+		assertThat(response.getBody()).contains("<b>application-secret:</b> <i>Hello world.</i>");
 	}
 
 	@Test
@@ -67,11 +67,11 @@ public class SecretManagerSampleTests {
 		HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(params, new HttpHeaders());
 
 		ResponseEntity<String> response = this.testRestTemplate.postForEntity("/createSecret", request, String.class);
-		assertThat(response.getStatusCode().is3xxRedirection()).isTrue();
+		assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
 		response = this.testRestTemplate.getForEntity(
 				"/getSecret?secretId=secret-manager-sample-secret", String.class);
-		assertThat(response.getBody()).isEqualTo(
+		assertThat(response.getBody()).contains(
 				"Secret ID: secret-manager-sample-secret | Value: 12345");
 	}
 }

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
@@ -25,8 +25,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.cloud</groupId>
-			<artifactId>google-cloud-secretmanager</artifactId>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-gcp-secretmanager</artifactId>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This adds a non-bootstrap phase autoconfiguration class to autowire the `SecretManagerTemplate` and then extends the existing sample application to use the template class.

Contributes to #2176.

**Refdoc** is prepared in the PR here: #2224.