### PR TITLE
Return fake zero to avoid tripping nullability checks

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/ParallelSpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/ParallelSpannerRepositoryIntegrationTests.java
@@ -66,7 +66,7 @@ public class ParallelSpannerRepositoryIntegrationTests extends AbstractSpannerIn
 				assertThat(repo.count()).isZero();
 			});
 			assertThat(repo.count()).isZero();
-			return null;
+			return 0;
 		});
 
 		executeInParallel(unused -> assertThat(this.tradeRepository.countByAction("BUY")).isEqualTo(PARALLEL_OPERATIONS));


### PR DESCRIPTION
Should fix the build.

```
[ERROR] testParallelOperations  Time elapsed: 0.243 s  <<< ERROR!
org.springframework.dao.EmptyResultDataAccessException: Result must not be null!
	at org.springframework.cloud.gcp.data.spanner.repository.it.ParallelSpannerRepositoryIntegrationTests.testParallelOperations(ParallelSpannerRepositoryIntegrationTests.java:59)
```

The other way this could get fixed is to override the `performReadOnlyTransaction` in the test repository and explicitly mark it nullable.