### PR TITLE
Update test to retrieve json format

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
@@ -16,6 +16,7 @@
 
 package com.example;
 
+import com.google.cloud.logging.Payload.JsonPayload;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -108,7 +109,8 @@ public class LoggingSampleApplicationTests {
 					});
 
 					List<String> logContents = logEntries.stream()
-							.map((logEntry) -> ((StringPayload) logEntry.getPayload()).getData())
+							.map((logEntry) -> (String) ((JsonPayload) logEntry.getPayload())
+									.getDataAsMap().get("message"))
 							.collect(Collectors.toList());
 
 					assertThat(logContents).containsExactlyInAnyOrder(


### PR DESCRIPTION
Same fix as #2377, but for logging sample test.

The logging format switched from text to json in com.google.cloud.google-cloud-logging-logback:v0.117.0 (googleapis/java-logging-logback#43).

This PR fixes the trace integration test by switching from reading textPayload to jsonPayload for verification of trace correlation to log.