### PR TITLE
Remove extra secret manager property declaration.

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -49,12 +49,6 @@
       "defaultValue": true
     },
     {
-      "name": "spring.cloud.gcp.secretmanager.enabled",
-      "type": "java.lang.Boolean",
-      "description": "Auto-configure Google Cloud Secret Manager components.",
-      "defaultValue": true
-    },
-    {
       "name": "spring.cloud.gcp.spanner.enabled",
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud Spanner components.",


### PR DESCRIPTION
Removes the extra declaration of `secretmanager.enabled` from the configuration metadata json.

Reverts #2363.

cc/ @eddumelendez 