### PR TITLE
Secret Manager Integration Test Bug Fix

### DIFF
--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 public class SecretManagerPropertySourceIntegrationTests {
 
 	private ConfigurableApplicationContext context =
-			new SpringApplicationBuilder(TestConfiguration.class, SecretManagerTestConfiguration.class)
+			new SpringApplicationBuilder(TestConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.run();
 

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.gcp.secretmanager.it;
 
 import io.grpc.StatusRuntimeException;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
@@ -48,7 +48,7 @@ public class SecretManagerPropertySourceIntegrationTests {
 						+ "Please use '-Dit.secretmanager=true' to enable them.")
 				.isEqualTo("true");
 
-    // Create the test secret if it does not already currently exist.
+		// Create the test secret if it does not already currently exist.
 		ConfigurableApplicationContext setupContext =
 				new SpringApplicationBuilder(SecretManagerTestConfiguration.class)
 						.web(WebApplicationType.NONE)

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
@@ -42,19 +42,21 @@ public class SecretManagerPropertySourceIntegrationTests {
 
 	private static final String TEST_SECRET_ID = "spring-cloud-gcp-it-secret";
 
-	private SecretManagerTemplate template;
-
 	@BeforeClass
 	public static void prepare() {
 		assumeThat(System.getProperty("it.secretmanager"))
 				.as("Secret manager integration tests are disabled. "
 						+ "Please use '-Dit.secretmanager=true' to enable them.")
 				.isEqualTo("true");
-	}
 
-	@Before
-	public void setupSecretManager() {
-		this.template = context.getBeanFactory().getBean(SecretManagerTemplate.class);
+    // Create the test secret if it does not already currently exist.
+		ConfigurableApplicationContext setupContext =
+				new SpringApplicationBuilder(SecretManagerTestConfiguration.class)
+						.web(WebApplicationType.NONE)
+						.run();
+
+		SecretManagerTemplate template =
+				setupContext.getBeanFactory().getBean(SecretManagerTemplate.class);
 		if (!template.secretExists(TEST_SECRET_ID)) {
 			template.createSecret(TEST_SECRET_ID, "the secret data.");
 		}


### PR DESCRIPTION
There was a bug in the secret manager integration test where I need to split up the configuration objects in the test's context object.

Basically the `TestConfiguration` class looks for the secret and the `SecretManagerTestConfiguration` is what provides the template to create the secret if it doesn't exist. Realized I have to separate them otherwise it will try to resolve the secret before I get a chance to create it in the `setup()`.