### PR TITLE
Update samples checkstyle commit to match main project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,13 @@
 		<zipkin-gcp.version>0.16.0</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
+
+		<!-- Checkstyle version settings. Keep in sync with spring-cloud-gcp-samples/pom.xml -->
 		<spring-javaformat-checkstyle.version>0.0.21</spring-javaformat-checkstyle.version>
 		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
 		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
 		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
+
 	</properties>
 
 	<dependencyManagement>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -20,9 +20,9 @@
 
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
-		<spring-cloud-build-tools.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-build-tools.version>
-		<puppycrawl-tools-checkstyle.version>8.18</puppycrawl-tools-checkstyle.version>
-		<maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
+		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
+		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -20,6 +20,8 @@
 
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
+
+		<!-- Checkstyle version settings. Keep in sync with ../pom.xml -->
 		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
 		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
 		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>


### PR DESCRIPTION
Samples directory inherits from spring boot parent, and not from this project's parent. It will be easier to maintain checkstyle if both checkstyle versions are consistent.

Checkstyle in samples is turned off by default, so our users are not affected. It does run on CI, though.