### PR TITLE
Add delete secret operation to SecretManagerTemplate

### DIFF
--- a/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerOperations.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerOperations.java
@@ -86,6 +86,21 @@ public interface SecretManagerOperations {
 	void createSecret(String secretId, byte[] payload, String projectId);
 
 	/**
+	 * Deletes the specified secret under the default-configured project.
+	 *
+	 * @param secretId the secret ID of the secret to delete.
+	 */
+	void deleteSecret(String secretId);
+
+	/**
+	 * Deletes the specified secret.
+	 *
+	 * @param secretId the secret ID of the secret to delete.
+	 * @param projectId the GCP project containing the secret to delete.
+	 */
+	void deleteSecret(String secretId, String projectId);
+
+	/**
 	 * Gets the secret payload of the specified {@code secretIdentifier} secret.
 	 *
 	 * <p>The {@code secretIdentifier} must either be a secret ID or a fully qualified

--- a/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplate.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplate.java
@@ -20,6 +20,7 @@ import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.secretmanager.v1beta1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1beta1.AddSecretVersionRequest;
 import com.google.cloud.secretmanager.v1beta1.CreateSecretRequest;
+import com.google.cloud.secretmanager.v1beta1.DeleteSecretRequest;
 import com.google.cloud.secretmanager.v1beta1.ProjectName;
 import com.google.cloud.secretmanager.v1beta1.Replication;
 import com.google.cloud.secretmanager.v1beta1.Secret;
@@ -100,6 +101,10 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 		return true;
 	}
 
+	public void deleteSecret(String secretId, String projectId) {
+		removeSecret(secretId, projectId);
+	}
+
 	ByteString getSecretByteString(String secretIdentifier) {
 		SecretVersionName secretVersionName =
 				SecretManagerPropertyUtils.getSecretVersionName(secretIdentifier, projectIdProvider);
@@ -163,5 +168,13 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 				.setSecret(secretId)
 				.setSecretVersion(LATEST_VERSION)
 				.build();
+	}
+
+	private void removeSecret(String secretId, String projectId) {
+		SecretName name = SecretName.of(projectId, secretId);
+		DeleteSecretRequest request = DeleteSecretRequest.newBuilder()
+				.setName(name.toString())
+				.build();
+		secretManagerServiceClient.deleteSecret(request);
 	}
 }

--- a/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplate.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplate.java
@@ -101,8 +101,18 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 		return true;
 	}
 
+	@Override
+	public void deleteSecret(String secretId) {
+		deleteSecret(secretId, this.projectIdProvider.getProjectId());
+	}
+
+	@Override
 	public void deleteSecret(String secretId, String projectId) {
-		removeSecret(secretId, projectId);
+		SecretName name = SecretName.of(projectId, secretId);
+		DeleteSecretRequest request = DeleteSecretRequest.newBuilder()
+				.setName(name.toString())
+				.build();
+		this.secretManagerServiceClient.deleteSecret(request);
 	}
 
 	ByteString getSecretByteString(String secretIdentifier) {
@@ -168,13 +178,5 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 				.setSecret(secretId)
 				.setSecretVersion(LATEST_VERSION)
 				.build();
-	}
-
-	private void removeSecret(String secretId, String projectId) {
-		SecretName name = SecretName.of(projectId, secretId);
-		DeleteSecretRequest request = DeleteSecretRequest.newBuilder()
-				.setName(name.toString())
-				.build();
-		secretManagerServiceClient.deleteSecret(request);
 	}
 }

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplateTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplateTests.java
@@ -20,6 +20,7 @@ import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.secretmanager.v1beta1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1beta1.AddSecretVersionRequest;
 import com.google.cloud.secretmanager.v1beta1.CreateSecretRequest;
+import com.google.cloud.secretmanager.v1beta1.DeleteSecretRequest;
 import com.google.cloud.secretmanager.v1beta1.Replication;
 import com.google.cloud.secretmanager.v1beta1.Secret;
 import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
@@ -180,6 +181,19 @@ public class SecretManagerTemplateTests {
 		assertThat(result).isEqualTo("get after it.");
 	}
 
+	@Test
+	public void testDeleteSecret() {
+		// This means that no previous secrets exist.
+		when(this.client.getSecret(any(SecretName.class))).thenThrow(NotFoundException.class);
+
+		this.secretManagerTemplate.createSecret("my-secret", "hello world!");
+
+		// Verify the secret is created correctly.
+		verifyCreateSecretRequest("my-secret", "my-project");
+		this.secretManagerTemplate.deleteSecret("my-secret", "my-project");
+		verifyDeleteSecretRequest("my-secret", "my-project");
+	}
+
 	private void verifyCreateSecretRequest(String secretId, String projectId) {
 		Secret secretToAdd = Secret.newBuilder()
 				.setReplication(
@@ -202,5 +216,13 @@ public class SecretManagerTemplateTests {
 				.setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(payload)))
 				.build();
 		verify(this.client).addSecretVersion(addSecretVersionRequest);
+	}
+
+	private void verifyDeleteSecretRequest(String secretId, String projectId) {
+		SecretName name = SecretName.of(projectId, secretId);
+		DeleteSecretRequest request = DeleteSecretRequest.newBuilder()
+				.setName(name.toString())
+				.build();
+		verify(this.client).deleteSecret(request);
 	}
 }

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplateTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplateTests.java
@@ -183,15 +183,11 @@ public class SecretManagerTemplateTests {
 
 	@Test
 	public void testDeleteSecret() {
-		// This means that no previous secrets exist.
-		when(this.client.getSecret(any(SecretName.class))).thenThrow(NotFoundException.class);
-
-		this.secretManagerTemplate.createSecret("my-secret", "hello world!");
-
-		// Verify the secret is created correctly.
-		verifyCreateSecretRequest("my-secret", "my-project");
-		this.secretManagerTemplate.deleteSecret("my-secret", "my-project");
+		this.secretManagerTemplate.deleteSecret("my-secret");
 		verifyDeleteSecretRequest("my-secret", "my-project");
+
+		this.secretManagerTemplate.deleteSecret("my-secret", "custom-project");
+		verifyDeleteSecretRequest("my-secret", "custom-project");
 	}
 
 	private void verifyCreateSecretRequest(String secretId, String projectId) {


### PR DESCRIPTION
Adding a delete Secrets method to simplify the process of deleting secrets. This is an additional method to beef up features for the spring secret manager service.