### PR TITLE
Updates GAE samples and juggles some plugin bits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<spring-cloud-sleuth.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Horsham.SR5</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.17.0</zipkin-gcp.version>
-		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
+		<app-engine-maven-plugin.version>2.2.0</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
 		<errorprone.version>2.3.4</errorprone.version>
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -25,6 +25,7 @@
 		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
 		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
 		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+		<app-engine-maven-plugin.version>2.2.0</app-engine-maven-plugin.version>
 	</properties>
 
 	<modules>
@@ -116,12 +117,26 @@
 	</profiles>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>com.google.cloud.tools</groupId>
+					<artifactId>appengine-maven-plugin</artifactId>
+					<version>${app-engine-maven-plugin.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
+			</plugin>
+			<plugin>
+				<!-- Enables repackaging the JAR into an executable. -->
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/README.adoc
@@ -25,9 +25,17 @@ $ curl --header "x-cloud-trace-context: [Some-Trace-ID]" localhost:8080/log
 To see the logged lines, navigate to the https://console.cloud.google.com/logs/viewer[Logging section of the Cloud Console].
 Select the `Global` resource and look under the `spring.log` channel to see the logged text.
 
+=== Running on Google Cloud Platform
+
+Deploy to Google AppEngine:
+
+----
+$ mvn clean package appengine:deploy -Dapp.deploy.projectId=$PROJECT_ID -Dapp.deploy.version=$VERSION
+----
+
 If your application is deployed to Google App Engine (GAE) or Google Kubernetes Engine (GKE), you will instead find the logs under the deployment's resource in the Stackdriver UI under the `spring.log` channel.
 You can further narrow down the log by request by using the following filtering text that takes advantage of the trace ID label in each logged line.
-For example, if deployed to App Engine (by using `mvn appengine:deploy` in this sample) you can use the following to filter by the trace ID:
+For example, if deployed to App Engine, you can use the following to filter by the trace ID:
 
 ----
  resource.type="gae_app"
@@ -38,4 +46,4 @@ For example, if deployed to App Engine (by using `mvn appengine:deploy` in this 
 Expand the log entry labels and note that `appengine.googleapis.com/trace_id` label is set to the same value for both log messages.
 The trace ID header `x-cloud-trace-context` is set automatically when deployed to App Engine.
 
-NOTE: When running on GAE or GKE, also remember to remove the `CONSOLE` appender, otherwise logs will appear on Cloud Logging in duplicate: once in the `spring.log` stream and once in the `stdout` stream.
+NOTE: When running on GAE or GKE, remember to remove the `CONSOLE` appender. Otherwise, logs are duplicated in Cloud Logging (once in the `spring.log` stream and once in the `stdout` stream).

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/README.adoc
@@ -27,7 +27,7 @@ Select the `Global` resource and look under the `spring.log` channel to see the 
 
 === Running on Google Cloud Platform
 
-Deploy to Google AppEngine:
+Deploy to App Engine:
 
 ----
 $ mvn clean package appengine:deploy -Dapp.deploy.projectId=$PROJECT_ID -Dapp.deploy.version=$VERSION

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/pom.xml
@@ -69,7 +69,6 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
-                <version>1.3.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/main/appengine/app.yaml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/main/appengine/app.yaml
@@ -1,9 +1,5 @@
-runtime: java
-env: flex
+runtime: java11
+instance_class: F1
 
-handlers:
-- url: /.*
-  script: this field is required, but ignored
-
-manual_scaling:
-  instances: 1
+env_variables:
+  JAVA_TOOL_OPTIONS: "-XX:MaxRAM=256m -XX:ActiveProcessorCount=2 -Xmx32m"

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/main/resources/application.properties
@@ -1,1 +1,3 @@
+# Set the port to the PORT environment variable
+server.port=${PORT:8080}
 spring.cloud.gcp.logging.enabled=true

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/pom.xml
@@ -32,4 +32,16 @@
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/pom.xml
@@ -47,6 +47,4 @@
     </dependency>
 
   </dependencies>
-
-
 </project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/README.adoc
@@ -53,10 +53,10 @@ $ curl -H "x-goog-iap-jwt-assertion: [JWK TOKEN]" localhost:8080/topsecret
 ----
 
 
-== Deploying the Sample to AppEngine Flexible
+== Deploying the Sample to AppEngine Standard
 
-The following Maven target will deploy this application to the root of your AppEngine Flexible instance:
+The following Maven target will deploy this application to the root of your AppEngine Standard instance:
 ----
-$ mvn appengine:deploy
+$ mvn clean package appengine:deploy -Dapp.deploy.projectId=$PROJECT_ID -Dapp.deploy.version=$VERSION
 ----
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
@@ -81,7 +81,6 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
-                <version>1.3.2</version>
             </plugin>
         </plugins>
     </build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/appengine/app.yaml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/src/main/appengine/app.yaml
@@ -1,15 +1,6 @@
-runtime: java
-env: flex
-
-handlers:
-- url: /.*
-  script: this field is required, but ignored
-
-manual_scaling:
-  instances: 1
-
-resources:
-  memory_gb: 4
+runtime: java11
+instance_class: F1
 
 env_variables:
   JAVA_OPTS: -Djava.security.egd=file:/dev/./urandom
+  JAVA_TOOL_OPTIONS: "-XX:MaxRAM=256m -XX:ActiveProcessorCount=2 -Xmx32m"

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/README.adoc
@@ -32,10 +32,10 @@ Additionally, if you logged in with the Google Cloud SDK or have the `GOOGLE_CLO
 Note that the trace transmission delay default value is 10 seconds, so it can take a little while for the traces to show up in the Trace List page.
 You can shorten this delay using the `spring.cloud.gcp.trace.scheduled-delay-seconds` property.
 
-== Deploy to App Engine Flexible Environment
+== Deploy to App Engine Standard Environment
 
-If you have Cloud SDK installed, https://cloud.google.com/appengine/docs/flexible/java/using-maven[Maven App Engine Plug-in] can be used to deploy the application to App Engine Flexible environment:
+If you have Cloud SDK installed, https://cloud.google.com/appengine/docs/standard/java11/testing-and-deploying-your-app[Maven App Engine Plug-in] can be used to deploy the application to App Engine Standard environment:
 
 ----
-$ mvn appengine:deploy
+$ mvn clean package appengine:deploy -Dapp.deploy.projectId=$PROJECT_ID -Dapp.deploy.version=$VERSION
 ----

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -87,7 +87,6 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
-                <version>1.3.2</version>
             </plugin>
         </plugins>
     </build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/appengine/app.yaml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/appengine/app.yaml
@@ -1,16 +1,5 @@
-runtime: java
-env: flex
+runtime: java11
+instance_class: F1
 
-handlers:
-- url: /.*
-  script: this field is required, but ignored
-
-manual_scaling:
-  instances: 1
-
-resources:
-  memory_gb: 4
-#env_variables:
-#  # on App Engine flexible environment, logging flush level must be the same as the log level
-#  # see: https://github.com/spring-cloud/spring-cloud-gcp/issues/1096
-#  STACKDRIVER_LOG_FLUSH_LEVEL: 'INFO'
+env_variables:
+  JAVA_TOOL_OPTIONS: "-XX:MaxRAM=256m -XX:ActiveProcessorCount=2 -Xmx32m"


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/1682

Two commits here:

1. Based on my preliminary research and a long discussion with the team yesterday around Maven plugins, I pulled the `spring-boot-maven-plugin` into the `spring-cloud-gcp-samples` parent POM. It looked like all modules under `spring-cloud-gcp-samples` were Spring Boot applications.
    * I also pulled up the `appengine-maven-plugin` into the parent POM's `pluginManagement` now that I understand what that element does. In this case, I'm setting the version in one spot. It also appears this plugin is also used in the top-level `spring-cloud-gcp` POM, where I also updated it to the latest version. Based on my understanding now of `plugin` vs `pluginManagement`, I wonder why this plugin is needed here?
    * I removed a few `maven-deploy-plugin`s too - it's my understanding that this is only needed if these are to be published, which I don't think our samples need to be. To add to that, the configurations all had `skip=true`, which means they weren't doing anything anyway (maybe this was done to explicitly _disable_ publishing?). I checked up the POM hierarchy and it doesn't appear that any parent POM applies this plugin (please doublecheck me on this though).


1. The second commit updates the 3 GAE Flex runnable samples to use GAE Standard with Java 11.  This was actually the driving force behind the first commit, as the JAR needs to be executable for GAE Standard, and the `spring-boot-maven-plugin` is what makes that happen (through a hook into the `package` goal).