### PR TITLE
Add DataSpannerTest annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 		<module>spring-cloud-gcp-bigquery</module>
 		<module>spring-cloud-gcp-security-firebase</module>
 		<module>spring-cloud-gcp-secretmanager</module>
+		<module>spring-cloud-gcp-test-support</module>
 	</modules>
 
 	<properties>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -80,6 +80,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-gcp-test-support</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-gcp-vision</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/spring-cloud-gcp-test-support/pom.xml
+++ b/spring-cloud-gcp-test-support/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-cloud-gcp</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>1.2.4.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-cloud-gcp-test-support</artifactId>
+	<name>Spring Cloud GCP Test Support</name>
+	<description>Spring Cloud GCP Test Support</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-test</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-test-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-gcp-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-gcp-data-spanner</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<optional>true</optional>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/AutoConfigureDataSpanner.java
+++ b/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/AutoConfigureDataSpanner.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+
+/**
+ * @author Eddú Meléndez
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureDataSpanner {
+}

--- a/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/DataSpannerTest.java
+++ b/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/DataSpannerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Eddú Meléndez
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@BootstrapWith(DataSpannerTestContextBootstrapper.class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(DataSpannerTypeExcludeFilter.class)
+@Transactional
+@AutoConfigureCache
+@AutoConfigureDataSpanner
+@ImportAutoConfiguration
+public @interface DataSpannerTest {
+
+	/**
+	 * Properties in form {@literal key=value} that should be added to the Spring
+	 * {@link Environment} before the test runs.
+	 * @return the properties to add
+	 */
+	String[] properties() default {};
+
+	/**
+	 * Determines if default filtering should be used with
+	 * {@link SpringBootApplication @SpringBootApplication}. By default no beans are
+	 * included.
+	 * @see #includeFilters()
+	 * @see #excludeFilters()
+	 * @return if default filters should be used
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * A set of include filters which can be used to add otherwise filtered beans to the
+	 * application context.
+	 * @return include filters to apply
+	 */
+	Filter[] includeFilters() default {};
+
+	/**
+	 * A set of exclude filters which can be used to filter beans that would otherwise be
+	 * added to the application context.
+	 * @return exclude filters to apply
+	 */
+	Filter[] excludeFilters() default {};
+
+	/**
+	 * Auto-configuration exclusions that should be applied for this test.
+	 * @return auto-configuration exclusions to apply
+	 */
+	@AliasFor(annotation = ImportAutoConfiguration.class, attribute = "exclude")
+	Class<?>[] excludeAutoConfiguration() default {};
+
+}

--- a/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/DataSpannerTestContextBootstrapper.java
+++ b/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/DataSpannerTestContextBootstrapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;
+
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
+
+/**
+ * @author Eddú Meléndez
+ */
+class DataSpannerTestContextBootstrapper extends SpringBootTestContextBootstrapper {
+
+	@Override
+	protected String[] getProperties(Class<?> testClass) {
+		return MergedAnnotations.from(testClass, SearchStrategy.INHERITED_ANNOTATIONS).get(DataSpannerTest.class)
+				.getValue("properties", String[].class).orElse(null);
+	}
+
+}

--- a/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/DataSpannerTypeExcludeFilter.java
+++ b/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/DataSpannerTypeExcludeFilter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;
+
+import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class DataSpannerTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeFilter<DataSpannerTest> {
+
+	DataSpannerTypeExcludeFilter(Class<?> testClass) {
+		super(testClass);
+	}
+
+}

--- a/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/package-info.java
+++ b/spring-cloud-gcp-test-support/src/main/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Data Spanner tests.
+ */
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;

--- a/spring-cloud-gcp-test-support/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-test-support/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,6 @@
+org.springframework.cloud.gcp.test.autoconfigure.data.spanner.AutoConfigureDataSpanner=\
+org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.spanner.GcpSpannerAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.spanner.GcpSpannerEmulatorAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.spanner.SpannerRepositoriesAutoConfiguration,\
+org.springframework.cloud.gcp.autoconfigure.spanner.SpannerTransactionManagerAutoConfiguration

