### PR TITLE
Switch Guava from Java7-supporting android version to Java8+ jre version

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -241,7 +241,7 @@ public class DefaultDatastoreEntityConverterTests {
 		this.thrown.expectMessage("Unable to read property boolField");
 		this.thrown.expectMessage(
 				"Unable to convert class " +
-				"com.google.common.collect.RegularImmutableList to class java.lang.Boolean");
+				"com.google.common.collect.SingletonImmutableList to class java.lang.Boolean");
 
 		Entity entity = getEntityBuilder()
 				.set("stringField", "string value")

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -19,10 +19,21 @@
 		<gcp-libraries-bom.version>5.3.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.0.16</cloud-sql-socket-factory.version>
 		<java-cfenv.version>1.1.3.RELEASE</java-cfenv.version>
+		<guava.version>29.0-jre</guava.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
+
+			<!-- Overriding Guava from libraries-bom; Spring Cloud GCP does not require Java 7 support -->
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava-bom</artifactId>
+				<version>${guava.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-gcp-core</artifactId>


### PR DESCRIPTION
Google Cloud BOM defaults to android version of Guava in order to support client libraries with Java7 minimum supported version ([details](https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM#guava-versions--jre-or--android)).

Spring applications from [Spring Framework v5.1](https://docs.spring.io/spring/docs/current/spring-framework-reference/overview.html) and [Spring Boot from version 2.3.0](https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started.html#getting-started-system-requirements) require Java8+, making it safe for Spring Cloud GCP to switch to guava-jre.

I ran all integration tests except Vision (something with credentials), so it's safe to merge.

Fixes spring-cloud/spring-cloud-gcp#2419