### PR TITLE
Clarify Secret Manager sample property class

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -49,7 +49,7 @@ public class SecretManagerWebController {
 	@Value("${my-application-secret}")
 	private String myApplicationSecretValue;
 
-	// Another way to access these properties is to @Autowire a @ConfigurationProperties-annotated class
+	// Another way to access your secrets is to @Autowire a @ConfigurationProperties-annotated class.
 	@Autowired
 	private MyAppProperties properties;
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -37,9 +37,6 @@ public class SecretManagerWebController {
 	private Environment environment;
 
 	@Autowired
-	private MyAppProperties properties;
-
-	@Autowired
 	private SecretManagerTemplate secretManagerTemplate;
 
 	// Application secrets can be accessed using @Value and passing in the secret name.
@@ -51,6 +48,12 @@ public class SecretManagerWebController {
 	// Application secret is set into the properties file and get here using @Value
 	@Value("${my-application-secret}")
 	private String myApplicationSecretValue;
+
+	// Another way to access these properties is to @Autowire a Properties class in which the fields
+	// of the properties are injected with @Value annotations.
+	@Autowired
+	private MyAppProperties properties;
+
 
 	@GetMapping("/")
 	public ModelAndView renderIndex(ModelMap map) {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -49,8 +49,7 @@ public class SecretManagerWebController {
 	@Value("${my-application-secret}")
 	private String myApplicationSecretValue;
 
-	// Another way to access these properties is to @Autowire a Properties class in which the fields
-	// of the properties are injected with @Value annotations.
+	// Another way to access these properties is to @Autowire a @ConfigurationProperties-annotated class
 	@Autowired
 	private MyAppProperties properties;
 


### PR DESCRIPTION
Add a comment to clarify the `@Autowiring` of the `MyAppProperties` in the Secret Manager sample.

Fixes #2299.