### PR TITLE
Cleanup Secret Manager module organization

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
@@ -47,9 +47,8 @@ public class SecretManagerBootstrapConfigurationTests {
 	private static final String PROJECT_NAME = "hollow-light-of-the-sealed-land";
 
 	private SpringApplicationBuilder applicationBuilder =
-			new SpringApplicationBuilder(TestBootstrapConfiguration.class)
-					.child(GcpSecretManagerBootstrapConfiguration.class)
-					.child(TestConfiguration.class)
+			new SpringApplicationBuilder(
+					TestBootstrapConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
 					.properties("spring.cloud.gcp.secretmanager.project-id=" + PROJECT_NAME)
 					.web(WebApplicationType.NONE);
 
@@ -58,6 +57,15 @@ public class SecretManagerBootstrapConfigurationTests {
 		try (ConfigurableApplicationContext c = applicationBuilder.run()) {
 			String secret = c.getEnvironment().getProperty("sm://my-secret");
 			assertThat(secret).isEqualTo("hello");
+		}
+	}
+
+	@Test
+	public void testGetProperty_otherProject() {
+		try (ConfigurableApplicationContext c = applicationBuilder.run()) {
+			String secret = c.getEnvironment().getProperty(
+					"sm://projects/other-project/secrets/other-secret/versions/3");
+			assertThat(secret).isEqualTo("goodbye");
 		}
 	}
 
@@ -72,8 +80,23 @@ public class SecretManagerBootstrapConfigurationTests {
 		}
 	}
 
+	@Test
+	public void configurationDisabled() {
+		SpringApplicationBuilder disabledConfigurationApp =
+				new SpringApplicationBuilder(
+						TestBootstrapConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
+						.properties("spring.cloud.gcp.secretmanager.project-id=" + PROJECT_NAME)
+						.properties("spring.cloud.gcp.secretmanager.enabled=false")
+						.web(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext c = disabledConfigurationApp.run()) {
+			String secret = c.getEnvironment().getProperty("sm://my-secret");
+			assertThat(secret).isEqualTo(null);
+		}
+	}
+
 	@Configuration
-	static class TestConfiguration {
+	static class TestBootstrapConfiguration {
 
 		@Value("${sm://my-secret}")
 		private String secret;
@@ -90,23 +113,34 @@ public class SecretManagerBootstrapConfigurationTests {
 		public String fullyQualifiedSecret() {
 			return secret;
 		}
-	}
-
-	@Configuration
-	static class TestBootstrapConfiguration {
 
 		@Bean
 		public static SecretManagerServiceClient secretManagerClient() {
 			SecretManagerServiceClient client = mock(SecretManagerServiceClient.class);
+
 			SecretVersionName secretVersionName =
 					SecretVersionName.newBuilder()
 							.setProject(PROJECT_NAME)
 							.setSecret("my-secret")
 							.setSecretVersion("latest")
 							.build();
+
 			when(client.accessSecretVersion(secretVersionName)).thenReturn(
 					AccessSecretVersionResponse.newBuilder()
 							.setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("hello")))
+							.build());
+
+			secretVersionName =
+					SecretVersionName.newBuilder()
+							.setProject("other-project")
+							.setSecret("other-secret")
+							.setSecretVersion("3")
+							.build();
+
+			when(client.accessSecretVersion(secretVersionName)).thenReturn(
+					AccessSecretVersionResponse.newBuilder()
+							.setPayload(
+									SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("goodbye")))
 							.build());
 
 			return client;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
@@ -61,6 +61,15 @@ public class SecretManagerBootstrapConfigurationTests {
 	}
 
 	@Test
+	public void testGetProperty_otherVersion() {
+		try (ConfigurableApplicationContext c = applicationBuilder.run()) {
+			String secret = c.getEnvironment().getProperty(
+					"sm://my-secret/1");
+			assertThat(secret).isEqualTo("hello v1");
+		}
+	}
+
+	@Test
 	public void testGetProperty_otherProject() {
 		try (ConfigurableApplicationContext c = applicationBuilder.run()) {
 			String secret = c.getEnvironment().getProperty(
@@ -128,6 +137,18 @@ public class SecretManagerBootstrapConfigurationTests {
 			when(client.accessSecretVersion(secretVersionName)).thenReturn(
 					AccessSecretVersionResponse.newBuilder()
 							.setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("hello")))
+							.build());
+
+			secretVersionName =
+					SecretVersionName.newBuilder()
+							.setProject(PROJECT_NAME)
+							.setSecret("my-secret")
+							.setSecretVersion("1")
+							.build();
+
+			when(client.accessSecretVersion(secretVersionName)).thenReturn(
+					AccessSecretVersionResponse.newBuilder()
+							.setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("hello v1")))
 							.build());
 
 			secretVersionName =

--- a/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerPropertyUtils.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerPropertyUtils.java
@@ -20,7 +20,6 @@ import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
 
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * Utilities for parsing Secret Manager properties.
@@ -81,17 +80,14 @@ final class SecretManagerPropertyUtils {
 					"Unrecognized format for specifying a GCP Secret Manager secret: " + input);
 		}
 
-		Assert.isTrue(
-				!StringUtils.isEmpty(secretId),
-				"The GCP Secret Manager secret id must not be empty: " + input);
+		Assert.hasText(
+				secretId, "The GCP Secret Manager secret id must not be empty: " + input);
 
-		Assert.isTrue(
-				!StringUtils.isEmpty(projectId),
-				"The GCP Secret Manager project id must not be empty: " + input);
+		Assert.hasText(
+				projectId, "The GCP Secret Manager project id must not be empty: " + input);
 
-		Assert.isTrue(
-				!StringUtils.isEmpty(version),
-				"The GCP Secret Manager secret version must not be empty: " + input);
+		Assert.hasText(
+				version, "The GCP Secret Manager secret version must not be empty: " + input);
 
 		return SecretVersionName.newBuilder()
 				.setProject(projectId)

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerIntegrationTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.gcp.autoconfigure.secretmanager.it;
+package org.springframework.cloud.gcp.secretmanager.it;
 
 import java.util.concurrent.TimeUnit;
 
@@ -39,8 +39,6 @@ import org.junit.Test;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
-import org.springframework.cloud.gcp.autoconfigure.secretmanager.GcpSecretManagerBootstrapConfiguration;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -72,7 +70,7 @@ public class SecretManagerIntegrationTests {
 	@Before
 	public void setupSecretManager() {
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
+				.child(SecretManagerTestConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.run();
 
@@ -89,7 +87,7 @@ public class SecretManagerIntegrationTests {
 		createSecret(TEST_SECRET_ID, "the secret data.");
 
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
+				.child(SecretManagerTestConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.run();
 
@@ -102,27 +100,13 @@ public class SecretManagerIntegrationTests {
 	}
 
 	@Test
-	public void testConfigurationDisabled() {
-		createSecret(TEST_SECRET_ID, "the secret data.");
-
-		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
-				.web(WebApplicationType.NONE)
-				.properties("spring.cloud.gcp.secretmanager.enabled=false")
-				.run();
-
-		assertThat(context.getEnvironment().getProperty(
-				"sm://" + TEST_SECRET_ID, String.class)).isNull();
-	}
-
-	@Test
 	public void testSecretsWithSpecificVersion() {
 		createSecret(VERSIONED_SECRET_ID, "the secret data");
 		createSecret(VERSIONED_SECRET_ID, "the secret data v2");
 		createSecret(VERSIONED_SECRET_ID, "the secret data v3");
 
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
+				.sources(SecretManagerTestConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.run();
 
@@ -136,7 +120,7 @@ public class SecretManagerIntegrationTests {
 		createSecret(VERSIONED_SECRET_ID, "the secret data");
 
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(GcpContextAutoConfiguration.class, GcpSecretManagerBootstrapConfiguration.class)
+				.sources(SecretManagerTestConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.run();
 

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
@@ -70,7 +70,7 @@ public class SecretManagerPropertySourceIntegrationTests {
 	@Before
 	public void setupSecretManager() {
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.child(SecretManagerTestConfiguration.class)
+				.sources(SecretManagerTestConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.run();
 
@@ -87,7 +87,7 @@ public class SecretManagerPropertySourceIntegrationTests {
 		createSecret(TEST_SECRET_ID, "the secret data.");
 
 		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.child(SecretManagerTestConfiguration.class)
+				.sources(SecretManagerTestConfiguration.class)
 				.web(WebApplicationType.NONE)
 				.run();
 

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
@@ -47,9 +47,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 
-public class SecretManagerIntegrationTests {
+public class SecretManagerPropertySourceIntegrationTests {
 
-	private static final Log LOGGER = LogFactory.getLog(SecretManagerIntegrationTests.class);
+	private static final Log LOGGER = LogFactory.getLog(SecretManagerPropertySourceIntegrationTests.class);
 
 	private static final String TEST_SECRET_ID = "spring-cloud-gcp-it-secret";
 

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
@@ -16,48 +16,33 @@
 
 package org.springframework.cloud.gcp.secretmanager.it;
 
-import java.util.concurrent.TimeUnit;
-
-import com.google.api.gax.rpc.NotFoundException;
-import com.google.cloud.secretmanager.v1beta1.AddSecretVersionRequest;
-import com.google.cloud.secretmanager.v1beta1.CreateSecretRequest;
-import com.google.cloud.secretmanager.v1beta1.ProjectName;
-import com.google.cloud.secretmanager.v1beta1.Replication;
-import com.google.cloud.secretmanager.v1beta1.Secret;
-import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
-import com.google.cloud.secretmanager.v1beta1.SecretName;
-import com.google.cloud.secretmanager.v1beta1.SecretPayload;
-import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
-import com.google.protobuf.ByteString;
 import io.grpc.StatusRuntimeException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.awaitility.Duration;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
+import org.springframework.cloud.gcp.secretmanager.SecretManagerTemplate;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.awaitility.Awaitility.await;
 
 public class SecretManagerPropertySourceIntegrationTests {
 
-	private static final Log LOGGER = LogFactory.getLog(SecretManagerPropertySourceIntegrationTests.class);
+	private ConfigurableApplicationContext context =
+			new SpringApplicationBuilder(TestConfiguration.class, SecretManagerTestConfiguration.class)
+					.web(WebApplicationType.NONE)
+					.run();
 
 	private static final String TEST_SECRET_ID = "spring-cloud-gcp-it-secret";
 
-	private static final String VERSIONED_SECRET_ID = "spring-cloud-gcp-it-versioned-secret";
-
-	private GcpProjectIdProvider projectIdProvider;
-
-	private SecretManagerServiceClient client;
+	private SecretManagerTemplate template;
 
 	@BeforeClass
 	public static void prepare() {
@@ -69,28 +54,14 @@ public class SecretManagerPropertySourceIntegrationTests {
 
 	@Before
 	public void setupSecretManager() {
-		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(SecretManagerTestConfiguration.class)
-				.web(WebApplicationType.NONE)
-				.run();
-
-		this.projectIdProvider = context.getBeanFactory().getBean(GcpProjectIdProvider.class);
-		this.client = context.getBeanFactory().getBean(SecretManagerServiceClient.class);
-
-		// Clean up the test secrets in the project from prior runs.
-		deleteSecret(TEST_SECRET_ID);
-		deleteSecret(VERSIONED_SECRET_ID);
+		this.template = context.getBeanFactory().getBean(SecretManagerTemplate.class);
+		if (!template.secretExists(TEST_SECRET_ID)) {
+			template.createSecret(TEST_SECRET_ID, "the secret data.");
+		}
 	}
 
 	@Test
 	public void testConfiguration() {
-		createSecret(TEST_SECRET_ID, "the secret data.");
-
-		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(SecretManagerTestConfiguration.class)
-				.web(WebApplicationType.NONE)
-				.run();
-
 		assertThat(context.getEnvironment().getProperty("sm://" + TEST_SECRET_ID))
 				.isEqualTo("the secret data.");
 
@@ -100,101 +71,28 @@ public class SecretManagerPropertySourceIntegrationTests {
 	}
 
 	@Test
-	public void testSecretsWithSpecificVersion() {
-		createSecret(VERSIONED_SECRET_ID, "the secret data");
-		createSecret(VERSIONED_SECRET_ID, "the secret data v2");
-		createSecret(VERSIONED_SECRET_ID, "the secret data v3");
-
-		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(SecretManagerTestConfiguration.class)
-				.web(WebApplicationType.NONE)
-				.run();
-
-		String versionedSecret = context.getEnvironment().getProperty(
-				"sm://" + VERSIONED_SECRET_ID + "/2", String.class);
-		assertThat(versionedSecret).isEqualTo("the secret data v2");
+	public void testValueAnnotation() {
+		String secret = context.getBean("secret", String.class);
+		assertThat(secret).isEqualTo("the secret data.");
 	}
 
 	@Test
 	public void testMissingSecret() {
-		createSecret(VERSIONED_SECRET_ID, "the secret data");
-
-		ConfigurableApplicationContext context = new SpringApplicationBuilder()
-				.sources(SecretManagerTestConfiguration.class)
-				.web(WebApplicationType.NONE)
-				.run();
-
 		assertThatThrownBy(() ->
-				context.getEnvironment().getProperty("sm://" + VERSIONED_SECRET_ID + "/2", String.class))
+				context.getEnvironment().getProperty("sm://missing-secret/10", String.class))
 				.hasCauseInstanceOf(StatusRuntimeException.class)
 				.hasMessageContaining("NOT_FOUND");
 	}
-	/**
-	 * Creates the secret with the specified payload if the secret does not already exist.
-	 * Otherwise creates a new version of the secret under the existing {@code secretId}.
-	 */
-	private void createSecret(String secretId, String payload) {
-		ProjectName projectName = ProjectName.of(projectIdProvider.getProjectId());
 
-		if (!secretExists(secretId)) {
-			// Creates the secret.
-			Secret secret = Secret.newBuilder()
-					.setReplication(
-							Replication.newBuilder()
-									.setAutomatic(Replication.Automatic.newBuilder().build())
-									.build())
-					.build();
-			CreateSecretRequest request = CreateSecretRequest.newBuilder()
-					.setParent(projectName.toString())
-					.setSecretId(secretId)
-					.setSecret(secret)
-					.build();
-			client.createSecret(request);
-		}
+	@Configuration
+	static class TestConfiguration {
 
-		createSecretPayload(secretId, payload);
-	}
+		@Value("${sm://" + TEST_SECRET_ID + "}")
+		private String secret;
 
-	private void createSecretPayload(String secretId, String data) {
-		// Create the secret payload.
-		SecretName name = SecretName.of(projectIdProvider.getProjectId(), secretId);
-		SecretPayload payloadObject = SecretPayload.newBuilder()
-				.setData(ByteString.copyFromUtf8(data))
-				.build();
-		AddSecretVersionRequest payloadRequest = AddSecretVersionRequest.newBuilder()
-				.setParent(name.toString())
-				.setPayload(payloadObject)
-				.build();
-		client.addSecretVersion(payloadRequest);
-	}
-
-	private boolean secretExists(String secretId) {
-		try {
-			SecretVersionName secretVersionName =
-					SecretVersionName.newBuilder()
-							.setProject(projectIdProvider.getProjectId())
-							.setSecret(secretId)
-							.setSecretVersion("latest")
-							.build();
-			this.client.accessSecretVersion(secretVersionName);
-		}
-		catch (NotFoundException e) {
-			return false;
-		}
-
-		return true;
-	}
-
-	private void deleteSecret(String secretId) {
-		try {
-			this.client.deleteSecret(SecretName.of(this.projectIdProvider.getProjectId(), secretId));
-
-			// Wait for the secret to be successfully removed from the project in the backend.
-			await().pollInterval(Duration.ONE_SECOND)
-					.atMost(20, TimeUnit.SECONDS).until(() -> !secretExists(secretId));
-		}
-		catch (NotFoundException e) {
-			LOGGER.debug("Skipped deleting " + secretId + " because it does not exist.");
+		@Bean
+		public String secret() {
+			return secret;
 		}
 	}
 }

--- a/spring-cloud-gcp-secretmanager/src/test/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-secretmanager/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+org.springframework.cloud.gcp.secretmanager.it.SecretManagerTestConfiguration


### PR DESCRIPTION
Some cleanup for secret manager module.

* Move property source integration test from autoconfigure/ to secret-manager/
* Change to using `Assert.hasText(...)`