### PR TITLE
Fix incorrect package for java.time.Instant

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -469,7 +469,7 @@ Natively supported types:
 * `long[]`
 * `boolean[]`
 * `java.util.Date`
-* `java.util.Instant`
+* `java.time.Instant`
 * `java.sql.Date`
 * `java.time.LocalDate`
 * `java.time.LocalDateTime`


### PR DESCRIPTION
Fixes incorrect package name for Instant class. It should be java.time.Instant instead of java.util.Instant.