### PR TITLE
Allow users to provide the ImageContext in CloudVisionTemplate

### DIFF
--- a/spring-cloud-gcp-vision/src/test/java/org/springframework/cloud/gcp/vision/CloudVisionTemplateTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/org/springframework/cloud/gcp/vision/CloudVisionTemplateTests.java
@@ -19,11 +19,16 @@ package org.springframework.cloud.gcp.vision;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.google.cloud.vision.v1.AnnotateImageRequest;
 import com.google.cloud.vision.v1.AnnotateImageResponse;
 import com.google.cloud.vision.v1.BatchAnnotateImagesRequest;
 import com.google.cloud.vision.v1.BatchAnnotateImagesResponse;
+import com.google.cloud.vision.v1.Feature;
 import com.google.cloud.vision.v1.Feature.Type;
+import com.google.cloud.vision.v1.Image;
 import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.google.cloud.vision.v1.ImageContext;
+import com.google.protobuf.ByteString;
 import com.google.rpc.Status;
 import io.grpc.Status.Code;
 import org.junit.Before;
@@ -37,6 +42,8 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -55,6 +62,11 @@ public class CloudVisionTemplateTests {
 	// Resource representing a fake image blob
 	private static final Resource FAKE_IMAGE = new ByteArrayResource("fake_image".getBytes());
 
+	private static final BatchAnnotateImagesResponse DEFAULT_API_RESPONSE =
+			BatchAnnotateImagesResponse.newBuilder()
+					.addResponses(AnnotateImageResponse.getDefaultInstance())
+					.build();
+
 	private ImageAnnotatorClient imageAnnotatorClient;
 
 	private CloudVisionTemplate cloudVisionTemplate;
@@ -63,6 +75,49 @@ public class CloudVisionTemplateTests {
 	public void setupVisionTemplateMock() {
 		this.imageAnnotatorClient = Mockito.mock(ImageAnnotatorClient.class);
 		this.cloudVisionTemplate = new CloudVisionTemplate(this.imageAnnotatorClient);
+	}
+
+	@Test
+	public void testAddImageContext_analyzeImage() throws IOException {
+		when(this.imageAnnotatorClient.batchAnnotateImages(any(BatchAnnotateImagesRequest.class)))
+				.thenReturn(DEFAULT_API_RESPONSE);
+
+		ImageContext imageContext = Mockito.mock(ImageContext.class);
+
+		this.cloudVisionTemplate.analyzeImage(FAKE_IMAGE, imageContext, Type.FACE_DETECTION);
+
+		BatchAnnotateImagesRequest expectedRequest =
+				BatchAnnotateImagesRequest.newBuilder()
+						.addRequests(
+								AnnotateImageRequest.newBuilder()
+										.addFeatures(Feature.newBuilder().setType(Type.FACE_DETECTION))
+										.setImageContext(imageContext)
+										.setImage(Image.newBuilder().setContent(
+												ByteString.readFrom(FAKE_IMAGE.getInputStream())).build()))
+						.build();
+
+		verify(this.imageAnnotatorClient, times(1)).batchAnnotateImages(expectedRequest);
+	}
+
+	@Test
+	public void testAddImageContext_extractText() throws IOException {
+		when(this.imageAnnotatorClient.batchAnnotateImages(any(BatchAnnotateImagesRequest.class)))
+				.thenReturn(DEFAULT_API_RESPONSE);
+
+		ImageContext imageContext = Mockito.mock(ImageContext.class);
+
+		this.cloudVisionTemplate.extractTextFromImage(FAKE_IMAGE, imageContext);
+
+		BatchAnnotateImagesRequest expectedRequest =
+				BatchAnnotateImagesRequest.newBuilder()
+						.addRequests(
+								AnnotateImageRequest.newBuilder()
+										.addFeatures(Feature.newBuilder().setType(Type.TEXT_DETECTION))
+										.setImageContext(imageContext)
+										.setImage(Image.newBuilder().setContent(ByteString.readFrom(FAKE_IMAGE.getInputStream())).build()))
+						.build();
+
+		verify(this.imageAnnotatorClient, times(1)).batchAnnotateImages(expectedRequest);
 	}
 
 	@Test


### PR DESCRIPTION
Allows the user to add the ImageContext to their calls in the CloudVisionTemplate. This allows users to customize their API requests to Cloud Vision.

Fixes #2282.

cc/ @santpandey123