### PR TITLE
Add support for Firestore Sort PartTree queries

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQuery.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQuery.java
@@ -130,11 +130,9 @@ public class PartTreeFirestoreQuery implements RepositoryQuery {
 			ParameterAccessor paramAccessor = new ParametersParameterAccessor(getQueryMethod().getParameters(),
 					parameters);
 			Pageable pageable = paramAccessor.getPageable();
-			if (pageable != null) {
-				if (pageable.isPaged()) {
-					builder.setOffset((int) Math.min(Integer.MAX_VALUE, pageable.getOffset()));
-					builder.setLimit(Int32Value.newBuilder().setValue(pageable.getPageSize()));
-				}
+			if (pageable != null && pageable.isPaged()) {
+				builder.setOffset((int) Math.min(Integer.MAX_VALUE, pageable.getOffset()));
+				builder.setLimit(Int32Value.newBuilder().setValue(pageable.getPageSize()));
 			}
 
 			Sort sort = paramAccessor.getSort();

--- a/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQuery.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQuery.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gcp.data.firestore.repository.query;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.firestore.v1.StructuredQuery;
+import com.google.firestore.v1.StructuredQuery.FieldReference;
 import com.google.protobuf.Int32Value;
 
 import org.springframework.cloud.gcp.core.util.MapBuilder;
@@ -33,6 +35,9 @@ import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreClassMapper
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingContext;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestorePersistentEntity;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
@@ -53,6 +58,7 @@ import static org.springframework.data.repository.query.parser.Part.Type.SIMPLE_
 /**
  * @author Dmitry Solomakha
  * @author Chengyuan Zhao
+ * @author Daniel Zou
  *
  * @since 1.2
  */
@@ -124,9 +130,16 @@ public class PartTreeFirestoreQuery implements RepositoryQuery {
 			ParameterAccessor paramAccessor = new ParametersParameterAccessor(getQueryMethod().getParameters(),
 					parameters);
 			Pageable pageable = paramAccessor.getPageable();
-			if (pageable != null && pageable.isPaged()) {
-				builder.setOffset((int) Math.min(Integer.MAX_VALUE, pageable.getOffset()));
-				builder.setLimit(Int32Value.newBuilder().setValue(pageable.getPageSize()));
+			if (pageable != null) {
+				if (pageable.isPaged()) {
+					builder.setOffset((int) Math.min(Integer.MAX_VALUE, pageable.getOffset()));
+					builder.setLimit(Int32Value.newBuilder().setValue(pageable.getPageSize()));
+				}
+			}
+
+			Sort sort = paramAccessor.getSort();
+			if (sort != null) {
+				builder.addAllOrderBy(createFirestoreSortOrders(sort));
 			}
 		}
 
@@ -136,6 +149,39 @@ public class PartTreeFirestoreQuery implements RepositoryQuery {
 		else {
 			return this.reactiveOperations.execute(builder, this.persistentEntity.getType());
 		}
+	}
+
+	/**
+	 * This method converts {@link org.springframework.data.domain.Sort.Order}
+	 * to {@link StructuredQuery.Order} for Firestore.
+	 */
+	private List<StructuredQuery.Order> createFirestoreSortOrders(Sort sort) {
+		List<StructuredQuery.Order> sortOrders = new ArrayList<>();
+
+		for (Order order : sort) {
+			if (order.isIgnoreCase()) {
+				throw new IllegalArgumentException("Datastore does not support ignore case sort orders.");
+			}
+
+			// Get the name of the field to sort on
+			String fieldName =
+					this.persistentEntity.getPersistentProperty(order.getProperty()).getFieldName();
+
+			StructuredQuery.Direction dir =
+					order.getDirection() == Direction.DESC
+							? StructuredQuery.Direction.DESCENDING : StructuredQuery.Direction.ASCENDING;
+
+			FieldReference ref = FieldReference.newBuilder().setFieldPath(fieldName).build();
+			com.google.firestore.v1.StructuredQuery.Order firestoreOrder =
+					com.google.firestore.v1.StructuredQuery.Order.newBuilder()
+							.setField(ref)
+							.setDirection(dir)
+							.build();
+
+			sortOrders.add(firestoreOrder);
+		}
+
+		return sortOrders;
 	}
 
 	private StructuredQuery.Builder createBuilderWithFilter(Object[] parameters) {

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/entities/User.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/entities/User.java
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.gcp.data.firestore;
+package org.springframework.cloud.gcp.data.firestore.entities;
 
 import java.util.List;
 import java.util.Objects;
 
 import com.google.cloud.firestore.annotation.DocumentId;
 import com.google.cloud.firestore.annotation.PropertyName;
+
+import org.springframework.cloud.gcp.data.firestore.Document;
 
 /**
  * Sample entity for integration tests.

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/entities/UserRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/entities/UserRepository.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.gcp.data.firestore.it;
+package org.springframework.cloud.gcp.data.firestore.entities;
 
 import java.util.List;
 
@@ -22,8 +22,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gcp.data.firestore.FirestoreReactiveRepository;
-import org.springframework.cloud.gcp.data.firestore.User;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 /**
  * A test custom repository.
@@ -41,6 +41,8 @@ public interface UserRepository extends FirestoreReactiveRepository<User> {
 	Flux<User> findByAgeGreaterThanAndAgeLessThan(Integer age1, Integer age2);
 
 	Flux<User> findByAgeGreaterThan(Integer age);
+
+	Flux<User> findByAgeGreaterThan(Integer age, Sort sort);
 
 	Flux<User> findByAgeGreaterThan(Integer age, Pageable pageable);
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTests.java
@@ -30,7 +30,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gcp.data.firestore.FirestoreDataException;
 import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
-import org.springframework.cloud.gcp.data.firestore.User;
+import org.springframework.cloud.gcp.data.firestore.entities.User;
 import org.springframework.cloud.gcp.data.firestore.transaction.ReactiveFirestoreTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
+import org.springframework.cloud.gcp.data.firestore.entities.UserRepository;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreClassMapper;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreDefaultClassMapper;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingContext;
@@ -44,7 +45,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @Configuration
 @PropertySource("application-test.properties")
-@EnableReactiveFirestoreRepositories
+@EnableReactiveFirestoreRepositories(basePackageClasses = UserRepository.class)
 @EnableTransactionManagement
 public class FirestoreIntegrationTestsConfiguration {
 	@Value("projects/${test.integration.firestore.project-id}/databases/(default)/documents")

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/UserService.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/UserService.java
@@ -21,7 +21,8 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gcp.data.firestore.FirestoreDataException;
-import org.springframework.cloud.gcp.data.firestore.User;
+import org.springframework.cloud.gcp.data.firestore.entities.User;
+import org.springframework.cloud.gcp.data.firestore.entities.UserRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/repository/query/FirestoreRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/repository/query/FirestoreRepositoryTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.firestore.repository.query;
+
+import com.google.firestore.v1.StructuredQuery;
+import com.google.firestore.v1.StructuredQuery.Direction;
+import com.google.firestore.v1.StructuredQuery.FieldReference;
+import com.google.firestore.v1.StructuredQuery.Order;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
+import org.springframework.cloud.gcp.data.firestore.entities.User;
+import org.springframework.cloud.gcp.data.firestore.entities.UserRepository;
+import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreClassMapper;
+import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreDefaultClassMapper;
+import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingContext;
+import org.springframework.cloud.gcp.data.firestore.repository.config.EnableReactiveFirestoreRepositories;
+import org.springframework.cloud.gcp.data.firestore.repository.query.FirestoreRepositoryTests.FirestoreRepositoryTestsConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = FirestoreRepositoryTestsConfiguration.class)
+public class FirestoreRepositoryTests {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private FirestoreTemplate template;
+
+	@Test
+	public void testSortQuery() {
+		userRepository.findByAgeGreaterThan(0, Sort.by("name")).blockLast();
+
+		ArgumentCaptor<StructuredQuery.Builder> captor =
+				ArgumentCaptor.forClass(StructuredQuery.Builder.class);
+		verify(template).execute(captor.capture(), eq(User.class));
+
+		StructuredQuery.Builder result = captor.getValue();
+		assertThat(result.getOrderByList()).containsExactly(
+				Order.newBuilder()
+						.setDirection(Direction.ASCENDING)
+						.setField(
+								FieldReference.newBuilder().setFieldPath("name"))
+						.build());
+	}
+
+	@Configuration
+	@EnableReactiveFirestoreRepositories(basePackageClasses = UserRepository.class)
+	static class FirestoreRepositoryTestsConfiguration {
+		private static final String DEFAULT_PARENT = "projects/my-project/databases/(default)/documents";
+
+		@Bean
+		public FirestoreMappingContext firestoreMappingContext() {
+			return new FirestoreMappingContext();
+		}
+
+		@Bean
+		public FirestoreTemplate firestoreTemplate(
+				FirestoreClassMapper classMapper, FirestoreMappingContext firestoreMappingContext) {
+			FirestoreTemplate template = Mockito.mock(FirestoreTemplate.class);
+			Mockito.when(template.getClassMapper()).thenReturn(classMapper);
+			Mockito.when(template.getMappingContext()).thenReturn(firestoreMappingContext);
+			Mockito.when(template.execute(any(), any())).thenReturn(Flux.empty());
+			return template;
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		public FirestoreClassMapper getClassMapper() {
+			return new FirestoreDefaultClassMapper();
+		}
+	}
+}

--- a/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
@@ -26,7 +26,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gcp.data.firestore.FirestoreDataException;
 import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
-import org.springframework.cloud.gcp.data.firestore.User;
+import org.springframework.cloud.gcp.data.firestore.entities.User;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreClassMapper;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreDefaultClassMapper;
 import org.springframework.cloud.gcp.data.firestore.mapping.FirestoreMappingContext;


### PR DESCRIPTION
This allows user to add the `Sort` parameter to their Firestore repository query methods.

Fixes #1940.