### PR TITLE
Update trace docs now that the trace scheduler is hidden

### DIFF
--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -94,7 +94,7 @@ spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)  # Ignore some URL paths.
 spring.sleuth.scheduled.enabled=false                   # disable executor 'async' traces
 ----
 
-WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which may cause recurring traces with the name `async` to appear in Cloud Trace if your application or one of its dependencies introduces scheduler beans into Spring application context. To avoid this noise, please disable automatic instrumentation of executors via `spring.sleuth.scheduled.enabled=false` in your application configuration.
+WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which may cause recurring traces with the name `async` to appear in Stackdriver Trace if your application or one of its dependencies introduces scheduler beans into Spring application context. To avoid this noise, please disable automatic instrumentation of executors via `spring.sleuth.scheduled.enabled=false` in your application configuration.
 
 Spring Cloud GCP Trace does override some Sleuth configurations:
 

--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -3,10 +3,10 @@
 https://cloud.spring.io/spring-cloud-sleuth/[Spring Cloud Sleuth] is an instrumentation framework for Spring Boot applications.
 It captures trace information and can forward traces to services like Zipkin for storage and analysis.
 
-Google Cloud Platform provides its own managed distributed tracing service called https://cloud.google.com/trace/[Stackdriver Trace].
-Instead of running and maintaining your own Zipkin instance and storage, you can use Stackdriver Trace to store traces, view trace details, generate latency distributions graphs, and generate performance regression reports.
+Google Cloud Platform provides its own managed distributed tracing service called https://cloud.google.com/trace/[Cloud Trace].
+Instead of running and maintaining your own Zipkin instance and storage, you can use Cloud Trace to store traces, view trace details, generate latency distributions graphs, and generate performance regression reports.
 
-This Spring Cloud GCP starter can forward Spring Cloud Sleuth traces to Stackdriver Trace without an intermediary Zipkin server.
+This Spring Cloud GCP starter can forward Spring Cloud Sleuth traces to Cloud Trace without an intermediary Zipkin server.
 
 Maven coordinates, using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
 
@@ -27,12 +27,12 @@ dependencies {
 }
 ----
 
-You must enable Stackdriver Trace API from the Google Cloud Console in order to capture traces.
-Navigate to the https://console.cloud.google.com/apis/api/cloudtrace.googleapis.com/overview[Stackdriver Trace API] for your project and make sure it’s enabled.
+You must enable Cloud Trace API from the Google Cloud Console in order to capture traces.
+Navigate to the https://console.cloud.google.com/apis/api/cloudtrace.googleapis.com/overview[Cloud Trace API] for your project and make sure it’s enabled.
 
 [NOTE]
 ====
-If you are already using a Zipkin server capturing trace information from multiple platform/frameworks, you can also use a https://cloud.google.com/trace/docs/zipkin[Stackdriver Zipkin proxy] to forward those traces to Stackdriver Trace without modifying existing applications.
+If you are already using a Zipkin server capturing trace information from multiple platform/frameworks, you can also use a https://cloud.google.com/trace/docs/zipkin[Stackdriver Zipkin proxy] to forward those traces to Cloud Trace without modifying existing applications.
 ====
 
 === Tracing
@@ -52,22 +52,22 @@ The value of the `x-cloud-trace-context` key can be formatted in three different
 `TRACE_ID` is a 32-character hexadecimal value that encodes a 128-bit number.
 
 `SPAN_ID` is an unsigned long.
-Since Stackdriver Trace doesn't support span joins, a new span ID is always generated, regardless of the one specified in `x-cloud-trace-context`.
+Since Cloud Trace doesn't support span joins, a new span ID is always generated, regardless of the one specified in `x-cloud-trace-context`.
 
 `TRACE_TRUE` can either be `0` if the entity should be untraced, or `1` if it should be traced.
 This field forces the decision of whether or not to trace the request; if omitted then the decision is deferred to the sampler.
 
 If a `x-cloud-trace-context` key isn't found, `StackdriverTracePropagation` falls back to tracing with the https://github.com/openzipkin/b3-propagation[X-B3 headers].
 
-=== Spring Boot Starter for Stackdriver Trace
+=== Spring Boot Starter for Cloud Trace
 
