### PR TITLE
Add Micrometer AutoConfiguration

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -56,6 +56,10 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-cloud-gcp-starter-metrics</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
 		</dependency>
 		<dependency>

--- a/docs/src/main/asciidoc/metrics.adoc
+++ b/docs/src/main/asciidoc/metrics.adoc
@@ -1,6 +1,6 @@
 == Stackdriver Monitoring
 
-Google Cloud Platform provides a managed distributed tracing service called https://cloud.google.com/monitoring/[Stackdriver Monitoring], and https://micrometer.io/docs/registry/stackdriver[Micrometer] can be used with it to easily instrument Spring Boot applications for observability.
+Google Cloud Platform provides a service called https://cloud.google.com/monitoring/[Stackdriver Monitoring], and https://micrometer.io/docs/registry/stackdriver[Micrometer] can be used with it to easily instrument Spring Boot applications for observability.
 
 Spring Boot already provides auto-configuration for Stackdriver. This module enables to auto-detect the `project-id` and `credentials`. Also, it can be customized.
 
@@ -23,7 +23,7 @@ dependencies {
 }
 ----
 
-You must enable Stackdriver Monitoring API from the Google Cloud Console in order to capture traces.
+You must enable Stackdriver Monitoring API from the Google Cloud Console in order to capture metrics.
 Navigate to the https://console.cloud.google.com/apis/api/monitoring.googleapis.com/overview[Stackdriver Monitoring API] for your project and make sure it’s enabled.
 
 === Spring Boot Starter for Stackdriver Monitoring

--- a/docs/src/main/asciidoc/metrics.adoc
+++ b/docs/src/main/asciidoc/metrics.adoc
@@ -1,0 +1,45 @@
+== Stackdriver Monitoring
+
+Google Cloud Platform provides a managed distributed tracing service called https://cloud.google.com/monitoring/[Stackdriver Monitoring], and https://micrometer.io/docs/registry/stackdriver[Micrometer] can be used with it to easily instrument Spring Boot applications for observability.
+
+Spring Boot already provides auto-configuration for Stackdriver. This module enables to auto-detect the `project-id` and `credentials`. Also, it can be customized.
+
+Maven coordinates, using <<getting-started.adoc#_bill_of_materials, Spring Cloud GCP BOM>>:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-metrics</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+[source,subs="normal"]
+----
+dependencies {
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-metrics'
+}
+----
+
+You must enable Stackdriver Monitoring API from the Google Cloud Console in order to capture traces.
+Navigate to the https://console.cloud.google.com/apis/api/monitoring.googleapis.com/overview[Stackdriver Monitoring API] for your project and make sure it’s enabled.
+
+=== Spring Boot Starter for Stackdriver Monitoring
+
+Spring Boot Starter for Stackdriver Monitoring uses Micrometer.
+
+All configurations are optional:
+
+|===
+| Name | Description | Required | Default value
+| `spring.cloud.gcp.metrics.enabled` | Auto-configure Micrometer to send metrics to Stackdriver Monitoring. | No | `true`
+| `spring.cloud.gcp.metrics.project-id` | Overrides the project ID from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
+| `spring.cloud.gcp.metrics.credentials.location` | Overrides the credentials location from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
+| `spring.cloud.gcp.metrics.credentials.encoded-key` | Overrides the credentials encoded key from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
+| `spring.cloud.gcp.metrics.credentials.scopes` | Overrides the credentials scopes from the <<spring-cloud-gcp-core,Spring Cloud GCP Module>> | No |
+|===
+
+You can use core Spring Boot Actuator properties to control reporting frequency, etc.
+Read https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-export-stackdriver[Spring Boot Actuator documentation] for more information on Stackdriver Actuator configurations.

