### PR TITLE
Secret manager autoconfigure projectId selection

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -101,6 +101,7 @@ public class GcpSecretManagerBootstrapConfiguration {
 		SecretManagerPropertySourceLocator propertySourceLocator = new SecretManagerPropertySourceLocator(
 				client, this.gcpProjectIdProvider, this.properties.getSecretNamePrefix());
 		propertySourceLocator.setVersions(this.properties.getVersions());
+		propertySourceLocator.setProjectIds(this.properties.getProjectIds());
 		return propertySourceLocator;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerProperties.java
@@ -40,8 +40,8 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 	private String projectId;
 
 	/**
-	 * Defines a prefix String that will be prepended to the environment property names
-	 * of secrets in Secret Manager.
+	 * Defines a prefix String that will be prepended to the environment property names of
+	 * secrets in Secret Manager.
 	 */
 	private String secretNamePrefix = "";
 
@@ -49,6 +49,11 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 	 * Defines versions for specific secret-ids.
 	 */
 	private Map<String, String> versions = new HashMap<>();
+
+	/**
+	 * Defines projectIds for specific secret-ids.
+	 */
+	private Map<String, String> projectIds = new HashMap<>();
 
 	public Credentials getCredentials() {
 		return credentials;
@@ -72,6 +77,10 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 
 	public Map<String, String> getVersions() {
 		return versions;
+	}
+
+	public Map<String, String> getProjectIds() {
+		return projectIds;
 	}
 
 	public void setVersions(Map<String, String> versions) {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySource.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySource.java
@@ -55,7 +55,8 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
 			SecretManagerServiceClient client,
 			GcpProjectIdProvider projectIdProvider,
 			String secretsPrefix) {
-		this(propertySourceName, client, projectIdProvider, secretsPrefix, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+		this(propertySourceName, client, projectIdProvider, secretsPrefix, Collections.EMPTY_MAP,
+				Collections.EMPTY_MAP);
 	}
 
 	public SecretManagerPropertySource(
@@ -68,7 +69,7 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
 		super(propertySourceName, client);
 
 		Map<String, Object> propertiesMap = createSecretsPropertiesMap(
-				client, projectIdProvider.getProjectId(), secretsPrefix, versions,projectIds);
+				client, projectIdProvider.getProjectId(), secretsPrefix, versions, projectIds);
 
 		this.properties = propertiesMap;
 		this.propertyNames = propertiesMap.keySet().toArray(new String[propertiesMap.size()]);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySourceLocator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerPropertySourceLocator.java
@@ -45,6 +45,8 @@ public class SecretManagerPropertySourceLocator implements PropertySourceLocator
 
 	private Map<String, String> versions;
 
+	private Map<String, String> projectIds;
+
 	SecretManagerPropertySourceLocator(
 			SecretManagerServiceClient client,
 			GcpProjectIdProvider projectIdProvider,
@@ -58,6 +60,10 @@ public class SecretManagerPropertySourceLocator implements PropertySourceLocator
 		this.versions = versions;
 	}
 
+	public void setProjectIds(Map<String, String> projectIds) {
+		this.projectIds = projectIds;
+	}
+
 	@Override
 	public PropertySource<?> locate(Environment environment) {
 		return new SecretManagerPropertySource(
@@ -65,6 +71,7 @@ public class SecretManagerPropertySourceLocator implements PropertySourceLocator
 				this.client,
 				this.projectIdProvider,
 				this.secretsPrefix,
-				this.versions);
+				this.versions,
+				this.projectIds);
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/it/SecretManagerIntegrationTests.java
@@ -19,8 +19,15 @@ package org.springframework.cloud.gcp.autoconfigure.secretmanager.it;
 import java.util.stream.StreamSupport;
 
 import com.google.api.gax.rpc.NotFoundException;
-import com.google.cloud.secretmanager.v1beta1.*;
+import com.google.cloud.secretmanager.v1beta1.ProjectName;
+import com.google.cloud.secretmanager.v1beta1.Replication;
+import com.google.cloud.secretmanager.v1beta1.Secret;
+import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1beta1.CreateSecretRequest;
+import com.google.cloud.secretmanager.v1beta1.AddSecretVersionRequest;
 import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient.ListSecretsPagedResponse;
+import com.google.cloud.secretmanager.v1beta1.SecretName;
+import com.google.cloud.secretmanager.v1beta1.SecretPayload;
 import com.google.protobuf.ByteString;
 import io.grpc.StatusRuntimeException;
 import org.junit.Before;
@@ -71,11 +78,12 @@ public class SecretManagerIntegrationTests {
 		deleteSecret(TEST_SECRET_ID);
 		deleteSecret(VERSIONED_SECRET_ID);
 
-		// The custom project is the same one as the default project. Integration test not relevant.
+		// The custom project is the same one as the default project. Integration test not
+		// relevant.
 		// TODO Which other project to use?
 		String customProject = projectIdProvider.getProjectId();
-		deleteSecret(TEST_SECRET_ID,customProject);
-		deleteSecret(VERSIONED_SECRET_ID,customProject);
+		deleteSecret(TEST_SECRET_ID, customProject);
+		deleteSecret(VERSIONED_SECRET_ID, customProject);
 
 	}
 
@@ -130,7 +138,8 @@ public class SecretManagerIntegrationTests {
 	public void testSecretsWithSpecificProjectId() {
 		createSecret(TEST_SECRET_ID, "the secret data", projectIdProvider.getProjectId());
 
-		// The custom project is the same one as the default project. Integration test not relevant.
+		// The custom project is the same one as the default project. Integration test not
+		// relevant.
 		// TODO Which other project to use?
 		String customProject = projectIdProvider.getProjectId();
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
@@ -154,7 +163,8 @@ public class SecretManagerIntegrationTests {
 		createSecret(VERSIONED_SECRET_ID, "the secret data", projectIdProvider.getProjectId());
 		createSecret(VERSIONED_SECRET_ID, "the secret data v2", projectIdProvider.getProjectId());
 
-		// The custom project is the same one as the default project. Integration test not relevant.
+		// The custom project is the same one as the default project. Integration test not
+		// relevant.
 		// TODO Which other project to use?
 		String customProject = projectIdProvider.getProjectId();
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
@@ -1,7 +1,9 @@
 # Set this setting to true if you want to load your GCP secrets as a
 # property source for your application.
 spring.cloud.gcp.secretmanager.bootstrap.enabled=true
-
 # This optional setting adds a prefix to your secret property names that get
 # injected into the application Environment.
 spring.cloud.gcp.secretmanager.secret-name-prefix=secrets.
+# You can specify the project of your secret like this example
+# Pattern: spring.cloud.gcp.secretmanager.projectIds.<secretId>=<projectId>
+#spring.cloud.gcp.secretmanager.projectIds.application-secret=PROJECT_ID


### PR DESCRIPTION
Bootstrap part for using custom project when define a secret into the bootstrap file or into the @Value decorator.

TODOs to solve on integration tests: Need an additional project for performing tests of creation and access to the secrets because, currently, the tests are performed in the current default project. Not relevant.