### PR TITLE
Make 403 an allowable Pub/Sub UP status

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -25,6 +25,27 @@ dependencies {
 
 This starter is also available from https://start.spring.io[Spring Initializr] through the `GCP Messaging` entry.
 
+=== Spring Boot Actuator Support
+
+==== Cloud Pub/Sub Health Indicator
+
+If you are using Spring Boot Actuator, you can take advantage of the Cloud Pub/Sub health indicator called `pubsub`.
+The health indicator will verify whether Cloud Pub/Sub is up and accessible by your application.
+To enable it, all you need to do is add the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready[Spring Boot Actuator] to your project.
+
+The `pubsub` indicator will then roll up to the overall application status visible at http://localhost:8080/actuator/health (use the `management.endpoint.health.show-details` property to view per-indicator details).
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+----
+
+NOTE: If your application already has actuator and Cloud Pub/Sub starters, this health indicator is enabled by default.
+To disable the Cloud Pub/Sub indicator, set `management.health.pubsub.enabled` to `false`.
+
 [#pubsub-configuration]
 === Configuration
 
@@ -116,25 +137,6 @@ The timeout of the previous call is multiplied by the RpcTimeoutMultiplier to ca
 MaxRpcTimeout puts a limit on the value of the RPC timeout, so that the RpcTimeoutMultiplier
 can't increase the RPC timeout higher than this amount. | No | 0
 |===
-
-=== Spring Boot Actuator Support
-
-==== Cloud Pub/Sub Health Indicator
-
-If you are using Spring Boot Actuator, you can take advantage of the Cloud Pub/Sub health indicator called `pubsub`.
-The health indicator will verify whether Cloud Pub/Sub is up and accessible by your application.
-To enable it, all you need to do is add the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready[Spring Boot Actuator] to your project.
-To disable the Cloud Pub/Sub indicator, set `management.health.pubsub.enabled` to `false`.
-
-The `pubsub` indicator will then roll up to the overall application status visible at http://localhost:8080/actuator/health (use the `management.endpoint.health.show-details` property to view per-indicator details).
-
-[source,xml]
-----
-<dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-actuator</artifactId>
-</dependency>
-----
 
 === Pub/Sub Operations & Template
 

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -25,27 +25,6 @@ dependencies {
 
 This starter is also available from https://start.spring.io[Spring Initializr] through the `GCP Messaging` entry.
 
-=== Spring Boot Actuator Support
-
-==== Cloud Pub/Sub Health Indicator
-
-If you are using Spring Boot Actuator, you can take advantage of the Cloud Pub/Sub health indicator called `pubsub`.
-The health indicator will verify whether Cloud Pub/Sub is up and accessible by your application.
-To enable it, all you need to do is add the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready[Spring Boot Actuator] to your project.
-
-The `pubsub` indicator will then roll up to the overall application status visible at http://localhost:8080/actuator/health (use the `management.endpoint.health.show-details` property to view per-indicator details).
-
-[source,xml]
-----
-<dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-actuator</artifactId>
-</dependency>
-----
-
-NOTE: If your application already has actuator and Cloud Pub/Sub starters, this health indicator is enabled by default.
-To disable the Cloud Pub/Sub indicator, set `management.health.pubsub.enabled` to `false`.
-
 [#pubsub-configuration]
 === Configuration
 
@@ -137,6 +116,27 @@ The timeout of the previous call is multiplied by the RpcTimeoutMultiplier to ca
 MaxRpcTimeout puts a limit on the value of the RPC timeout, so that the RpcTimeoutMultiplier
 can't increase the RPC timeout higher than this amount. | No | 0
 |===
+
+=== Spring Boot Actuator Support
+
+==== Cloud Pub/Sub Health Indicator
+
+If you are using Spring Boot Actuator, you can take advantage of the Cloud Pub/Sub health indicator called `pubsub`.
+The health indicator will verify whether Cloud Pub/Sub is up and accessible by your application.
+To enable it, all you need to do is add the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready[Spring Boot Actuator] to your project.
+
+The `pubsub` indicator will then roll up to the overall application status visible at http://localhost:8080/actuator/health (use the `management.endpoint.health.show-details` property to view per-indicator details).
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+----
+
+NOTE: If your application already has actuator and Cloud Pub/Sub starters, this health indicator is enabled by default.
+To disable the Cloud Pub/Sub indicator, set `management.health.pubsub.enabled` to `false`.
 
 === Pub/Sub Operations & Template
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.gcp.autoconfigure.pubsub.health;
 
-import com.google.api.gax.rpc.StatusCode.Code;
 import java.util.UUID;
 
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StatusCode.Code;
 
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/health/PubSubHealthIndicator.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gcp.autoconfigure.pubsub.health;
 
+import com.google.api.gax.rpc.StatusCode.Code;
 import java.util.UUID;
 
 import com.google.api.gax.rpc.ApiException;
@@ -53,7 +54,8 @@ public class PubSubHealthIndicator extends AbstractHealthIndicator {
 			this.pubSubTemplate.pull("subscription-" + UUID.randomUUID().toString(), 1, true);
 		}
 		catch (ApiException aex) {
-			if (aex.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
+			Code errorCode = aex.getStatusCode().getCode();
+			if (errorCode == StatusCode.Code.NOT_FOUND || errorCode == Code.PERMISSION_DENIED) {
 				builder.up();
 			}
 			else {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/PubSubHealthIndicatorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/PubSubHealthIndicatorTests.java
@@ -16,12 +16,6 @@
 
 package org.springframework.cloud.gcp.autoconfigure.pubsub;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.rpc.ApiException;
 import io.grpc.Status.Code;
@@ -29,12 +23,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicator;
 import org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the PubSub Health Indicator.


### PR DESCRIPTION
Starting this week, Cloud Pub/Sub accounts without _pubsub.subscriptions.list_ permission (normally granted through _Pub/Sub Viewer_ role) receive 403 Permission Denied instead of 404 Resource Not Found.

This PR makes 403 a valid healthcheck UP status and updates documentation to make actuator use more prominent.

Fixes #2374.