### PR TITLE
Clarify Secret Manager properties are set in bootstrap.properties

### DIFF
--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -47,7 +47,7 @@ If you would like to append a prefix string to all property names imported from 
 
 Spring Cloud GCP Secret Manager offers several bootstrap configuration properties to customize the behavior.
 
-NOTE: All of the below settings must be specified in a https://cloud.spring.io/spring-cloud-commons/multi/multi__spring_cloud_context_application_context_services.html#_the_bootstrap_application_context[`bootstrap.properties`] (or `bootstrap.yaml`) file which is the properties file used to configure the behavior of bootstrap configuration.
+NOTE: All of the below settings must be specified in a https://cloud.spring.io/spring-cloud-commons/multi/multi__spring_cloud_context_application_context_services.html#_the_bootstrap_application_context[`bootstrap.properties`] (or `bootstrap.yaml`) file which is the properties file used to configure settings for bootstrap-phase Spring configuration.
 
 |===
 | Name | Description | Required | Default value

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -37,7 +37,7 @@ The Spring Cloud GCP integration for Google Cloud Secret Manager enables you to 
 
 This feature allows you to automatically load your GCP project's secrets as properties into the application context during the https://cloud.spring.io/spring-cloud-commons/reference/html/#the-bootstrap-application-context[Bootstrap Phase], which refers to the initial phase when a Spring application is being loaded.
 
-NOTE: This feature disabled by default; to use it, you must set `spring.cloud.gcp.secretmanager.bootstrap.enabled` to **true**.
+NOTE: This feature disabled by default; to use it, you must set `spring.cloud.gcp.secretmanager.bootstrap.enabled` to **true** in your `bootstrap.properties` file.
 
 Spring Cloud GCP will load the **latest** version of each secret into the application context.
 
@@ -45,7 +45,9 @@ All secrets will be loaded into the application environment using their `secretI
 For example, if your secret's id is `my-secret` then it will be accessible as a property using the name `my-secret`.
 If you would like to append a prefix string to all property names imported from Secret Manager, you may use the `spring.cloud.gcp.secretmanager.secret-name-prefix` setting described below.
 
-Spring Cloud GCP Secret Manager offers several configuration properties to customize the behavior.
+Spring Cloud GCP Secret Manager offers several bootstrap configuration properties to customize the behavior.
+
+NOTE: All of the below settings must be specified in a https://cloud.spring.io/spring-cloud-commons/multi/multi__spring_cloud_context_application_context_services.html#_the_bootstrap_application_context[`bootstrap.properties`] (or `bootstrap.yaml`) file which is the properties file used to configure the behavior of bootstrap configuration.
 
 |===
 | Name | Description | Required | Default value


### PR DESCRIPTION
Clarify that secret manager properties are to be added to `bootstrap.properties`.

Fixes #2273.