### PR TITLE
Turn hardcoded checkstyle versions into properties

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -63,7 +63,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-checkstyle-plugin</artifactId>
-						<version>3.0.0</version>
 						<dependencies>
 							<dependency>
 								<groupId>com.puppycrawl.tools</groupId>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -21,6 +21,8 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 		<spring-cloud-build-tools.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-build-tools.version>
+		<puppycrawl-tools-checkstyle.version>8.18</puppycrawl-tools-checkstyle.version>
+		<maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
 	</properties>
 
 	<modules>
@@ -63,11 +65,12 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-checkstyle-plugin</artifactId>
+						<version>${maven-checkstyle-plugin.version}</version>
 						<dependencies>
 							<dependency>
 								<groupId>com.puppycrawl.tools</groupId>
 								<artifactId>checkstyle</artifactId>
-								<version>8.18</version>
+								<version>${puppycrawl-tools-checkstyle.version}</version>
 							</dependency>
 							<dependency>
 								<groupId>io.spring.javaformat</groupId>


### PR DESCRIPTION
Most of spring-cloud-gcp inherits checkstyle rules and maven plugin versions from `spring-cloud-build`, which defines them as variables `maven-checkstyle-plugin.version` and `puppycrawl-tools-checkstyle.version`. This enables checkstyle's CI to override our plugin/rules version with the latest to test for regressions prior to releasing (see checkstyle/checkstyle#8106 for additional context).

The samples directory is different -- we inherit from Spring Boot starter parent instead, and there is a hardcoded version of the checkstyle plugin.

This PR:
* removes the hardcoding
* introduces variables to control the samples' checkstyle versions, identical to the main project
* sets variable default to be the same as in `spring-cloud-build` version we are on right now