### PR TITLE
Add the refdoc for Secret Manager API Integration

### DIFF
--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -37,7 +37,7 @@ The Spring Cloud GCP integration for Google Cloud Secret Manager enables you to 
 
 This feature allows you to automatically load your GCP project's secrets as properties into the application context during the https://cloud.spring.io/spring-cloud-commons/reference/html/#the-bootstrap-application-context[Bootstrap Phase], which refers to the initial phase when a Spring application is being loaded.
 
-NOTE: To begin using this feature, you must set `spring.cloud.gcp.secretmanager.bootstrap.enabled=true` because this feature is disabled by default.
+NOTE: This feature disabled by default; to use it, you must set `spring.cloud.gcp.secretmanager.bootstrap.enabled` to **true**.
 
 Spring Cloud GCP will load the **latest** version of each secret into the application context.
 
@@ -50,9 +50,6 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 |===
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. Set this to **true** to enable the feature. | No | `false`
-| `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
-| `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating with the Google Cloud Storage API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
-| `spring.cloud.gcp.secretmanager.project-id` | The GCP Project used to access Secret Manager API. | No | By default, infers the project from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix string to prepend to the property names of secrets read from Secret Manager | No | "" (empty string)
 |===
 
@@ -60,7 +57,7 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 
 The `SecretManagerTemplate` class simplifies operations of creating, updating, and reading secrets.
 
-To begin using this class, you may autowire an instance of the class using `@Autowired` after adding the starter dependency to your project.
+To begin using this class, you may inject an instance of the class using `@Autowired` after adding the starter dependency to your project.
 
 [source, java]
 ----
@@ -73,8 +70,17 @@ Please consult https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spri
 |===
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.secretmanager.enabled` | Enables the autowiring of the `SecretManagerTemplate` in the application context. | No | `true`
-| `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
-| `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating with the Google Cloud Storage API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+|===
+
+=== Authentication Settings
+
+By default, Spring Cloud GCP Secret Manager will authenticate using Application Default Credentials.
+This can be overridden using the authentication properties below.
+
+|===
+| Name | Description | Required | Default value
+| `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating to the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+| `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating to the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.project-id` | The GCP Project used to access Secret Manager API. | No | By default, infers the project from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 |===
 

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -37,7 +37,7 @@ The Spring Cloud GCP integration for Google Cloud Secret Manager enables you to 
 
 This feature allows you to automatically load your GCP project's secrets as properties into the application context during the https://cloud.spring.io/spring-cloud-commons/reference/html/#the-bootstrap-application-context[Bootstrap Phase], which refers to the initial phase when a Spring application is being loaded.
 
-NOTE: To begin using this feature, you must set the setting `spring.cloud.gcp.secretmanager.bootstrap.enabled` to **true**, this feature disabled by default.
+NOTE: To begin using this feature, you must set `spring.cloud.gcp.secretmanager.bootstrap.enabled=true` because this feature is disabled by default.
 
 Spring Cloud GCP will load the **latest** version of each secret into the application context.
 

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -53,6 +53,8 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 | `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix string to prepend to the property names of secrets read from Secret Manager | No | "" (empty string)
 |===
 
+See the Authentication Settings section below for information on how to set properties to authenticate to Secret Manager.
+
 === Secret Manager Template
 
 The `SecretManagerTemplate` class simplifies operations of creating, updating, and reading secrets.
@@ -71,6 +73,8 @@ Please consult https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spri
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.secretmanager.enabled` | Enables the autowiring of the `SecretManagerTemplate` in the application context. | No | `true`
 |===
