### PR TITLE
Clarify Secret Manager secret-prefix description

### DIFF
--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -50,7 +50,9 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 |===
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. Set this to **true** to enable the feature. | No | `false`
-| `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix to prepend to the property key for secrets read from Secret Manager. E.g., Secret Manager key is `applicationSecret`, with a prefix of `secrets`, the property becomes `secrets.applicationSecret`. | No | "" (empty string)
+| `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix to prepend to the property key for secrets read from Secret Manager.
+
+E.g., if the Secret Manager key is `applicationSecret`, with a prefix of `secrets`, the property key becomes `secrets.applicationSecret`. | No | "" (empty string)
 | `spring.cloud.gcp.secretmanager.version` | Defines a specific version of secrets to read from Secret Manager | No | "latest"
 | `spring.cloud.gcp.secretmanager.versions.<secret-id>` | Defines a version for a specific secret-id to read from Secret Manager. It will take precedence over `spring.cloud.gcp.secretmanager.version` if both are specified | No | "" (empty string)
 |===

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -50,7 +50,7 @@ Spring Cloud GCP Secret Manager offers several configuration properties to custo
 |===
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.secretmanager.bootstrap.enabled` | Enables loading secrets from Secret Manager as a bootstrap property source. Set this to **true** to enable the feature. | No | `false`
-| `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix string to prepend to the property names of secrets read from Secret Manager | No | "" (empty string)
+| `spring.cloud.gcp.secretmanager.secret-name-prefix` | A prefix to prepend to the property key for secrets read from Secret Manager. E.g., Secret Manager key is `applicationSecret`, with a prefix of `secrets`, the property becomes `secrets.applicationSecret`. | No | "" (empty string)
 | `spring.cloud.gcp.secretmanager.version` | Defines a specific version of secrets to read from Secret Manager | No | "latest"
 | `spring.cloud.gcp.secretmanager.versions.<secret-id>` | Defines a version for a specific secret-id to read from Secret Manager. It will take precedence over `spring.cloud.gcp.secretmanager.version` if both are specified | No | "" (empty string)
 |===


### PR DESCRIPTION
Clarifies the secret manager `secret-name-prefix` description.

Fixes #2276. 