### PR TITLE
Polish Secret Manager Code

### DIFF
--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -51,11 +51,7 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. Set this to **true** to enable the feature. | No | `false`
 | `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix string to prepend to the property names of secrets read from Secret Manager | No | "" (empty string)
-| `spring.cloud.gcp.secretmanager.default-version`
-| The default version that secrets will be read at, if a specific version for the secret is not configured.
-
-Note: If you set this to a value other than "latest" and a secret has not reached that version yet, then the secret **will not** be injected into the environment. | No | "latest"
-| `spring.cloud.gcp.secretmanager.versions.<secret-id>` | Defines a version for a specific secret-id to read from Secret Manager. It will take precedence over `spring.cloud.gcp.secretmanager.version` if both are specified | No | "" (empty string)
+| `spring.cloud.gcp.secretmanager.versions.<secret-id>` | Defines a version for a specific secret-id to read from Secret Manager instead of using the latest version. | No | "" (empty string)
 |===
 
 See the Authentication Settings section below for information on how to set properties to authenticate to Secret Manager.

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -52,7 +52,7 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 | `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. Set this to **true** to enable the feature. | No | `false`
 | `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix string to prepend to the property names of secrets read from Secret Manager | No | "" (empty string)
 | `spring.cloud.gcp.secretmanager.default-version`
-| The default version that secrets will be read at, if a specific version for the secret is not configured.version
+| The default version that secrets will be read at, if a specific version for the secret is not configured.
 
 Note: If you set this to a value other than "latest" and a secret has not reached that version yet, then the secret **will not** be injected into the environment. | No | "latest"
 | `spring.cloud.gcp.secretmanager.versions.<secret-id>` | Defines a version for a specific secret-id to read from Secret Manager. It will take precedence over `spring.cloud.gcp.secretmanager.version` if both are specified | No | "" (empty string)

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -51,7 +51,10 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. Set this to **true** to enable the feature. | No | `false`
 | `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix string to prepend to the property names of secrets read from Secret Manager | No | "" (empty string)
