### PR TITLE
Adds exception handling to the PubSubReactiveFactory, where the exception is published to the Flux sink

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/reactive/PubSubReactiveFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/reactive/PubSubReactiveFactory.java
@@ -67,6 +67,9 @@ public final class PubSubReactiveFactory {
 	 * <p>For specific demand, as many messages as are available will be returned immediately,
 	 * with remaining demand being fulfilled in the future.
 	 * Pub/Sub timeout will cause a retry with the same demand.
+	 * <p>Any exceptions that are thrown by the Pub/Sub client will be passed as an error to the stream.
+	 * The error handling operators, like {@link Flux#retry()},
+	 * can be used to recover and continue streaming messages.
 	 * @param subscriptionName subscription from which to retrieve messages.
 	 * @param pollingPeriodMs how frequently to poll the source subscription in case of unlimited demand, in milliseconds.
 	 * @return infinite stream of {@link AcknowledgeablePubsubMessage} objects.

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/reactive/PubSubReactiveFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/reactive/PubSubReactiveFactory.java
@@ -88,7 +88,7 @@ public final class PubSubReactiveFactory {
 				}
 			});
 
-			sink.onCancel(subscriptionWorker);
+			sink.onDispose(subscriptionWorker);
 
 		});
 	}
@@ -139,21 +139,26 @@ public final class PubSubReactiveFactory {
 
 		@Override
 		public void run() {
-			long demand = this.initialDemand;
-			List<AcknowledgeablePubsubMessage> messages;
+			try {
+				long demand = this.initialDemand;
+				List<AcknowledgeablePubsubMessage> messages;
 
-			while (demand > 0 && !this.sink.isCancelled()) {
-				try {
-					int intDemand = demand > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) demand;
-					demand -= pullToSink(intDemand, true);
-				}
-				catch (DeadlineExceededException e) {
-					if (LOGGER.isTraceEnabled()) {
-						LOGGER.trace("Blocking pull timed out due to empty subscription "
-							+ this.subscriptionName
-							+ "; retrying.");
+				while (demand > 0 && !this.sink.isCancelled()) {
+					try {
+						int intDemand = demand > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) demand;
+						demand -= pullToSink(intDemand, true);
+					}
+					catch (DeadlineExceededException e) {
+						if (LOGGER.isTraceEnabled()) {
+							LOGGER.trace("Blocking pull timed out due to empty subscription "
+									+ this.subscriptionName
+									+ "; retrying.");
+						}
 					}
 				}
+			}
+			catch (RuntimeException e) {
+				sink.error(e);
 			}
 		}
 
@@ -171,7 +176,12 @@ public final class PubSubReactiveFactory {
 
 		@Override
 		public void run() {
-			pullToSink(Integer.MAX_VALUE, false);
+			try {
+				pullToSink(Integer.MAX_VALUE, false);
+			}
+			catch (RuntimeException e) {
+				sink.error(e);
+			}
 		}
 
 	}

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/reactive/PubSubReactiveFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/reactive/PubSubReactiveFactoryTests.java
@@ -177,7 +177,8 @@ public class PubSubReactiveFactoryTests {
 	/**
 	 * Replays provided messages.
 	 * If a synthetic message "stop" is encountered, immediately returns previously collected messages.
-	 * If a synthetic message "throw" is encountered, throws an {@link DeadlineExceededException}.
+	 * If a synthetic message "timeout" is encountered, throws an {@link DeadlineExceededException}.
+	 * If a synthetic message "throw" is encountered, throws an {@link RuntimeException}.
 	 * Fails the calling test if there are not enough messages to fulfill demand from cumulative calls to {@code pull()}.
 	 * @param messages messages to replay
 	 */

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/reactive/PubSubReactiveFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/reactive/PubSubReactiveFactoryTests.java
@@ -201,7 +201,7 @@ public class PubSubReactiveFactoryTests {
 						}
 						throw new DeadlineExceededException("this is a noop", null, GrpcStatusCode.of(Status.Code.DEADLINE_EXCEEDED), true);
 					case "throw":
-						throw new RuntimeException("exception during pull of messages");
+						throw new RuntimeException("expected exception during pull of messages");
 				}
 
 				AcknowledgeablePubsubMessage msg = mock(AcknowledgeablePubsubMessage.class);


### PR DESCRIPTION
Fixes #2229 by publishing the exception to the Flux sink.

This may be partially seen as a breaking change as it changes the behaviour for the unlimited poll because the unlimited poll would previously ignore exceptions and keep on being rescheduled.