### PR TITLE
Upgrade spring-cloud-config dependency

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
@@ -14,6 +14,31 @@
     <packaging>pom</packaging>
     <name>Spring Cloud GCP Pub/Sub Bus Configuration Management Code Sample</name>
 
+    <properties>
+        <spring-cloud-config.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-config.version>
+    </properties>
+
+    <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-config-dependencies</artifactId>
+                <version>${spring-cloud-config.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>spring-cloud-gcp-pubsub-bus-config-sample-client</module>
         <module>spring-cloud-gcp-pubsub-bus-config-sample-server-local</module>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/pom.xml
@@ -13,31 +13,6 @@
   <artifactId>spring-cloud-gcp-pubsub-bus-config-sample-client</artifactId>
   <name>Spring Cloud GCP Pub/Sub Bus Sample (Client)</name>
 
-  <properties>
-    <spring-cloud-config.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-config.version>
-  </properties>
-
-  <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-config-dependencies</artifactId>
-        <version>${spring-cloud-config.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-github/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-github/pom.xml
@@ -13,31 +13,6 @@
   <artifactId>spring-cloud-gcp-pubsub-bus-config-sample-server-github</artifactId>
   <name>Spring Cloud GCP Pub/Sub Bus Sample (GitHub Configuration)</name>
 
-  <properties>
-    <spring-cloud-config.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-config.version>
-  </properties>
-
-  <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-config-dependencies</artifactId>
-        <version>${spring-cloud-config.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-local/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-local/pom.xml
@@ -13,31 +13,6 @@
   <artifactId>spring-cloud-gcp-pubsub-bus-config-sample-server-local</artifactId>
   <name>Spring Cloud GCP Pub/Sub Bus Sample (Local Configuration)</name>
 
-  <properties>
-    <spring-cloud-config.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-config.version>
-  </properties>
-
-  <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-config-dependencies</artifactId>
-        <version>${spring-cloud-config.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/pom.xml
@@ -12,31 +12,6 @@
 
   <artifactId>spring-cloud-gcp-pubsub-bus-config-sample-test</artifactId>
 
-  <properties>
-    <spring-cloud-config.version>2.2.1.BUILD-SNAPSHOT</spring-cloud-config.version>
-  </properties>
-
-  <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-config-dependencies</artifactId>
-        <version>${spring-cloud-config.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/src/test/java/com/example/LocalSampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/src/test/java/com/example/LocalSampleAppIntegrationTest.java
@@ -186,7 +186,6 @@ public class LocalSampleAppIntegrationTest {
 				// drain all lines up to the one requested, or until no more lines in reader.
 				while (reader.ready()) {
 					String line = reader.readLine();
-
 					if (line == null) {
 						return false;
 					}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/src/test/java/com/example/LocalSampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/src/test/java/com/example/LocalSampleAppIntegrationTest.java
@@ -186,6 +186,7 @@ public class LocalSampleAppIntegrationTest {
 				// drain all lines up to the one requested, or until no more lines in reader.
 				while (reader.ready()) {
 					String line = reader.readLine();
+
 					if (line == null) {
 						return false;
 					}


### PR DESCRIPTION
* Upgrades spring-cloud-config dependency to the latest.
* Moves all version management to the sample parent.

This should fix the build. It was not a spring-cloud-commons problem -- instead it was an old-version-in-sample problem. 