### PR TITLE
Add SpannerOptions auto-configuration for emulator

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -88,6 +88,8 @@ The schema for the tables will be "ON DELETE NO ACTION" if `false`. | No | `true
 | `spring.cloud.gcp.spanner.writeSessionsFraction` | Fraction of sessions to be kept prepared for write transactions | No | 0.2 - Determined by Cloud Spanner client library
 | `spring.cloud.gcp.spanner.keepAliveIntervalMinutes` | How long to keep idle sessions alive | No | 30 - Determined by Cloud Spanner client library
 | `spring.cloud.gcp.spanner.failIfPoolExhausted` |  If all sessions are in use, fail the request by throwing an exception. Otherwise, by default, block until a session becomes available. | No | `false`
+| `spring.cloud.gcp.spanner.emulator.enabled` |  Enables the usage of an emulator. If this is set to true, then you should set the `spring.cloud.gcp.spanner.host-port` to the host:port of your locally running emulator instance. | No | `false`
+| `spring.cloud.gcp.spanner.host-port` |  The host and port of the Spanner service; can be overridden to specify connecting to an already-running https://cloud.google.com/spanner/docs/emulator#installing_and_running_the_emulator[Spanner emulator] instance. | No |
 |===
 
 ==== Repository settings
@@ -1435,10 +1437,11 @@ This command can be used to create Cloud Spanner instances:
 $ gcloud spanner instances create <instance-name> --config=emulator-config --description="<description>" --nodes=1
 ----
 
-Remember that you need to set the `SPANNER_EMULATOR_HOST` environment variable to use the emulator:
+Once the Spanner emulator is running, ensure that the following properties are set in your `application.properties` of your Spring application:
 
 ----
-$ export SPANNER_EMULATOR_HOST=localhost:9010
+spring.cloud.gcp.spanner.emulator.enabled=true
+spring.cloud.gcp.spanner.host-port=${EMULATOR_HOSTPORT}
 ----
 
 === Sample

--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -88,8 +88,8 @@ The schema for the tables will be "ON DELETE NO ACTION" if `false`. | No | `true
 | `spring.cloud.gcp.spanner.writeSessionsFraction` | Fraction of sessions to be kept prepared for write transactions | No | 0.2 - Determined by Cloud Spanner client library
 | `spring.cloud.gcp.spanner.keepAliveIntervalMinutes` | How long to keep idle sessions alive | No | 30 - Determined by Cloud Spanner client library
 | `spring.cloud.gcp.spanner.failIfPoolExhausted` |  If all sessions are in use, fail the request by throwing an exception. Otherwise, by default, block until a session becomes available. | No | `false`
-| `spring.cloud.gcp.spanner.emulator.enabled` |  Enables the usage of an emulator. If this is set to true, then you should set the `spring.cloud.gcp.spanner.host-port` to the host:port of your locally running emulator instance. | No | `false`
-| `spring.cloud.gcp.spanner.host-port` |  The host and port of the Spanner service; can be overridden to specify connecting to an already-running https://cloud.google.com/spanner/docs/emulator#installing_and_running_the_emulator[Spanner emulator] instance. | No |
+| `spring.cloud.gcp.spanner.emulator.enabled` |  Enables the usage of an emulator. If this is set to true, then you should set the `spring.cloud.gcp.spanner.emulator-host` to the host:port of your locally running emulator instance. | No | `false`
+| `spring.cloud.gcp.spanner.emulator-host` |  The host and port of the Spanner emulator; can be overridden to specify connecting to an already-running https://cloud.google.com/spanner/docs/emulator#installing_and_running_the_emulator[Spanner emulator] instance. | No | `localhost:9010`
 |===
 
 ==== Repository settings
@@ -1441,7 +1441,7 @@ Once the Spanner emulator is running, ensure that the following properties are s
 
 ----
 spring.cloud.gcp.spanner.emulator.enabled=true
