### PR TITLE
Repair firestore.adoc file references

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -33,6 +33,7 @@
 |spring.cloud.gcp.firestore.credentials.encoded-key |  | 
 |spring.cloud.gcp.firestore.credentials.location |  | 
 |spring.cloud.gcp.firestore.credentials.scopes |  | 
+|spring.cloud.gcp.firestore.emulator.enabled | false | Enables autoconfiguration to use the Firestore emulator.
 |spring.cloud.gcp.firestore.enabled | true | Auto-configure Google Cloud Firestore components.
 |spring.cloud.gcp.firestore.host-port | firestore.googleapis.com:443 | The host and port of the Firestore emulator service; can be overridden to specify an emulator.
 |spring.cloud.gcp.firestore.project-id |  | 
@@ -97,6 +98,8 @@
 |spring.cloud.gcp.spanner.credentials.location |  | 
 |spring.cloud.gcp.spanner.credentials.scopes |  | 
 |spring.cloud.gcp.spanner.database |  | 
+|spring.cloud.gcp.spanner.emulator-host | localhost:9010 | 
+|spring.cloud.gcp.spanner.emulator.enabled | false | Enables auto-configuration to use the Spanner emulator.
 |spring.cloud.gcp.spanner.enabled | true | Auto-configure Google Cloud Spanner components.
 |spring.cloud.gcp.spanner.fail-if-pool-exhausted | false | 
 |spring.cloud.gcp.spanner.instance-id |  | 

--- a/docs/src/main/asciidoc/firestore.adoc
+++ b/docs/src/main/asciidoc/firestore.adoc
@@ -103,7 +103,7 @@ Spring Data Cloud Firestore allows you to map domain POJOs to https://firebase.g
 import com.google.cloud.firestore.annotation.DocumentId;
 import org.springframework.cloud.gcp.data.firestore.Document;
 
-include::{project-root}/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java[tag=class_definition]
+include::{project-root}/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/entities/User.java[tag=class_definition]
 ----
 
 `@Document(collectionName = "usersCollection")` annotation configures the collection name for the documents of this type.
@@ -122,7 +122,7 @@ Example:
 
 [source,java,indent=0]
 ----
-include::{project-root}/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/User.java[tag=embedded_class_collections]
+include::{project-root}/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/entities/User.java[tag=embedded_class_collections]
 ----
 
 === Reactive Repositories
@@ -134,7 +134,7 @@ For example:
 [source,java]
 ----
 
-include::{project-root}/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/it/UserRepository.java[tag=repository]
+include::{project-root}/spring-cloud-gcp-data-firestore/src/test/java/org/springframework/cloud/gcp/data/firestore/entities/UserRepository.java[tag=repository]
 
 ----
 


### PR DESCRIPTION
Repairs the firestore.adoc external file references. Some of these files were moved and we forgot to update the references from the docs.