-Spring Boot Starter for Stackdriver Trace uses Spring Cloud Sleuth and auto-configures a https://github.com/openzipkin/zipkin-gcp/blob/master/sender-stackdriver/src/main/java/zipkin2/reporter/stackdriver/StackdriverSender.java[StackdriverSender] that sends the Sleuth’s trace information to Stackdriver Trace.
+Spring Boot Starter for Cloud Trace uses Spring Cloud Sleuth and auto-configures a https://github.com/openzipkin/zipkin-gcp/blob/master/sender-stackdriver/src/main/java/zipkin2/reporter/stackdriver/StackdriverSender.java[StackdriverSender] that sends the Sleuth’s trace information to Cloud Trace.
 
 All configurations are optional:
 
 |===
 | Name | Description | Required | Default value
-| `spring.cloud.gcp.trace.enabled` | Auto-configure Spring Cloud Sleuth to send traces to Stackdriver Trace. | No | `true`
+| `spring.cloud.gcp.trace.enabled` | Auto-configure Spring Cloud Sleuth to send traces to Cloud Trace. | No | `true`
 | `spring.cloud.gcp.trace.project-id` | Overrides the project ID from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
 | `spring.cloud.gcp.trace.credentials.location` | Overrides the credentials location from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
 | `spring.cloud.gcp.trace.credentials.encoded-key` | Overrides the credentials encoded key from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
@@ -79,7 +79,7 @@ All configurations are optional:
 | `spring.cloud.gcp.trace.max-inbound-size` | Maximum size for inbound messages | No |
 | `spring.cloud.gcp.trace.max-outbound-size` | Maximum size for outbound messages | No |
 | `spring.cloud.gcp.trace.wait-for-ready` | https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md[Waits for the channel to be ready] in case of a transient failure | No | `false`
-| `spring.cloud.gcp.trace.messageTimeout` | Timeout in seconds before pending spans will be sent in batches to GCP Stackdriver Trace. (previously `spring.zipkin.messageTimeout`) | No | 1
+| `spring.cloud.gcp.trace.messageTimeout` | Timeout in seconds before pending spans will be sent in batches to GCP Cloud Trace. (previously `spring.zipkin.messageTimeout`) | No | 1
 |===
 
 You can use core Spring Cloud Sleuth properties to control Sleuth’s sampling rate, etc.
@@ -89,21 +89,21 @@ For example, when you are testing to see the traces are going through, you can s
 
 [source]
 ----
-spring.sleuth.sampler.probability=1                     # Send 100% of the request traces to Stackdriver.
+spring.sleuth.sampler.probability=1                     # Send 100% of the request traces to Cloud Trace.
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)  # Ignore some URL paths.
 spring.sleuth.scheduled.enabled=false                   # disable executor 'async' traces
 ----
 
-WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which causes many traces with the name `async` to appear in Stackdriver Trace. This is especially a problem because our starter comes with an executor. To avoid this noise, please disable automatic instrumentation of executors via `spring.sleuth.scheduled.enabled=false` in your application configuration.
+WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which may cause recurring traces with the name `async` to appear in Cloud Trace if your application or one of its dependencies introduces scheduler beans into Spring application context.
 
 Spring Cloud GCP Trace does override some Sleuth configurations:
 
 - Always uses 128-bit Trace IDs.
-This is required by Stackdriver Trace.
+This is required by Cloud Trace.
 - Does not use Span joins.
 Span joins will share the span ID between the client and server Spans.
-Stackdriver requires that every Span ID within a Trace to be unique, so Span joins are not supported.
-- Uses `StackdriverHttpClientParser` and `StackdriverHttpServerParser` by default to populate Stackdriver related fields.
+Cloud Trace requires that every Span ID within a Trace to be unique, so Span joins are not supported.
+- Uses `StackdriverHttpClientParser` and `StackdriverHttpServerParser` by default to populate Cloud Trace related fields.
 
 === Overriding the auto-configuration
 
@@ -145,11 +145,11 @@ public class Application implements WebMvcConfigurer {
 }
 ----
 
-You can then search and filter traces based on these additional tags in the Stackdriver Trace service.
+You can then search and filter traces based on these additional tags in the Cloud Trace service.
 
 === Integration with Logging
 
-Integration with Stackdriver Logging is available through the link:logging.adoc[Stackdriver Logging Support].
+Integration with Cloud Logging is available through the link:logging.adoc[Stackdriver Logging Support].
 If the Trace integration is used together with the Logging one, the request logs will be associated to the corresponding traces.
 The trace logs can be viewed by going to the https://console.cloud.google.com/traces/traces[Google Cloud Console Trace List], selecting a trace and pressing the `Logs -> View` link in the `Details` section.
 

--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -3,10 +3,10 @@
 https://cloud.spring.io/spring-cloud-sleuth/[Spring Cloud Sleuth] is an instrumentation framework for Spring Boot applications.
 It captures trace information and can forward traces to services like Zipkin for storage and analysis.
 
