### PR TITLE
Add secret manager enabled property to properties metadata

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -49,6 +49,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.cloud.gcp.secretmanager.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud Secret Manager components.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.cloud.gcp.spanner.enabled",
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud Spanner components.",


### PR DESCRIPTION
This adds the missing `secretmanager enable` property to the project metadata.

Fixes #2362.