### PR TITLE
Fix reading log format

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
@@ -16,8 +16,6 @@
 
 package com.example;
 
-import com.google.cloud.logging.Payload.JsonPayload;
-import com.google.protobuf.Value;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +27,7 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
-import com.google.cloud.logging.Payload.StringPayload;
+import com.google.cloud.logging.Payload.JsonPayload;
 import com.google.devtools.cloudtrace.v1.GetTraceRequest;
 import com.google.devtools.cloudtrace.v1.Trace;
 import com.google.devtools.cloudtrace.v1.TraceServiceGrpc;
@@ -157,7 +155,7 @@ public class TraceSampleApplicationTests {
 
 
 			List<String> logContents = logEntries.stream()
-					.map((logEntry) -> (String)((JsonPayload) logEntry.getPayload())
+					.map((logEntry) -> (String) ((JsonPayload) logEntry.getPayload())
 							.getDataAsMap().get("message"))
 					.collect(Collectors.toList());
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
@@ -16,6 +16,8 @@
 
 package com.example;
 
+import com.google.cloud.logging.Payload.JsonPayload;
+import com.google.protobuf.Value;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -155,7 +157,8 @@ public class TraceSampleApplicationTests {
 
 
 			List<String> logContents = logEntries.stream()
-					.map((logEntry) -> ((StringPayload) logEntry.getPayload()).getData())
+					.map((logEntry) -> (String)((JsonPayload) logEntry.getPayload())
+							.getDataAsMap().get("message"))
 					.collect(Collectors.toList());
 
 			assertThat(logContents).contains("starting busy work");


### PR DESCRIPTION
The logging format switched from text to json in `com.google.cloud.google-cloud-logging-logback:v0.117.0` (googleapis/java-logging-logback#43). 

This PR fixes the trace integration test by switching from reading `textPayload` to `jsonPayload` for verification of trace correlation to log.