-spring.cloud.gcp.spanner.host-port=${EMULATOR_HOSTPORT}
+spring.cloud.gcp.spanner.emulator-host=${EMULATOR_HOSTPORT}
 ----
 
 === Sample

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.spanner;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.SpannerOptions;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides auto-configuration to use the Spanner emulator if enabled.
+ *
+ * @author Eddú Meléndez
+ */
+@Configuration
+@AutoConfigureBefore(GcpSpannerAutoConfiguration.class)
+@EnableConfigurationProperties(GcpSpannerProperties.class)
+@ConditionalOnProperty(prefix = "spring.cloud.gcp.spanner.emulator", name = "enabled", havingValue = "true")
+public class GcpSpannerEmulatorAutoConfiguration {
+
+	private final GcpSpannerProperties properties;
+
+	public GcpSpannerEmulatorAutoConfiguration(GcpSpannerProperties properties) {
+		this.properties = properties;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SpannerOptions spannerOptions() {
+		SpannerOptions.Builder builder = SpannerOptions.newBuilder()
+				.setProjectId(this.properties.getProjectId())
+				.setCredentials(NoCredentials.getInstance());
+		if (this.properties.getEmulatorHost() != null) {
+			builder.setEmulatorHost(this.properties.getEmulatorHost());
+		}
+		return builder.build();
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  * Provides auto-configuration to use the Spanner emulator if enabled.
  *
  * @author Eddú Meléndez
+ * @since 1.3
  */
 @Configuration
 @AutoConfigureBefore(GcpSpannerAutoConfiguration.class)

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
 
 /**
  * Provides auto-configuration to use the Spanner emulator if enabled.
@@ -46,12 +47,10 @@ public class GcpSpannerEmulatorAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public SpannerOptions spannerOptions() {
-		SpannerOptions.Builder builder = SpannerOptions.newBuilder()
+		Assert.notNull(this.properties.getHostPort(), "`spring.cloud.gcp.spanner.host-port` must be set.");
+		return SpannerOptions.newBuilder()
 				.setProjectId(this.properties.getProjectId())
-				.setCredentials(NoCredentials.getInstance());
-		if (this.properties.getEmulatorHost() != null) {
-			builder.setEmulatorHost(this.properties.getEmulatorHost());
-		}
-		return builder.build();
+				.setCredentials(NoCredentials.getInstance())
+				.setEmulatorHost(this.properties.getHostPort()).build();
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.util.Assert;
  * Provides auto-configuration to use the Spanner emulator if enabled.
  *
  * @author Eddú Meléndez
- * @since 1.3
+ * @since 1.2.3
  */
 @Configuration
 @AutoConfigureBefore(GcpSpannerAutoConfiguration.class)
@@ -48,10 +48,10 @@ public class GcpSpannerEmulatorAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public SpannerOptions spannerOptions() {
-		Assert.notNull(this.properties.getHostPort(), "`spring.cloud.gcp.spanner.host-port` must be set.");
+		Assert.notNull(this.properties.getEmulatorHost(), "`spring.cloud.gcp.spanner.emulator-host` must be set.");
 		return SpannerOptions.newBuilder()
 				.setProjectId(this.properties.getProjectId())
 				.setCredentials(NoCredentials.getInstance())
-				.setEmulatorHost(this.properties.getHostPort()).build();
+				.setEmulatorHost(this.properties.getEmulatorHost()).build();
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.gcp.core.GcpScope;
  * Settings for Spring Data Cloud Spanner.
  * @author Chengyuan Zhao
  * @author Ray Tsang
+ * @author Eddú Meléndez
  */
 @ConfigurationProperties("spring.cloud.gcp.spanner")
 public class GcpSpannerProperties implements CredentialsSupplier {
@@ -69,6 +70,8 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 	// When {@code true}, if all sessions are in use, fail the request by throwing an exception.
 	// Otherwise, by default, block until a session becomes available.
 	private boolean failIfPoolExhausted = false;
+
+	private String emulatorHost;
 
 	public Credentials getCredentials() {
 		return this.credentials;
@@ -170,5 +173,13 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 
 	public void setFailIfPoolExhausted(boolean failIfPoolExhausted) {
 		this.failIfPoolExhausted = failIfPoolExhausted;
+	}
+
+	public String getEmulatorHost() {
+		return this.emulatorHost;
+	}
+
+	public void setEmulatorHost(String emulatorHost) {
+		this.emulatorHost = emulatorHost;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
@@ -71,6 +71,7 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 	// Otherwise, by default, block until a session becomes available.
 	private boolean failIfPoolExhausted = false;
 
+	// If set, it is used to connect to the emulator.
 	private String hostPort;
 
 	public Credentials getCredentials() {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.gcp.core.GcpScope;
  * @author Chengyuan Zhao
  * @author Ray Tsang
  * @author Eddú Meléndez
+ * @author Mike Eltsufin
  */
 @ConfigurationProperties("spring.cloud.gcp.spanner")
 public class GcpSpannerProperties implements CredentialsSupplier {
@@ -71,8 +72,8 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 	// Otherwise, by default, block until a session becomes available.
 	private boolean failIfPoolExhausted = false;
 
-	// If set, it is used to connect to the emulator.
-	private String hostPort;
+	// Host:port used to connect to the emulator, when the emulator is enabled.
+	private String emulatorHost = "localhost:9010";
 
 	public Credentials getCredentials() {
 		return this.credentials;
@@ -176,11 +177,11 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 		this.failIfPoolExhausted = failIfPoolExhausted;
 	}
 
-	public String getHostPort() {
-		return this.hostPort;
+	public String getEmulatorHost() {
+		return this.emulatorHost;
 	}
 
-	public void setHostPort(String hostPort) {
-		this.hostPort = hostPort;
+	public void setEmulatorHost(String emulatorHost) {
+		this.emulatorHost = emulatorHost;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerProperties.java
@@ -71,7 +71,7 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 	// Otherwise, by default, block until a session becomes available.
 	private boolean failIfPoolExhausted = false;
 
-	private String emulatorHost;
+	private String hostPort;
 
 	public Credentials getCredentials() {
 		return this.credentials;
@@ -175,11 +175,11 @@ public class GcpSpannerProperties implements CredentialsSupplier {
 		this.failIfPoolExhausted = failIfPoolExhausted;
 	}
 
-	public String getEmulatorHost() {
-		return this.emulatorHost;
+	public String getHostPort() {
+		return this.hostPort;
 	}
 
-	public void setEmulatorHost(String emulatorHost) {
-		this.emulatorHost = emulatorHost;
+	public void setHostPort(String hostPort) {
+		this.hostPort = hostPort;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -55,6 +55,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.cloud.gcp.spanner.emulator.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enables auto-configuration to use the Spanner emulator.",
+      "defaultValue": false
+    },
+    {
       "name": "spring.cloud.gcp.sql.enabled",
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud SQL support components.",

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -5,6 +5,7 @@ org.springframework.cloud.gcp.autoconfigure.logging.StackdriverLoggingAutoConfig
 org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.pubsub.GcpPubSubReactiveAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.spanner.GcpSpannerAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.spanner.GcpSpannerEmulatorAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.datastore.GcpDatastoreAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.firestore.GcpFirestoreAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.firestore.GcpFirestoreEmulatorAutoConfiguration,\

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfigurationTests.java
@@ -38,7 +38,7 @@ public class GcpSpannerEmulatorAutoConfigurationTests {
 	@Test
 	public void testEmulatorAutoConfigurationEnabled() {
 		this.contextRunner.withPropertyValues("spring.cloud.gcp.spanner.emulator.enabled=true",
-				"spring.cloud.gcp.spanner.emulator-host=localhost:9010")
+				"spring.cloud.gcp.spanner.host-port=localhost:9010")
 				.run(context -> {
 					SpannerOptions spannerOptions = context.getBean(SpannerOptions.class);
 					assertThat(spannerOptions.getEndpoint()).isEqualTo("localhost:9010");

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfigurationTests.java
@@ -37,11 +37,20 @@ public class GcpSpannerEmulatorAutoConfigurationTests {
 
 	@Test
 	public void testEmulatorAutoConfigurationEnabled() {
-		this.contextRunner.withPropertyValues("spring.cloud.gcp.spanner.emulator.enabled=true",
-				"spring.cloud.gcp.spanner.host-port=localhost:9010")
+		this.contextRunner.withPropertyValues("spring.cloud.gcp.spanner.emulator.enabled=true")
 				.run(context -> {
 					SpannerOptions spannerOptions = context.getBean(SpannerOptions.class);
 					assertThat(spannerOptions.getEndpoint()).isEqualTo("localhost:9010");
+				});
+	}
+
+	@Test
+	public void testEmulatorAutoConfigurationEnabledCustomHostPort() {
+		this.contextRunner.withPropertyValues("spring.cloud.gcp.spanner.emulator.enabled=true",
+				"spring.cloud.gcp.spanner.emulator-host=localhost:9090")
+				.run(context -> {
+					SpannerOptions spannerOptions = context.getBean(SpannerOptions.class);
+					assertThat(spannerOptions.getEndpoint()).isEqualTo("localhost:9090");
 				});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfigurationTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.spanner;
+
+import com.google.cloud.spanner.SpannerOptions;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class GcpSpannerEmulatorAutoConfigurationTests {
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(GcpSpannerEmulatorAutoConfiguration.class,
+					GcpSpannerAutoConfiguration.class, GcpContextAutoConfiguration.class))
+			.withPropertyValues("spring.cloud.gcp.spanner.project-id=test-project");
+
+	@Test
+	public void testEmulatorAutoConfigurationEnabled() {
+		this.contextRunner.withPropertyValues("spring.cloud.gcp.spanner.emulator.enabled=true",
+				"spring.cloud.gcp.spanner.emulator-host=localhost:9010")
+				.run(context -> {
+					SpannerOptions spannerOptions = context.getBean(SpannerOptions.class);
+					assertThat(spannerOptions.getEndpoint()).isEqualTo("localhost:9010");
+				});
+	}
+
+	@Test
+	public void testEmulatorAutoConfigurationDisabled() {
+		this.contextRunner
+				.run(context -> {
+					SpannerOptions spannerOptions = context.getBean(SpannerOptions.class);
+					assertThat(spannerOptions.getEndpoint()).isEqualTo("spanner.googleapis.com:443");
+				});
+	}
+}


### PR DESCRIPTION
Currently, in order to execute against the emulator, Spanner relies
on `SPANNER_EMULATOR_HOST` environment variable. This commit introduces
new configuration properties in order to enable and set the emulator host.
