### PR TITLE
Replace credentials mocking with NoCredentials in GcpDatastoreAutoConfigurationTests

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -184,7 +184,7 @@ public class GcpDatastoreAutoConfigurationTests {
 
 		@Bean
 		public CredentialsProvider credentialsProvider() {
-			return () -> mock(Credentials.class);
+			return () -> NoCredentials.getInstance();
 		}
 	}
 
@@ -196,7 +196,7 @@ public class GcpDatastoreAutoConfigurationTests {
 
 		@Bean
 		public CredentialsProvider credentialsProvider() {
-			return () -> mock(Credentials.class);
+			return () -> NoCredentials.getInstance();
 		}
 
 		@Bean
@@ -218,7 +218,7 @@ public class GcpDatastoreAutoConfigurationTests {
 
 		@Bean
 		public CredentialsProvider credentialsProvider() {
-			return () -> mock(Credentials.class);
+			return () -> NoCredentials.getInstance();
 		}
 
 		@Bean


### PR DESCRIPTION
Since we've run into issues with mocking from inside `@Configuration` classes (ByteBuddy agent hanging), might as well remove these instances of mocking credentials. 

Additionally, Credentials is a class, not an interface, and my normal view is to avoid mocking classes if possible. Although since Java9 Mockito uses external process attachment regardless of whether a class or an interface is mocked.