+
+See the Authentication Settings section below for information on how to set properties to authenticate to Secret Manager.
 
 === Authentication Settings
 

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -35,7 +35,10 @@ dependencies {
 
 The Spring Cloud GCP integration for Google Cloud Secret Manager enables you to use Secret Manager as a bootstrap property source.
 
-After adding the starter dependency to your project, Spring Cloud GCP will automatically load your GCP project's secrets as properties into the application context during the https://cloud.spring.io/spring-cloud-commons/reference/html/#the-bootstrap-application-context[Bootstrap Phase], which refers to the initial phase when a Spring application is being loaded.
+This feature allows you to automatically load your GCP project's secrets as properties into the application context during the https://cloud.spring.io/spring-cloud-commons/reference/html/#the-bootstrap-application-context[Bootstrap Phase], which refers to the initial phase when a Spring application is being loaded.
+
+NOTE: To begin using this feature, you must set the setting `spring.cloud.gcp.secretmanager.bootstrap.enabled` to **true**, this feature disabled by default.
+
 Spring Cloud GCP will load the **latest** version of each secret into the application context.
 
 All secrets will be loaded into the application environment using their `secretId` as the property's names.
@@ -46,7 +49,7 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 
 |===
 | Name | Description | Required | Default value
-| `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. | No | `true`
+| `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. Set this to **true** to enable the feature. | No | `false`
 | `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating with the Google Cloud Storage API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.project-id` | The GCP Project used to access Secret Manager API. | No | By default, infers the project from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
@@ -69,7 +72,7 @@ Please consult https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spri
 
 |===
 | Name | Description | Required | Default value
-| `spring.cloud.gcp.secretmanager.template.enabled` | Enables the autowiring of the `SecretManagerTemplate` | No | `true`
+| `spring.cloud.gcp.secretmanager.enabled` | Enables the autowiring of the `SecretManagerTemplate` in the application context. | No | `true`
 | `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating with the Google Cloud Storage API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.project-id` | The GCP Project used to access Secret Manager API. | No | By default, infers the project from https://cloud.google.com/docs/authentication/production[Application Default Credentials].

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -1,0 +1,80 @@
+== Secret Manager
+
+https://cloud.google.com/secret-manager[Google Cloud Secret Manager] is a secure and convenient method for storing API keys, passwords, certificates, and other sensitive data.
+A detailed summary of its features can be found in the https://cloud.google.com/blog/products/identity-security/introducing-google-clouds-secret-manager[Secret Manager documentation].
+
+Spring Cloud GCP provides:
+
+* A convenience starter which automatically loads the secrets of your GCP project into your application context as a https://cloud.spring.io/spring-cloud-commons/multi/multi__spring_cloud_context_application_context_services.html#_the_bootstrap_application_context[Bootstrap Property Source].
+* A `SecretManagerTemplate` which allows you to read, write, and update secrets in Secret Manager.
+
+=== Dependency Setup
+
+To begin using this library, add the `spring-cloud-gcp-starter-secretmanager` artifact to your project.
+
+Maven coordinates, using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.springframework.cloud</groupId>
+  <artifactId>spring-cloud-gcp-starter-secretmanager</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+[source]
+----
+dependencies {
+  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-secretmanager'
+}
+----
+
+=== Secret Manager Property Source
+
+The Spring Cloud GCP integration for Google Cloud Secret Manager enables you to use Secret Manager as a bootstrap property source.
+
+After adding the starter dependency to your project, Spring Cloud GCP will automatically load your GCP project's secrets as properties into the application context during the https://cloud.spring.io/spring-cloud-commons/reference/html/#the-bootstrap-application-context[Bootstrap Phase], which refers to the initial phase when a Spring application is being loaded.
+Spring Cloud GCP will load the **latest** version of each secret into the application context.
+
+All secrets will be loaded into the application environment using their `secretId` as the property's names.
+For example, if your secret's id is `my-secret` then it will be accessible as a property using the name `my-secret`.
+If you would like to append a prefix string to all property names imported from Secret Manager, you may use the `spring.cloud.gcp.secretmanager.secret-name-prefix` setting described below.
+
+Spring Cloud GCP Secret Manager offers several configuration properties to customize the behavior.
+
+|===
+| Name | Description | Required | Default value
+| `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. | No | `true`
+| `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+| `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating with the Google Cloud Storage API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+| `spring.cloud.gcp.secretmanager.project-id` | The GCP Project used to access Secret Manager API. | No | By default, infers the project from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+| `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix string to prepend to the property names of secrets read from Secret Manager | No | "" (empty string)
+|===
+
+=== Secret Manager Template
+
+The `SecretManagerTemplate` class simplifies operations of creating, updating, and reading secrets.
+
+To begin using this class, you may autowire an instance of the class using `@Autowired` after adding the starter dependency to your project.
+
+[source, java]
+----
+@Autowired
+private SecretManagerTemplate secretManagerTemplate;
+----
+
+Please consult https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerOperations.java[`SecretManagerOperations`] for information on what operations are available for the Secret Manager template.
+
+|===
+| Name | Description | Required | Default value
+| `spring.cloud.gcp.secretmanager.template.enabled` | Enables the autowiring of the `SecretManagerTemplate` | No | `true`
+| `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+| `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating with the Google Cloud Storage API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+| `spring.cloud.gcp.secretmanager.project-id` | The GCP Project used to access Secret Manager API. | No | By default, infers the project from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+|===
+
+=== Sample Application
+
+A https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample[Secret Manager Sample Application] is provided which demonstrates basic property source loading and usage of the template class.

--- a/docs/src/main/asciidoc/spring-cloud-gcp.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gcp.adoc
@@ -57,6 +57,8 @@ include::vision.adoc[]
 
 include::bigquery.adoc[]
 
+include::secretmanager.adoc[]
+
 include::cloudfoundry.adoc[]
 
 include::kotlin.adoc[]


### PR DESCRIPTION
Add the refdoc for the Secret Manager API Integration.

Contributes to #2176.

Should be submitted after #2223.