--- a/spring-cloud-gcp-test-support/src/test/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/DataSpannerTestIntegrationTests.java
+++ b/spring-cloud-gcp-test-support/src/test/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/DataSpannerTestIntegrationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(SpringRunner.class)
+@DataSpannerTest(properties = {"spring.cloud.gcp.spanner.instance-id=test-instance",
+		"spring.cloud.gcp.spanner.database=test-database", "spring.cloud.gcp.spanner.emulator.enabled=true"})
+public class DataSpannerTestIntegrationTests {
+
+	@Autowired
+	private ExampleRepository exampleRepository;
+
+	@Test
+	public void test() {
+		ExampleEntity exampleEntity = new ExampleEntity(1L, "Java");
+		this.exampleRepository.save(exampleEntity);
+
+		Iterable<ExampleEntity> entities = this.exampleRepository.findAll();
+		assertThat(entities).hasSize(1);
+	}
+
+	@TestConfiguration
+	static class TestConfig {
+
+		@Bean
+		public CredentialsProvider credentialsProvider() {
+			return () -> mock(Credentials.class);
+		}
+	}
+}

--- a/spring-cloud-gcp-test-support/src/test/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/ExampleEntity.java
+++ b/spring-cloud-gcp-test-support/src/test/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/ExampleEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;
+
+import org.springframework.cloud.gcp.data.spanner.core.mapping.PrimaryKey;
+import org.springframework.cloud.gcp.data.spanner.core.mapping.Table;
+
+@Table(name = "TestTable")
+public class ExampleEntity {
+
+	@PrimaryKey
+	private Long key;
+
+	private String value;
+
+	public ExampleEntity(Long key, String value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	public Long getKey() {
+		return key;
+	}
+
+	public void setKey(Long key) {
+		this.key = key;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+}

--- a/spring-cloud-gcp-test-support/src/test/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/ExampleRepository.java
+++ b/spring-cloud-gcp-test-support/src/test/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/ExampleRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;
+
+import org.springframework.cloud.gcp.data.spanner.repository.SpannerRepository;
+
+public interface ExampleRepository extends SpannerRepository<ExampleEntity, String> {
+}

--- a/spring-cloud-gcp-test-support/src/test/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/SpannerTestApplication.java
+++ b/spring-cloud-gcp-test-support/src/test/java/org/springframework/cloud/gcp/test/autoconfigure/data/spanner/SpannerTestApplication.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.test.autoconfigure.data.spanner;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpannerTestApplication {
+}

--- a/spring-cloud-gcp-test-support/src/test/resources/application.properties
+++ b/spring-cloud-gcp-test-support/src/test/resources/application.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2020 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring.cloud.gcp.spanner.project-id=test-project


### PR DESCRIPTION
Currently [this](https://gist.github.com/eddumelendez/2a305ea223b4fd34aa69a27d667f4678) configuration is required in order to test a Spanner repository. This PR help to improve that configuration in some way.  But previously required some commands to be executed

```
gcloud config configurations create emulator

gcloud config set auth/disable_credentials true

gcloud config set project test-project

gcloud config set api_endpoint_overrides/spanner http://localhost:9020/

gcloud spanner instances create test-instance --config=emulator-config --description="Test Instance" --nodes=1

gcloud spanner databases create test-database --instance test-instance --ddl "CREATE TABLE TestTable (key INT64, value STRING(MAX)) PRIMARY KEY (key)"
```

In order to improve from the test perspective, I think https://github.com/spring-cloud/spring-cloud-gcp/pull/2357 will help a lot and may this proposal will do the same. Also would like to think about how these initiatives will integrate with `testcontainers`, for example, I have a PR https://github.com/testcontainers/testcontainers-java/pull/2690/files which will use docker sdk but it requires additional installation in order to use alpine images so [there is an issue](https://github.com/testcontainers/testcontainers-java/pull/2690/files) requesting images for the other emulators, something similar to spanner.

The same can be done for `datasotre`, `firestore` and I already have something in progress but looks pretty similar. Also, considering `pubsub` but thinking more about it.

See gh-2281