### PR TITLE
Remove comments about secret-prefix from Secret Manager Sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -39,9 +39,7 @@ public class SecretManagerWebController {
 	@Autowired
 	private SecretManagerTemplate secretManagerTemplate;
 
-	// Application secrets can be accessed using @Value and passing in the secret name.
-	// Note that the secret name is prefixed with "secrets" because of the prefix setting in
-	// bootstrap.properties.
+	// Application secrets can be accessed using @Value and using the "sm://" syntax.
 	@Value("${sm://application-secret}")
 	private String appSecret;
 


### PR DESCRIPTION
The "secret-prefix" setting was removed in version 1.2.3 from the secret manager module.