### PR TITLE
[DO NOT MERGE] set an old version of spring-cloud-sleuth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<spring-cloud-commons.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-bus.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-bus.version>
-		<spring-cloud-sleuth.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
+		<spring-cloud-sleuth.version>2.2.2.RELEASE</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Ivyland.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.16.0</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>


### PR DESCRIPTION
`org.springframework.cloud:spring-cloud-sleuth:2.2.2.RELEASE` uses a version of brave that's compatible with the one used by `io.zipkin.gcp:zipkin-sender-stackdriver:0.16.0`.

Let's keep this as a backup plan if we can't fix the incompatibilities with the latest brave.

