### PR TITLE
Spring Integration doc formatting update

### DIFF
--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -309,7 +309,7 @@ The first patterns have precedence over the following ones.
 In the previous example, the `"*"` pattern means every header is mapped.
 However, because it comes last in the list, https://docs.spring.io/spring-integration/api/org/springframework/integration/util/PatternMatchUtils.html#smartMatch-java.lang.String-java.lang.String...-[the previous patterns take precedence].
 
-==== Pub/Sub Channel Adapter Samples
+==== Samples
 
 Available examples:
 

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -309,10 +309,10 @@ The first patterns have precedence over the following ones.
 In the previous example, the `"*"` pattern means every header is mapped.
 However, because it comes last in the list, https://docs.spring.io/spring-integration/api/org/springframework/integration/util/PatternMatchUtils.html#smartMatch-java.lang.String-java.lang.String...-[the previous patterns take precedence].
 
-=== Sample
+==== Pub/Sub Channel Adapter Samples
 
 Available examples:
 
-- https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample[sender and receiver sample application]
-- https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample[JSON payloads sample application]
-- https://codelabs.developers.google.com/codelabs/cloud-spring-cloud-gcp-pubsub-integration/index.html[codelab]
+- https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample[Sending/Receiving Messages with Channel Adapters]
+- https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample[Pub/Sub Channel Adapters with JSON payloads]
+- https://codelabs.developers.google.com/codelabs/cloud-spring-cloud-gcp-pubsub-integration/index.html[Spring Integration and Pub/Sub Codelab]

--- a/docs/src/main/asciidoc/spring-integration-storage.adoc
+++ b/docs/src/main/asciidoc/spring-integration-storage.adoc
@@ -95,6 +95,6 @@ public MessageHandler outboundChannelAdapter(Storage gcs) {
 }
 ----
 
-==== Samples
+==== Sample
 
 See the https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample[Spring Integration with Google Cloud Storage Sample Code].

--- a/docs/src/main/asciidoc/spring-integration-storage.adoc
+++ b/docs/src/main/asciidoc/spring-integration-storage.adoc
@@ -95,6 +95,6 @@ public MessageHandler outboundChannelAdapter(Storage gcs) {
 }
 ----
 
-=== Sample
+==== Samples
 
-A https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample[sample application] is available.
+See the https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample[Spring Integration with Google Cloud Storage Sample Code].


### PR DESCRIPTION
Updates the level of nesting of Spring integration samples sections in refdoc.

Because these two docs are composed to make the Spring integration docs, it will make it more clear from the index that the samples refer to pub/sub and storage respectively.

See currently: https://cloud.spring.io/spring-cloud-gcp/reference/html/#spring-integration