-Google Cloud Platform provides its own managed distributed tracing service called https://cloud.google.com/trace/[Cloud Trace].
-Instead of running and maintaining your own Zipkin instance and storage, you can use Cloud Trace to store traces, view trace details, generate latency distributions graphs, and generate performance regression reports.
+Google Cloud Platform provides its own managed distributed tracing service called https://cloud.google.com/trace/[Stackdriver Trace].
+Instead of running and maintaining your own Zipkin instance and storage, you can use Stackdriver Trace to store traces, view trace details, generate latency distributions graphs, and generate performance regression reports.
 
-This Spring Cloud GCP starter can forward Spring Cloud Sleuth traces to Cloud Trace without an intermediary Zipkin server.
+This Spring Cloud GCP starter can forward Spring Cloud Sleuth traces to Stackdriver Trace without an intermediary Zipkin server.
 
 Maven coordinates, using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
 
@@ -27,12 +27,12 @@ dependencies {
 }
 ----
 
-You must enable Cloud Trace API from the Google Cloud Console in order to capture traces.
-Navigate to the https://console.cloud.google.com/apis/api/cloudtrace.googleapis.com/overview[Cloud Trace API] for your project and make sure it’s enabled.
+You must enable Stackdriver Trace API from the Google Cloud Console in order to capture traces.
+Navigate to the https://console.cloud.google.com/apis/api/cloudtrace.googleapis.com/overview[Stackdriver Trace API] for your project and make sure it’s enabled.
 
 [NOTE]
 ====
-If you are already using a Zipkin server capturing trace information from multiple platform/frameworks, you can also use a https://cloud.google.com/trace/docs/zipkin[Stackdriver Zipkin proxy] to forward those traces to Cloud Trace without modifying existing applications.
+If you are already using a Zipkin server capturing trace information from multiple platform/frameworks, you can also use a https://cloud.google.com/trace/docs/zipkin[Stackdriver Zipkin proxy] to forward those traces to Stackdriver Trace without modifying existing applications.
 ====
 
 === Tracing
@@ -52,22 +52,22 @@ The value of the `x-cloud-trace-context` key can be formatted in three different
 `TRACE_ID` is a 32-character hexadecimal value that encodes a 128-bit number.
 
 `SPAN_ID` is an unsigned long.
-Since Cloud Trace doesn't support span joins, a new span ID is always generated, regardless of the one specified in `x-cloud-trace-context`.
+Since Stackdriver Trace doesn't support span joins, a new span ID is always generated, regardless of the one specified in `x-cloud-trace-context`.
 
 `TRACE_TRUE` can either be `0` if the entity should be untraced, or `1` if it should be traced.
 This field forces the decision of whether or not to trace the request; if omitted then the decision is deferred to the sampler.
 
 If a `x-cloud-trace-context` key isn't found, `StackdriverTracePropagation` falls back to tracing with the https://github.com/openzipkin/b3-propagation[X-B3 headers].
 
-=== Spring Boot Starter for Cloud Trace
+=== Spring Boot Starter for Stackdriver Trace
 
-Spring Boot Starter for Cloud Trace uses Spring Cloud Sleuth and auto-configures a https://github.com/openzipkin/zipkin-gcp/blob/master/sender-stackdriver/src/main/java/zipkin2/reporter/stackdriver/StackdriverSender.java[StackdriverSender] that sends the Sleuth’s trace information to Cloud Trace.
+Spring Boot Starter for Stackdriver Trace uses Spring Cloud Sleuth and auto-configures a https://github.com/openzipkin/zipkin-gcp/blob/master/sender-stackdriver/src/main/java/zipkin2/reporter/stackdriver/StackdriverSender.java[StackdriverSender] that sends the Sleuth’s trace information to Stackdriver Trace.
 
 All configurations are optional:
 
 |===
 | Name | Description | Required | Default value
-| `spring.cloud.gcp.trace.enabled` | Auto-configure Spring Cloud Sleuth to send traces to Cloud Trace. | No | `true`
+| `spring.cloud.gcp.trace.enabled` | Auto-configure Spring Cloud Sleuth to send traces to Stackdriver Trace. | No | `true`
 | `spring.cloud.gcp.trace.project-id` | Overrides the project ID from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
 | `spring.cloud.gcp.trace.credentials.location` | Overrides the credentials location from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
 | `spring.cloud.gcp.trace.credentials.encoded-key` | Overrides the credentials encoded key from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