-| `spring.cloud.gcp.secretmanager.version` | Defines a specific version of secrets to read from Secret Manager | No | "latest"
+| `spring.cloud.gcp.secretmanager.default-version`
+| The default version that secrets will be read at, if a specific version for the secret is not configured.version
+
+Note: If you set this to a value other than "latest" and a secret has not reached that version yet, then the secret **will not** be injected into the environment. | No | "latest"
 | `spring.cloud.gcp.secretmanager.versions.<secret-id>` | Defines a version for a specific secret-id to read from Secret Manager. It will take precedence over `spring.cloud.gcp.secretmanager.version` if both are specified | No | "" (empty string)
 |===
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -100,7 +100,6 @@ public class GcpSecretManagerBootstrapConfiguration {
 	public PropertySourceLocator secretManagerPropertySourceLocator(SecretManagerServiceClient client) {
 		SecretManagerPropertySourceLocator propertySourceLocator = new SecretManagerPropertySourceLocator(
 				client, this.gcpProjectIdProvider, this.properties.getSecretNamePrefix());
-		propertySourceLocator.setVersion(this.properties.getDefaultVersion());
 		propertySourceLocator.setVersions(this.properties.getVersions());
 		return propertySourceLocator;
 	}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -100,7 +100,7 @@ public class GcpSecretManagerBootstrapConfiguration {
 	public PropertySourceLocator secretManagerPropertySourceLocator(SecretManagerServiceClient client) {
 		SecretManagerPropertySourceLocator propertySourceLocator = new SecretManagerPropertySourceLocator(
 				client, this.gcpProjectIdProvider, this.properties.getSecretNamePrefix());
-		propertySourceLocator.setVersion(this.properties.getVersion());
+		propertySourceLocator.setVersion(this.properties.getDefaultVersion());
 		propertySourceLocator.setVersions(this.properties.getVersions());
 		return propertySourceLocator;
 	}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerProperties.java
@@ -48,7 +48,7 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 	/**
 	 * Defines the secret's version to be used.
 	 */
-	private String version;
+	private String defaultVersion = "latest";
 
 	/**
 	 * Defines versions for specific secret-ids.
@@ -75,12 +75,12 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 		this.secretNamePrefix = secretNamePrefix;
 	}
 
-	public String getVersion() {
-		return version;
+	public String getDefaultVersion() {
+		return defaultVersion;
 	}
 
-	public void setVersion(String version) {
-		this.version = version;
+	public void setDefaultVersion(String defaultVersion) {
+		this.defaultVersion = defaultVersion;
 	}
 
 	public Map<String, String> getVersions() {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerProperties.java
@@ -46,11 +46,6 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 	private String secretNamePrefix = "";
 
 	/**
-	 * Defines the secret's version to be used.
-	 */
-	private String defaultVersion = "latest";
-
-	/**
 	 * Defines versions for specific secret-ids.
 	 */
 	private Map<String, String> versions = new HashMap<>();
@@ -73,14 +68,6 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 
 	public void setSecretNamePrefix(String secretNamePrefix) {
 		this.secretNamePrefix = secretNamePrefix;
-	}
-
-	public String getDefaultVersion() {
-		return defaultVersion;
-	}
-
-	public void setDefaultVersion(String defaultVersion) {
-		this.defaultVersion = defaultVersion;
 	}
 
 	public Map<String, String> getVersions() {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySource.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySource.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.secretmanager.v1beta1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1beta1.ProjectName;
 import com.google.cloud.secretmanager.v1beta1.Secret;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySourceLocator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySourceLocator.java
@@ -43,8 +43,6 @@ public class SecretManagerPropertySourceLocator implements PropertySourceLocator
 
 	private final String secretsPrefix;
 
-	private String version;
-
 	private Map<String, String> versions;
 
 	SecretManagerPropertySourceLocator(
@@ -54,10 +52,6 @@ public class SecretManagerPropertySourceLocator implements PropertySourceLocator
 		this.client = client;
 		this.projectIdProvider = projectIdProvider;
 		this.secretsPrefix = secretsPrefix;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
 	}
 
 	public void setVersions(Map<String, String> versions) {
@@ -71,7 +65,6 @@ public class SecretManagerPropertySourceLocator implements PropertySourceLocator
 				this.client,
 				this.projectIdProvider,
 				this.secretsPrefix,
-				this.version,
 				this.versions);
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.autoconfigure.secretmanager.it;
 
 import java.util.stream.StreamSupport;
 
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.secretmanager.v1beta1.AddSecretVersionRequest;
 import com.google.cloud.secretmanager.v1beta1.CreateSecretRequest;
 import com.google.cloud.secretmanager.v1beta1.ProjectName;
@@ -27,9 +28,7 @@ import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient.ListSecretsPagedResponse;
 import com.google.cloud.secretmanager.v1beta1.SecretName;
 import com.google.cloud.secretmanager.v1beta1.SecretPayload;
-import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
 import com.google.protobuf.ByteString;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,6 +36,7 @@ import org.junit.Test;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.cloud.gcp.autoconfigure.secretmanager.GcpSecretManagerAutoConfiguration;
 import org.springframework.cloud.gcp.autoconfigure.secretmanager.GcpSecretManagerBootstrapConfiguration;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -46,9 +46,9 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class SecretManagerIntegrationTests {
 
-	private static final String TEST_SECRET_ID = "my-secret";
+	private static final String TEST_SECRET_ID = "spring-cloud-gcp-it-secret";
 
-	private ConfigurableApplicationContext context;
+	private static final String VERSIONED_SECRET_ID = "spring-cloud-gcp-it-versioned-secret";
 
 	private GcpProjectIdProvider projectIdProvider;
 
@@ -64,111 +64,96 @@ public class SecretManagerIntegrationTests {
 
 	@Before
 	public void setupSecretManager() {
-		this.context = new SpringApplicationBuilder()
+		ConfigurableApplicationContext context = new SpringApplicationBuilder()
+				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerAutoConfiguration.class)
+				.web(WebApplicationType.NONE)
+				.run();
+
+		this.projectIdProvider = context.getBeanFactory().getBean(GcpProjectIdProvider.class);
+		this.client = context.getBeanFactory().getBean(SecretManagerServiceClient.class);
+
+		// Clean up the test secrets in the project from prior runs.
+		deleteSecret(TEST_SECRET_ID);
+		deleteSecret(VERSIONED_SECRET_ID);
+	}
+
+	@Test
+	public void testConfiguration() {
+		createSecret(TEST_SECRET_ID, "the secret data.");
+
+		ConfigurableApplicationContext context = new SpringApplicationBuilder()
 				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.properties("spring.cloud.gcp.secretmanager.bootstrap.enabled=true")
 				.run();
 
-		this.projectIdProvider = this.context.getBeanFactory().getBean(GcpProjectIdProvider.class);
-		this.client = this.context.getBeanFactory().getBean(SecretManagerServiceClient.class);
-
-		createSecret(TEST_SECRET_ID, "the secret data");
-	}
-
-	@After
-	public void close() {
-		if (this.context != null) {
-			this.context.close();
-		}
-	}
-
-	@Test
-	public void testConfiguration() {
-		assertThat(this.context.getEnvironment().getProperty("my-secret"))
+		assertThat(context.getEnvironment().getProperty(TEST_SECRET_ID))
 				.isEqualTo("the secret data.");
 
-		byte[] byteArraySecret = this.context.getEnvironment().getProperty("my-secret", byte[].class);
+		byte[] byteArraySecret = context.getEnvironment().getProperty(TEST_SECRET_ID, byte[].class);
 		assertThat(byteArraySecret).isEqualTo("the secret data.".getBytes());
 	}
 
 	@Test
 	public void testConfigurationDisabled() {
+		createSecret(TEST_SECRET_ID, "the secret data.");
+
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
 				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.properties("spring.cloud.gcp.secretmanager.enabled=false")
 				.run();
 
-		assertThat(context.getEnvironment()
-				.getProperty("spring-cloud-gcp.secrets.my-secret")).isNull();
+		assertThat(context.getEnvironment().getProperty(TEST_SECRET_ID, String.class)).isNull();
 	}
 
 	@Test
-	public void testVersion() {
-		this.context = new SpringApplicationBuilder()
+	public void testDefaultVersion() {
+		createSecret(TEST_SECRET_ID, "secret-v1");
+		createSecret(VERSIONED_SECRET_ID, "the secret data");
+		createSecret(VERSIONED_SECRET_ID, "the secret data v2");
+		createSecret(VERSIONED_SECRET_ID, "the secret data v3");
+
+		ConfigurableApplicationContext context = new SpringApplicationBuilder()
 				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.properties("spring.cloud.gcp.secretmanager.bootstrap.enabled=true")
-				.properties("spring.cloud.gcp.secretmanager.bootstrap.version=2")
+				.properties("spring.cloud.gcp.secretmanager.default-version=2")
 				.run();
 
-		createSecret(TEST_SECRET_ID, "the secret data");
-		assertThat(secretExists(TEST_SECRET_ID, "1")).isTrue();
-		createSecret(TEST_SECRET_ID, "the secret data v2");
-		assertThat(secretExists(TEST_SECRET_ID, "2")).isTrue();
-		assertThat(secretExists(TEST_SECRET_ID, "latest")).isTrue();
+		String basicSecret = context.getEnvironment().getProperty(TEST_SECRET_ID, String.class);
+		assertThat(basicSecret).isNull();
 
-		byte[] byteArraySecret = this.context.getEnvironment().getProperty("my-secret", byte[].class);
-		assertThat(byteArraySecret).isEqualTo("the secret data v2.".getBytes());
+		String versionedSecret = context.getEnvironment().getProperty(VERSIONED_SECRET_ID, String.class);
+		assertThat(versionedSecret).isEqualTo("the secret data v2");
 	}
 
 	@Test
 	public void testSecretsWithSpecificVersion() {
-		this.context = new SpringApplicationBuilder()
+		createSecret(VERSIONED_SECRET_ID, "the secret data");
+		createSecret(VERSIONED_SECRET_ID, "the secret data v2");
+		createSecret(VERSIONED_SECRET_ID, "the secret data v3");
+
+		ConfigurableApplicationContext context = new SpringApplicationBuilder()
 				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.properties("spring.cloud.gcp.secretmanager.bootstrap.enabled=true")
-				.properties("spring.cloud.gcp.secretmanager.versions.my-secret=2")
+				.properties("spring.cloud.gcp.secretmanager.versions." + VERSIONED_SECRET_ID + "=2")
+				.properties("spring.cloud.gcp.secretmanager.default-version=latest")
 				.run();
 
-		createSecret(TEST_SECRET_ID, "the secret data");
-		createSecret(TEST_SECRET_ID, "the secret data v2");
-		assertThat(secretExists(TEST_SECRET_ID, "2")).isTrue();
-
-		byte[] byteArraySecret = this.context.getEnvironment().getProperty("my-secret", byte[].class);
-		assertThat(byteArraySecret).isEqualTo("the secret data v2.".getBytes());
-	}
-
-	@Test
-	public void testSecretsWithSpecificVersionHasPriorityOverGlobalVersion() {
-		this.context = new SpringApplicationBuilder()
-				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
-				.web(WebApplicationType.NONE)
-				.properties("spring.cloud.gcp.secretmanager.bootstrap.enabled=true")
-				.properties("spring.cloud.gcp.secretmanager.bootstrap.version=2")
-				.properties("spring.cloud.gcp.secretmanager.versions.my-secret=1")
-				.run();
-
-		createSecret(TEST_SECRET_ID, "the secret data");
-		assertThat(secretExists(TEST_SECRET_ID, "1")).isTrue();
-		createSecret(TEST_SECRET_ID, "the secret data v2");
-		assertThat(secretExists(TEST_SECRET_ID, "2")).isTrue();
-
-		byte[] byteArraySecret = this.context.getEnvironment().getProperty("my-secret", byte[].class);
-		assertThat(byteArraySecret).isEqualTo("the secret data".getBytes());
-	}
-
-	private void createSecret(String secretId, String payload) {
-		createSecret(secretId, payload, "latest");
+		String versionedSecret = context.getEnvironment().getProperty(VERSIONED_SECRET_ID, String.class);
+		assertThat(versionedSecret).isEqualTo("the secret data v2");
 	}
 
 	/**
 	 * Creates the secret with the specified payload if the secret does not already exist.
+	 * Otherwise creates a new version of the secret under the existing {@code secretId}.
 	 */
-	private void createSecret(String secretId, String payload, String version) {
+	private void createSecret(String secretId, String payload) {
 		ProjectName projectName = ProjectName.of(projectIdProvider.getProjectId());
-		if (!secretExists(secretId, version)) {
+
+		if (!secretExists(secretId)) {
 			// Creates the secret.
 			Secret secret = Secret.newBuilder()
 					.setReplication(
@@ -182,16 +167,14 @@ public class SecretManagerIntegrationTests {
 					.setSecret(secret)
 					.build();
 			client.createSecret(request);
-			createSecretPayload("the secret data.");
 		}
-		else {
-			createSecretPayload("the secret data v2.");
-		}
+
+		createSecretPayload(secretId, payload);
 	}
 
-	private void createSecretPayload(String data) {
+	private void createSecretPayload(String secretId, String data) {
 		// Create the secret payload.
-		SecretName name = SecretName.of(projectIdProvider.getProjectId(), TEST_SECRET_ID);
+		SecretName name = SecretName.of(projectIdProvider.getProjectId(), secretId);
 		SecretPayload payloadObject = SecretPayload.newBuilder()
 				.setData(ByteString.copyFromUtf8(data))
 				.build();
@@ -202,19 +185,21 @@ public class SecretManagerIntegrationTests {
 		client.addSecretVersion(payloadRequest);
 	}
 
-	private boolean secretExists(String secretId, String version) {
-		String projectId = projectIdProvider.getProjectId();
-		ProjectName projectName = ProjectName.of(projectId);
+	private boolean secretExists(String secretId) {
+		ProjectName projectName = ProjectName.of(projectIdProvider.getProjectId());
 		ListSecretsPagedResponse listSecretsResponse = this.client.listSecrets(projectName);
 		return StreamSupport.stream(listSecretsResponse.iterateAll().spliterator(), false)
-				.filter(secret -> secret.getName().contains(secretId))
-				.anyMatch(secret -> {
-					SecretVersionName secretVersionName = SecretVersionName.newBuilder()
-							.setProject(projectId)
-							.setSecret(secretId)
-							.setSecretVersion(version)
-							.build();
-					return this.client.accessSecretVersion(secretVersionName) != null;
-				});
+				.anyMatch(secret -> secret.getName().contains(secretId));
+	}
+
+	private void deleteSecret(String secretId) {
+		try {
+			this.client.deleteSecret(SecretName.of(this.projectIdProvider.getProjectId(), secretId));
+		}
+		catch (Exception e) {
+			if (!(e instanceof NotFoundException)) {
+				throw e;
+			}
+		}
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
@@ -34,7 +34,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.boot.WebApplicationType;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
@@ -114,27 +114,6 @@ public class SecretManagerIntegrationTests {
 	}
 
 	@Test
-	public void testDefaultVersion() {
-		createSecret(VERSIONED_SECRET_ID, "the secret data");
-		createSecret(VERSIONED_SECRET_ID, "the secret data v2");
-		createSecret(VERSIONED_SECRET_ID, "the secret data v3");
-		createSecret(TEST_SECRET_ID, "secret-v1");
-
-		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
-				.web(WebApplicationType.NONE)
-				.properties("spring.cloud.gcp.secretmanager.bootstrap.enabled=true")
-				.properties("spring.cloud.gcp.secretmanager.default-version=2")
-				.run();
-
-		String basicSecret = context.getEnvironment().getProperty(TEST_SECRET_ID, String.class);
-		assertThat(basicSecret).isNull();
-
-		String versionedSecret = context.getEnvironment().getProperty(VERSIONED_SECRET_ID, String.class);
-		assertThat(versionedSecret).isEqualTo("the secret data v2");
-	}
-
-	@Test
 	public void testSecretsWithSpecificVersion() {
 		createSecret(VERSIONED_SECRET_ID, "the secret data");
 		createSecret(VERSIONED_SECRET_ID, "the secret data v2");
@@ -145,7 +124,6 @@ public class SecretManagerIntegrationTests {
 				.web(WebApplicationType.NONE)
 				.properties("spring.cloud.gcp.secretmanager.bootstrap.enabled=true")
 				.properties("spring.cloud.gcp.secretmanager.versions." + VERSIONED_SECRET_ID + "=2")
-				.properties("spring.cloud.gcp.secretmanager.default-version=latest")
 				.run();
 
 		String versionedSecret = context.getEnvironment().getProperty(VERSIONED_SECRET_ID, String.class);
@@ -162,7 +140,6 @@ public class SecretManagerIntegrationTests {
 				.web(WebApplicationType.NONE)
 				.properties("spring.cloud.gcp.secretmanager.bootstrap.enabled=true")
 				.properties("spring.cloud.gcp.secretmanager.versions." + VERSIONED_SECRET_ID + "=7")
-				.properties("spring.cloud.gcp.secretmanager.default-version=latest")
 				.run())
 				.hasCauseInstanceOf(StatusRuntimeException.class);
 	}


### PR DESCRIPTION
Followup to secret manager version feature changes.

Contents of PR:
- Fixes integration tests
- Rename 'version' property to 'default-version' : I feel this more accurately conveys that when a user specifies a specific version of a secret it will override the default.
- Fixes bug where if the default version doesn't exist for a particular secret it will now correctly be skipped instead of throw error.
- General polish.