### PR TITLE
Override to latest checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
 		<spring-javaformat-checkstyle.version>0.0.21</spring-javaformat-checkstyle.version>
 		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
 		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
 	</properties>
 
 	<dependencyManagement>
@@ -188,6 +189,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
+				<dependencies>
+					<dependency>
+						<groupId>org.springframework.cloud</groupId>
+						<artifactId>spring-cloud-build-tools</artifactId>
+						<version>${spring-cloud-build-tools.version}</version>
+					</dependency>
+				</dependencies>
 				<executions>
 					<execution>
 						<id>checkstyle-validation</id>

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,13 @@
 		<zipkin-gcp.version>0.16.0</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
+		<spring-javaformat-checkstyle.version>0.0.21</spring-javaformat-checkstyle.version>
+		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
+		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
 	</properties>
 
 	<dependencyManagement>
+
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
`spring-cloud-build` upgraded on `master`, but can't upgrade in the `1.3.0` branch due to other downstream projects' rule incompatibility.

This PR upgrades to the latest checkstyle, checkstyle maven plugin, spring ruleset, and overrides one of spring-cloud-build's modules (`spring-cloud-build-tools`) to the latest version to avoid bringing in a newly invalid rule configuration.

cc: @OlgaMaciaszek 