--- a/docs/src/main/asciidoc/metrics.adoc
+++ b/docs/src/main/asciidoc/metrics.adoc
@@ -26,6 +26,26 @@ dependencies {
 You must enable Stackdriver Monitoring API from the Google Cloud Console in order to capture metrics.
 Navigate to the https://console.cloud.google.com/apis/api/monitoring.googleapis.com/overview[Stackdriver Monitoring API] for your project and make sure it’s enabled.
 
+This starter depends on `org.springframework.boot:spring-boot-starter-actuator` dependency. Make sure the dependency is being declared.
+
+Maven coordinates:
+
+----
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+[source,subs="normal"]
+----
+dependencies {
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
+}
+----
+
 === Spring Boot Starter for Stackdriver Monitoring
 
 Spring Boot Starter for Stackdriver Monitoring uses Micrometer.

--- a/docs/src/main/asciidoc/metrics.adoc
+++ b/docs/src/main/asciidoc/metrics.adoc
@@ -26,7 +26,7 @@ dependencies {
 You must enable Stackdriver Monitoring API from the Google Cloud Console in order to capture metrics.
 Navigate to the https://console.cloud.google.com/apis/api/monitoring.googleapis.com/overview[Stackdriver Monitoring API] for your project and make sure it’s enabled.
 
-This starter depends on `org.springframework.boot:spring-boot-starter-actuator` dependency. Make sure the dependency is being declared.
+This starter requires `org.springframework.boot:spring-boot-starter-actuator` dependency to activate. Make sure the dependency is being declared.
 
 Maven coordinates:
 

--- a/docs/src/main/asciidoc/spring-cloud-gcp.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gcp.adoc
@@ -41,6 +41,8 @@ include::trace.adoc[]
 
 include::logging.adoc[]
 
+include::metrics.adoc[]
+
 include::spanner.adoc[]
 
 include::datastore.adoc[]

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -284,6 +284,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-stackdriver</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>commons-io</groupId>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpMetricsProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpMetricsProperties.java
@@ -22,6 +22,12 @@ import org.springframework.cloud.gcp.core.Credentials;
 import org.springframework.cloud.gcp.core.CredentialsSupplier;
 import org.springframework.cloud.gcp.core.GcpScope;
 
+/**
+ * Settings for Stackdriver Metrics.
+ *
+ * @author Eddú Meléndez
+ * @since 1.2.4
+ */
 @ConfigurationProperties(prefix = "spring.cloud.gcp.metrics")
 public class GcpMetricsProperties implements CredentialsSupplier {
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpMetricsProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpMetricsProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.metrics;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.cloud.gcp.core.Credentials;
+import org.springframework.cloud.gcp.core.CredentialsSupplier;
+import org.springframework.cloud.gcp.core.GcpScope;
+
+@ConfigurationProperties(prefix = "spring.cloud.gcp.metrics")
+public class GcpMetricsProperties implements CredentialsSupplier {
+
+	/**
+	 * Overrides the GCP project ID specified in the Core module.
+	 */
+	private String projectId;
+
+	/**
+	 * Overrides the GCP OAuth2 credentials specified in the Core module.
+	 */
+	@NestedConfigurationProperty
+	private final Credentials credentials = new Credentials(GcpScope.CLOUD_MONITORING_WRITE.getUrl());
+
+	public String getProjectId() {
+		return this.projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	@Override
+	public Credentials getCredentials() {
+		return this.credentials;
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.metrics;
+
+import com.google.api.gax.core.CredentialsProvider;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.step.StepMeterRegistry;
+import io.micrometer.stackdriver.StackdriverConfig;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverProperties;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides auto-detection for project.
+ *
+ * @author Eddú Meléndez
+ */
+@Configuration
+@AutoConfigureBefore(StackdriverMetricsExportAutoConfiguration.class)
+@ConditionalOnClass({StepMeterRegistry.class, StackdriverConfig.class})
+@ConditionalOnBean(Clock.class)
+@EnableConfigurationProperties(StackdriverProperties.class)
+@ConditionalOnProperty(value = "spring.cloud.gcp.metrics.enabled", matchIfMissing = true)
+public class GcpStackdriverMetricsAutoConfiguration {
+
+	private final StackdriverProperties properties;
+
+	public GcpStackdriverMetricsAutoConfiguration(StackdriverProperties stackdriverProperties) {
+		this.properties = stackdriverProperties;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public StackdriverConfig stackdriverConfig(GcpProjectIdProvider projectIdProvider, CredentialsProvider credentialsProvider) {
+		String projectId = projectIdProvider.getProjectId();
+		return new GcpStackdriverPropertiesConfigAdapter(this.properties, projectId, credentialsProvider);
+	}
+
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Provides auto-detection for project.
+ * Provides auto-detection for `project-id` and `credentials`.
  *
  * @author Eddú Meléndez
  */
@@ -46,7 +46,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass({StepMeterRegistry.class, StackdriverConfig.class})
 @ConditionalOnBean(Clock.class)
 @EnableConfigurationProperties({GcpMetricsProperties.class, StackdriverProperties.class})
-@ConditionalOnProperty(value = "spring.cloud.gcp.metrics.enabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "spring.cloud.gcp.metrics.enabled", matchIfMissing = true, havingValue = "true")
 public class GcpStackdriverMetricsAutoConfiguration {
 
 	private final StackdriverProperties stackdriverProperties;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.context.annotation.Configuration;
  * Provides auto-detection for `project-id` and `credentials`.
  *
  * @author Eddú Meléndez
+ * @since 1.2.4
  */
 @Configuration
 @AutoConfigureBefore(StackdriverMetricsExportAutoConfiguration.class)

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverPropertiesConfigAdapter.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverPropertiesConfigAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.metrics;
+
+import com.google.api.gax.core.CredentialsProvider;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverProperties;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverPropertiesConfigAdapter;
+
+public class GcpStackdriverPropertiesConfigAdapter extends StackdriverPropertiesConfigAdapter {
+
+	private String projectId;
+
+	private CredentialsProvider credentialsProvider;
+
+	public GcpStackdriverPropertiesConfigAdapter(StackdriverProperties properties) {
+		super(properties);
+	}
+
+	public GcpStackdriverPropertiesConfigAdapter(StackdriverProperties properties, String projectId,
+			CredentialsProvider credentialsProvider) {
+		this(properties);
+		this.projectId = projectId;
+		this.credentialsProvider = credentialsProvider;
+	}
+
+	@Override
+	public String projectId() {
+		return this.projectId;
+	}
+
+	@Override
+	public CredentialsProvider credentials() {
+		return this.credentialsProvider;
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverPropertiesConfigAdapter.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverPropertiesConfigAdapter.java
@@ -23,6 +23,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver
 
 /**
  * @author Eddú Meléndez
+ * @since 1.2.4
  */
 public class GcpStackdriverPropertiesConfigAdapter extends StackdriverPropertiesConfigAdapter {
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverPropertiesConfigAdapter.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverPropertiesConfigAdapter.java
@@ -21,6 +21,9 @@ import com.google.api.gax.core.CredentialsProvider;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverProperties;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverPropertiesConfigAdapter;
 
+/**
+ * @author Eddú Meléndez
+ */
 public class GcpStackdriverPropertiesConfigAdapter extends StackdriverPropertiesConfigAdapter {
 
 	private String projectId;

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -37,6 +37,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.cloud.gcp.metrics.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud Monitoring for Micrometer.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.cloud.gcp.pubsub.enabled",
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud Pub/Sub components.",

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -23,7 +23,8 @@ org.springframework.cloud.gcp.autoconfigure.datastore.GcpDatastoreEmulatorAutoCo
 org.springframework.cloud.gcp.autoconfigure.bigquery.GcpBigQueryAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.datastore.DatastoreTransactionManagerAutoConfiguration,\
 org.springframework.cloud.gcp.autoconfigure.firestore.FirestoreRepositoriesAutoConfiguration,\
-org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration
+org.springframework.cloud.gcp.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.metrics.GcpStackdriverMetricsAutoConfiguration
 
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.gcp.autoconfigure.config.GcpConfigBootstrapConfiguration,\

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfigurationTest.java
@@ -31,6 +31,11 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for auto-config.
+ *
+ * @author Eddú Meléndez
+ */
 public class GcpStackdriverMetricsAutoConfigurationTest {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -42,6 +47,13 @@ public class GcpStackdriverMetricsAutoConfigurationTest {
 	public void testProjectIdIsSet() {
 		this.contextRunner
 				.withPropertyValues("spring.cloud.gcp.project-id=demo-project")
+				.run(context -> assertThat(context).hasSingleBean(StackdriverConfig.class));
+	}
+
+	@Test
+	public void testMetricsProjectIdIsSet() {
+		this.contextRunner
+				.withPropertyValues("spring.cloud.gcp.metrics.project-id=demo-project")
 				.run(context -> assertThat(context).hasSingleBean(StackdriverConfig.class));
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfigurationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.autoconfigure.metrics;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import io.micrometer.stackdriver.StackdriverConfig;
+import org.junit.Test;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GcpStackdriverMetricsAutoConfigurationTest {
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(GcpContextAutoConfiguration.class, GcpStackdriverMetricsAutoConfiguration.class,
+					StackdriverMetricsExportAutoConfiguration.class, MetricsAutoConfiguration.class))
+			.withUserConfiguration(Config.class);
+
+	@Test
+	public void testProjectIdIsSet() {
+		this.contextRunner
+				.withPropertyValues("spring.cloud.gcp.project-id=demo-project")
+				.run(context -> assertThat(context).hasSingleBean(StackdriverConfig.class));
+	}
+
+	@Configuration
+	static class Config {
+
+		@Bean
+		public CredentialsProvider credentialsProvider() {
+			return NoCredentialsProvider.create();
+		}
+
+	}
+
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/metrics/GcpStackdriverMetricsAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gcp.autoconfigure.metrics;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import io.micrometer.stackdriver.StackdriverConfig;
+import io.micrometer.stackdriver.StackdriverMeterRegistry;
 import org.junit.Test;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
@@ -47,14 +48,16 @@ public class GcpStackdriverMetricsAutoConfigurationTest {
 	public void testProjectIdIsSet() {
 		this.contextRunner
 				.withPropertyValues("spring.cloud.gcp.project-id=demo-project")
-				.run(context -> assertThat(context).hasSingleBean(StackdriverConfig.class));
+				.run(context -> assertThat(context).hasSingleBean(StackdriverConfig.class)
+						.hasSingleBean(StackdriverMeterRegistry.class));
 	}
 
 	@Test
 	public void testMetricsProjectIdIsSet() {
 		this.contextRunner
 				.withPropertyValues("spring.cloud.gcp.metrics.project-id=demo-project")
-				.run(context -> assertThat(context).hasSingleBean(StackdriverConfig.class));
+				.run(context -> assertThat(context).hasSingleBean(StackdriverConfig.class)
+						.hasSingleBean(StackdriverMeterRegistry.class));
 	}
 
 	@Configuration

--- a/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
+++ b/spring-cloud-gcp-core/src/main/java/org/springframework/cloud/gcp/core/GcpScope.java
@@ -57,7 +57,10 @@ public enum GcpScope {
 	CLOUD_VISION("https://www.googleapis.com/auth/cloud-vision"),
 
 	/** scope for BigQuery. */
-	BIG_QUERY("https://www.googleapis.com/auth/bigquery");
+	BIG_QUERY("https://www.googleapis.com/auth/bigquery"),
+
+	/** scope for Cloud Monitoring.*/
+	CLOUD_MONITORING_WRITE("https://www.googleapis.com/auth/monitoring.write");
 
 	private String url;
 

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -167,6 +167,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-gcp-starter-metrics</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/spring-cloud-gcp-starters/pom.xml
+++ b/spring-cloud-gcp-starters/pom.xml
@@ -31,6 +31,7 @@
 		<module>spring-cloud-gcp-starter-firestore</module>
 		<module>spring-cloud-gcp-starter-trace</module>
 		<module>spring-cloud-gcp-starter-logging</module>
+		<module>spring-cloud-gcp-starter-metrics</module>
 		<module>spring-cloud-gcp-starter-sql-mysql</module>
 		<module>spring-cloud-gcp-starter-sql-postgresql</module>
 		<module>spring-cloud-gcp-starter-security-iap</module>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-metrics/.repo-metadata.json
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-metrics/.repo-metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "spring-cloud-gcp-starter-metrics",
+  "name_pretty": "Spring Cloud GCP Support for Stackdriver Monitoring",
+  "client_documentation": "https://spring.io/projects/spring-cloud-gcp",
+  "api_description": "Provides support for enabling writing metrics to Stackdriver Monitoring from Spring Boot applications.",
+  "release_level": "ga",
+  "language": "java",
+  "repo": "spring-cloud/spring-cloud-gcp",
+  "repo_short": "spring-cloud-gcp",
+  "distribution_name": "org.springframework.cloud:spring-cloud-gcp-starter-metrics"
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-metrics/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-metrics/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-cloud-gcp-starters</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>1.2.3.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-cloud-gcp-starter-metrics</artifactId>
+	<name>Spring Cloud GCP Stackdriver Monitoring Starter</name>
+	<url>https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-starters/spring-cloud-gcp-starter-metrics</url>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-gcp-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-stackdriver</artifactId>
+		</dependency>
+	</dependencies>
+</project>


### PR DESCRIPTION
Currently, `project-id` has to be provided in order to make the app works. This auto-configuration provides the support to set a specific `project-id` and `credentials` or spin up with the project's default values.