### PR TITLE
Interpret missing maxMessages as MAX_INT in Pub/Sub PullRequests

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -99,6 +99,9 @@ h|pull(String subscription, Integer maxMessages,
        			Boolean returnImmediately) | Pulls a number of messages from a subscription, allowing for the retry settings to be configured.
        			Any messages received by `pull()` are not automatically acknowledged. See <<Acknowledging messages>>.
 
+				The `maxMessages` parameter is the maximum limit of how many messages to pull from a subscription in a single call; this value **must** be greater than 0.
+				You may omit this parameter by passing in `null`; this means there will be no limit on the number of messages pulled (`maxMessages` will be `Integer.MAX_INTEGER`).
+
        			If `returnImmediately` is `true`, the system will respond immediately even if it there are no messages available to return in the `Pull` response. Otherwise, the system may wait (for a bounded amount of time) until at least one message is available, rather than returning no messages.
 h|pullAndAck | Works the same as the `pull` method and, additionally, acknowledges all received messages.
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -86,8 +86,8 @@ public interface PubSubSubscriberOperations {
 	 * Pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
-	 * on the number of pulled messages.
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @return the list of received messages
@@ -98,8 +98,8 @@ public interface PubSubSubscriberOperations {
 	 * Asynchronously pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
-	 * on the number of pulled messages.
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @return the ListenableFuture for the asynchronous execution, returning the list of
@@ -112,8 +112,8 @@ public interface PubSubSubscriberOperations {
 	 * Pull a number of messages from a Google Cloud Pub/Sub subscription.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
-	 * on the number of pulled messages.
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @return the list of received acknowledgeable messages
@@ -124,8 +124,8 @@ public interface PubSubSubscriberOperations {
 	 * Asynchronously pull a number of messages from a Google Cloud Pub/Sub subscription.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
-	 * on the number of pulled messages.
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @return the ListenableFuture for the asynchronous execution, returning the list of
@@ -139,8 +139,8 @@ public interface PubSubSubscriberOperations {
 	 * the desired payload type.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
-	 * on the number of pulled messages.
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @param payloadType the type to which the payload of the Pub/Sub messages should be converted
@@ -156,8 +156,8 @@ public interface PubSubSubscriberOperations {
 	 * the desired payload type.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
-	 * on the number of pulled messages.
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @param payloadType the type to which the payload of the Pub/Sub messages should be converted

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -86,7 +86,8 @@ public interface PubSubSubscriberOperations {
 	 * Pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
+	 * on the number of pulled messages.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @return the list of received messages
@@ -97,7 +98,8 @@ public interface PubSubSubscriberOperations {
 	 * Asynchronously pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
+	 * on the number of pulled messages.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @return the ListenableFuture for the asynchronous execution, returning the list of
@@ -110,7 +112,8 @@ public interface PubSubSubscriberOperations {
 	 * Pull a number of messages from a Google Cloud Pub/Sub subscription.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
+	 * on the number of pulled messages.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @return the list of received acknowledgeable messages
@@ -121,7 +124,8 @@ public interface PubSubSubscriberOperations {
 	 * Asynchronously pull a number of messages from a Google Cloud Pub/Sub subscription.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
+	 * on the number of pulled messages.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @return the ListenableFuture for the asynchronous execution, returning the list of
@@ -135,7 +139,8 @@ public interface PubSubSubscriberOperations {
 	 * the desired payload type.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
+	 * on the number of pulled messages.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @param payloadType the type to which the payload of the Pub/Sub messages should be converted
@@ -151,7 +156,8 @@ public interface PubSubSubscriberOperations {
 	 * the desired payload type.
 	 * @param subscription canonical subscription name, e.g., "subscriptionName", or the fully-qualified
 	 * subscription name in the {@code projects/<project_name>/subscriptions/<subscription_name>} format
-	 * @param maxMessages the maximum number of pulled messages
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then there is no limit
+	 * on the number of pulled messages.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
 	 * messages to satisfy {@code maxMessages}
 	 * @param payloadType the type to which the payload of the Pub/Sub messages should be converted

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactory.java
@@ -223,15 +223,16 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 			Boolean returnImmediately) {
 		Assert.hasLength(subscriptionName, "The subscription name must be provided.");
 
-		PullRequest.Builder pullRequestBuilder =
-				PullRequest.newBuilder().setSubscription(
-						PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, this.projectId).toString());
-
-		if (maxMessages != null) {
-			Assert.isTrue(maxMessages > 0, "The maxMessages must be greater than 0.");
-
-			pullRequestBuilder.setMaxMessages(maxMessages);
+		if (maxMessages == null) {
+			maxMessages = Integer.MAX_VALUE;
 		}
+		Assert.isTrue(maxMessages > 0, "The maxMessages must be greater than 0.");
+
+		PullRequest.Builder pullRequestBuilder =
+				PullRequest.newBuilder()
+						.setSubscription(
+								PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, this.projectId).toString())
+						.setMaxMessages(maxMessages);
 
 		if (returnImmediately != null) {
 			pullRequestBuilder.setReturnImmediately(returnImmediately);

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/SubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/SubscriberFactory.java
@@ -54,8 +54,8 @@ public interface SubscriberFactory {
 	 * Create a {@link PullRequest} for synchronously pulling a number of messages from
 	 * a Google Cloud Pub/Sub subscription.
 	 * @param subscriptionName the name of the subscription
-	 * @param maxMessages the maximum number of pulled messages,
-	 * which must be a positive number
+	 * @param maxMessages the maximum number of pulled messages; must be greater than zero.
+	 * If null is passed in, then there will be no limit on the number of pulled messages.
 	 * @param returnImmediately causes the pull request to return immediately even
 	 * if subscription doesn't contain enough messages to satisfy {@code maxMessages}
 	 * @return the pull request that can be executed using a {@link SubscriberStub}

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/SubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/SubscriberFactory.java
@@ -55,7 +55,7 @@ public interface SubscriberFactory {
 	 * a Google Cloud Pub/Sub subscription.
 	 * @param subscriptionName the name of the subscription
 	 * @param maxMessages the maximum number of pulled messages; must be greater than zero.
-	 * If null is passed in, then there will be no limit on the number of pulled messages.
+	 * If null is passed in, then up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately causes the pull request to return immediately even
 	 * if subscription doesn't contain enough messages to satisfy {@code maxMessages}
 	 * @return the pull request that can be executed using a {@link SubscriberStub}

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -77,15 +77,13 @@ public class DefaultSubscriberFactoryTests {
 		factory.setCredentialsProvider(this.credentialsProvider);
 
 		// If a maxMessages is null (it was omitted), then set max to MAX_INT
-		PullRequest request =
-				factory.createPullRequest("test", null, true);
+		PullRequest request = factory.createPullRequest("test", null, true);
 		assertThat(request.getMaxMessages()).isEqualTo(Integer.MAX_VALUE);
 
 		// If maxMessages < 0, should throw an error.
 		this.expectedException.expect(IllegalArgumentException.class);
 		this.expectedException.expectMessage("The maxMessages must be greater than 0.");
-		request = factory.createPullRequest(
-				"test", -1, true);
+		request = factory.createPullRequest("test", -1, true);
 	}
 
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -72,18 +72,21 @@ public class DefaultSubscriberFactoryTests {
 	}
 
 	@Test
-	public void testCreatePullRequest_nonZeroMaxMessages() {
+	public void testCreatePullRequest_greaterThanZeroMaxMessages() {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project");
 		factory.setCredentialsProvider(this.credentialsProvider);
 
-		// If a maxMessages is null (it was omitted), then set max to MAX_INT
-		PullRequest request = factory.createPullRequest("test", null, true);
-		assertThat(request.getMaxMessages()).isEqualTo(Integer.MAX_VALUE);
-
-		// If maxMessages < 0, should throw an error.
 		this.expectedException.expect(IllegalArgumentException.class);
 		this.expectedException.expectMessage("The maxMessages must be greater than 0.");
-		request = factory.createPullRequest("test", -1, true);
+		factory.createPullRequest("test", -1, true);
 	}
 
+	@Test
+	public void testCreatePullRequest_nonNullMaxMessages() {
+		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project");
+		factory.setCredentialsProvider(this.credentialsProvider);
+
+		PullRequest request = factory.createPullRequest("test", null, true);
+		assertThat(request.getMaxMessages()).isEqualTo(Integer.MAX_VALUE);
+	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.pubsub.support;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.PullRequest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -68,6 +69,23 @@ public class DefaultSubscriberFactoryTests {
 		this.expectedException.expect(IllegalArgumentException.class);
 		this.expectedException.expectMessage("The project ID can't be null or empty.");
 		new DefaultSubscriberFactory(() -> null);
+	}
+
+	@Test
+	public void testCreatePullRequest_nonZeroMaxMessages() {
+		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project");
+		factory.setCredentialsProvider(this.credentialsProvider);
+
+		// If a maxMessages is null (it was omitted), then set max to MAX_INT
+		PullRequest request =
+				factory.createPullRequest("test", null, true);
+		assertThat(request.getMaxMessages()).isEqualTo(Integer.MAX_VALUE);
+
+		// If maxMessages < 0, should throw an error.
+		this.expectedException.expect(IllegalArgumentException.class);
+		this.expectedException.expectMessage("The maxMessages must be greater than 0.");
+		request = factory.createPullRequest(
+				"test", -1, true);
 	}
 
 }


### PR DESCRIPTION
If the `maxMessages` parameter is provided as `null` in the PubSubTemplate, interpret this as `Integer.MAX_INTEGER` which means there should be no limit on the number of messages pulled.

Fixes #2248.