@@ -79,7 +79,7 @@ All configurations are optional:
 | `spring.cloud.gcp.trace.max-inbound-size` | Maximum size for inbound messages | No |
 | `spring.cloud.gcp.trace.max-outbound-size` | Maximum size for outbound messages | No |
 | `spring.cloud.gcp.trace.wait-for-ready` | https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md[Waits for the channel to be ready] in case of a transient failure | No | `false`
-| `spring.cloud.gcp.trace.messageTimeout` | Timeout in seconds before pending spans will be sent in batches to GCP Cloud Trace. (previously `spring.zipkin.messageTimeout`) | No | 1
+| `spring.cloud.gcp.trace.messageTimeout` | Timeout in seconds before pending spans will be sent in batches to GCP Stackdriver Trace. (previously `spring.zipkin.messageTimeout`) | No | 1
 |===
 
 You can use core Spring Cloud Sleuth properties to control Sleuth’s sampling rate, etc.
@@ -89,21 +89,21 @@ For example, when you are testing to see the traces are going through, you can s
 
 [source]
 ----
-spring.sleuth.sampler.probability=1                     # Send 100% of the request traces to Cloud Trace.
+spring.sleuth.sampler.probability=1                     # Send 100% of the request traces to Stackdriver.
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)  # Ignore some URL paths.
 spring.sleuth.scheduled.enabled=false                   # disable executor 'async' traces
 ----
 
-WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which may cause recurring traces with the name `async` to appear in Cloud Trace if your application or one of its dependencies introduces scheduler beans into Spring application context.
+WARNING: By default, Spring Cloud Sleuth auto-configuration instruments executor beans, which may cause recurring traces with the name `async` to appear in Cloud Trace if your application or one of its dependencies introduces scheduler beans into Spring application context. To avoid this noise, please disable automatic instrumentation of executors via `spring.sleuth.scheduled.enabled=false` in your application configuration.
 
 Spring Cloud GCP Trace does override some Sleuth configurations:
 
 - Always uses 128-bit Trace IDs.
-This is required by Cloud Trace.
+This is required by Stackdriver Trace.
 - Does not use Span joins.
 Span joins will share the span ID between the client and server Spans.
-Cloud Trace requires that every Span ID within a Trace to be unique, so Span joins are not supported.
-- Uses `StackdriverHttpClientParser` and `StackdriverHttpServerParser` by default to populate Cloud Trace related fields.
+Stackdriver requires that every Span ID within a Trace to be unique, so Span joins are not supported.
+- Uses `StackdriverHttpClientParser` and `StackdriverHttpServerParser` by default to populate Stackdriver related fields.
 
 === Overriding the auto-configuration
 
@@ -145,11 +145,11 @@ public class Application implements WebMvcConfigurer {
 }
 ----
 
-You can then search and filter traces based on these additional tags in the Cloud Trace service.
+You can then search and filter traces based on these additional tags in the Stackdriver Trace service.
 
 === Integration with Logging
 
-Integration with Cloud Logging is available through the link:logging.adoc[Stackdriver Logging Support].
+Integration with Stackdriver Logging is available through the link:logging.adoc[Stackdriver Logging Support].
 If the Trace integration is used together with the Logging one, the request logs will be associated to the corresponding traces.
 The trace logs can be viewed by going to the https://console.cloud.google.com/traces/traces[Google Cloud Console Trace List], selecting a trace and pressing the `Logs -> View` link in the `Details` section.
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/resources/application.properties
@@ -3,6 +3,3 @@ spring.sleuth.sampler.probability=1.0
 
 # To ignore some frequently used URL patterns that are not useful in trace
 spring.sleuth.web.skipPattern=(^cleanup.*|.+favicon.*)
-
-# disable instrumentation of executors to avoid the 'async' traces noise
-spring.sleuth.scheduled.enabled=false


### PR DESCRIPTION
This is a leftover documentation task from #2016. After the trace scheduler bean was removed in #2158, this PR removes the following wording: " This is especially a problem because our starter comes with an executor. To avoid this noise, please disable automatic instrumentation of executors via `spring.sleuth.scheduled.enabled=false` in your application configuration."

I left the overall warning in place, though, because this will still be a problem when combined with any other starters (for example, our Pub/Sub starter) that add scheduler beans to context.

I also updated the branding from Stackdriver to Cloud Trace where possible (per [rebranding announcement](https://cloud.google.com/blog/products/management-tools/cloud-operations-grows-with-monitoring-logging-more)). The code stays prefixed with Stackdriver.

Closes #2016.
