### PR TITLE
Revert surefire property change

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -9,11 +9,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <properties>
-        <!-- TODO: Remove after resolving Jenkins build? -->
-        <surefire.useFile>false</surefire.useFile>
-    </properties>
-
     <artifactId>spring-cloud-gcp-autoconfigure</artifactId>
     <name>Spring Cloud GCP Autoconfigure Module</name>
 

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -9,6 +9,11 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <properties>
+        <!-- TODO: Remove after resolving Jenkins build? -->
+        <surefire.useFile>false</surefire.useFile>
+    </properties>
+
     <artifactId>spring-cloud-gcp-autoconfigure</artifactId>
     <name>Spring Cloud GCP Autoconfigure Module</name>
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gcp.autoconfigure.firestore;
 
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.cloud.firestore.FirestoreOptions;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -26,6 +27,8 @@ import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfigurat
 import org.springframework.cloud.gcp.data.firestore.FirestoreTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeThat;
 
 /**
  * Tests for Firestore Emulator autoconfiguration.
@@ -40,6 +43,13 @@ public class GcpFirestoreEmulatorAutoConfigurationTests {
 							GcpFirestoreEmulatorAutoConfiguration.class,
 							GcpContextAutoConfiguration.class,
 							GcpFirestoreAutoConfiguration.class));
+
+	@BeforeClass
+	public static void checkToRun() {
+		assumeThat("Firestore emulator integration tests are disabled. "
+						+ "Please use '-Dit.firestore=true' to enable them. ",
+				System.getProperty("it.firestore"), is("true"));
+	}
 
 	@Test
 	public void testAutoConfigurationEnabled() {


### PR DESCRIPTION
Revert the Surefire property change that was used for debugging the Jenkins build. This is no longer necessary after the Jenkins build was fixed.

Fixes #2347.