### PR TITLE
Replaced DatastoreTemplate with DatastoreOperations

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreOperations.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreOperations.java
@@ -24,12 +24,14 @@ import com.google.cloud.datastore.BaseEntity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 
+import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreEntityConverter;
 import org.springframework.data.domain.Example;
 
 /**
  * An interface of operations that can be done with Cloud Datastore.
  *
  * @author Chengyuan Zhao
+ * @author Vinicius Carvalho
  *
  * @since 1.1
  */
@@ -260,4 +262,23 @@ public interface DatastoreOperations {
 	 * @return result keys
 	 */
 	<T> Iterable<Key> keyQueryByExample(Example<T> example, DatastoreQueryOptions queryOptions);
+
+	/**
+	 * Get the {@link DatastoreEntityConverter} used by this template.
+	 * @return the converter.
+	 */
+	DatastoreEntityConverter getDatastoreEntityConverter();
+
+	/**
+	 * Finds objects by using a Cloud Datastore query. If the query is a key-query, then keys are
+	 * returned.
+	 * @param query the query to execute.
+	 * @param entityClass the type of object to retrieve.
+	 * @param <T> the type of object to retrieve.
+	 * @return a list of the objects found. If no keys could be found the list will be
+	 * empty.
+	 */
+	<T> DatastoreResultsIterable<?> queryKeysOrEntities(Query query, Class<T> entityClass);
+
+	<A, T> DatastoreResultsIterable<T> queryIterable(Query<A> query, Function<A, T> entityFunc);
 }

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreOperations.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreOperations.java
@@ -280,5 +280,14 @@ public interface DatastoreOperations {
 	 */
 	<T> DatastoreResultsIterable<?> queryKeysOrEntities(Query query, Class<T> entityClass);
 
+	/**
+	 * Runs given query and applies given function to each entity in the result.
+	 * @param query the query to run.
+	 * @param entityFunc the function to apply to each found entity or key.
+	 * @param <A> the row type of the query. This type can be either {@code Key} or a
+	 * Cloud Datastore entity.
+	 * @param <T> the type to map each entity or key to.
+	 * @return the mapped entities or keys.
+	 */
 	<A, T> DatastoreResultsIterable<T> queryIterable(Query<A> query, Function<A, T> entityFunc);
 }

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
@@ -88,6 +88,7 @@ import org.springframework.util.TypeUtils;
  * An implementation of {@link DatastoreOperations}.
  *
  * @author Chengyuan Zhao
+ * @author Vinicius Carvalho
  *
  * @since 1.1
  */
@@ -122,10 +123,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		this.objectToKeyFactory = objectToKeyFactory;
 	}
 
-	/**
-	 * Get the {@link DatastoreEntityConverter} used by this template.
-	 * @return the converter.
-	 */
+	@Override
 	public DatastoreEntityConverter getDatastoreEntityConverter() {
 		return this.datastoreEntityConverter;
 	}
@@ -261,15 +259,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 				: null;
 	}
 
-	/**
-	 * Finds objects by using a Cloud Datastore query. If the query is a key-query, then keys are
-	 * returned.
-	 * @param query the query to execute.
-	 * @param entityClass the type of object to retrieve.
-	 * @param <T> the type of object to retrieve.
-	 * @return a list of the objects found. If no keys could be found the list will be
-	 * empty.
-	 */
+	@Override
 	public <T> DatastoreResultsIterable<?> queryKeysOrEntities(Query query, Class<T> entityClass) {
 		QueryResults results = getDatastoreReadWriter().run(query);
 		DatastoreResultsIterable resultsIterable;
@@ -289,6 +279,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		return (List<T>) queryIterable(query, entityFunc).getIterable();
 	}
 
+	@Override
 	public <A, T> DatastoreResultsIterable<T> queryIterable(Query<A> query, Function<A, T> entityFunc) {
 		QueryResults<A> results = getDatastoreReadWriter().run(query);
 		List resultsList = new ArrayList();

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/AbstractDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/AbstractDatastoreQuery.java
@@ -40,15 +40,15 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
 
 	final DatastoreQueryMethod queryMethod;
 
-	final DatastoreOperations datastoreTemplate;
+	final DatastoreOperations datastoreOperations;
 
 	final Class<T> entityType;
 
 	public AbstractDatastoreQuery(DatastoreQueryMethod queryMethod,
-							DatastoreOperations datastoreTemplate,
+							DatastoreOperations datastoreOperations,
 			DatastoreMappingContext datastoreMappingContext, Class<T> entityType) {
 		this.queryMethod = queryMethod;
-		this.datastoreTemplate = datastoreTemplate;
+		this.datastoreOperations = datastoreOperations;
 		this.datastoreMappingContext = datastoreMappingContext;
 		this.entityType = entityType;
 	}
@@ -66,7 +66,7 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
 	 */
 	protected Object[] convertCollectionParamToCompatibleArray(List<?> param) {
 		List converted = param.stream()
-				.map((x) -> this.datastoreTemplate.getDatastoreEntityConverter().getConversions().convertOnWriteSingle(x)
+				.map((x) -> this.datastoreOperations.getDatastoreEntityConverter().getConversions().convertOnWriteSingle(x)
 						.get())
 				.collect(Collectors.toList());
 		return converted.toArray(
@@ -79,8 +79,8 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
 		return this.queryMethod.getResultProcessor().processResult(object);
 	}
 
-	public DatastoreOperations getDatastoreTemplate() {
-		return this.datastoreTemplate;
+	public DatastoreOperations getDatastoreOperations() {
+		return this.datastoreOperations;
 	}
 
 	boolean isPageQuery() {

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/AbstractDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/AbstractDatastoreQuery.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Array;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
+import org.springframework.cloud.gcp.data.datastore.core.DatastoreOperations;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
@@ -40,12 +40,12 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
 
 	final DatastoreQueryMethod queryMethod;
 
-	final DatastoreTemplate datastoreTemplate;
+	final DatastoreOperations datastoreTemplate;
 
 	final Class<T> entityType;
 
 	public AbstractDatastoreQuery(DatastoreQueryMethod queryMethod,
-			DatastoreTemplate datastoreTemplate,
+							DatastoreOperations datastoreTemplate,
 			DatastoreMappingContext datastoreMappingContext, Class<T> entityType) {
 		this.queryMethod = queryMethod;
 		this.datastoreTemplate = datastoreTemplate;
@@ -79,7 +79,7 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
 		return this.queryMethod.getResultProcessor().processResult(object);
 	}
 
-	public DatastoreTemplate getDatastoreTemplate() {
+	public DatastoreOperations getDatastoreTemplate() {
 		return this.datastoreTemplate;
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/DatastoreQueryLookupStrategy.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/DatastoreQueryLookupStrategy.java
@@ -39,24 +39,24 @@ import org.springframework.util.Assert;
  */
 public class DatastoreQueryLookupStrategy implements QueryLookupStrategy {
 
-	private final DatastoreOperations datastoreTemplate;
+	private final DatastoreOperations datastoreOperations;
 
 	private final DatastoreMappingContext datastoreMappingContext;
 
 	private QueryMethodEvaluationContextProvider evaluationContextProvider;
 
 	public DatastoreQueryLookupStrategy(DatastoreMappingContext datastoreMappingContext,
-										DatastoreOperations datastoreTemplate,
+			DatastoreOperations datastoreOperations,
 			QueryMethodEvaluationContextProvider evaluationContextProvider) {
 		Assert.notNull(datastoreMappingContext,
 				"A non-null DatastoreMappingContext is required.");
-		Assert.notNull(datastoreTemplate,
+		Assert.notNull(datastoreOperations,
 				"A non-null DatastoreOperations is required.");
 		Assert.notNull(evaluationContextProvider,
 				"A non-null EvaluationContextProvider is required.");
 		this.datastoreMappingContext = datastoreMappingContext;
 		this.evaluationContextProvider = evaluationContextProvider;
-		this.datastoreTemplate = datastoreTemplate;
+		this.datastoreOperations = datastoreOperations;
 	}
 
 	@Override
@@ -74,13 +74,13 @@ public class DatastoreQueryLookupStrategy implements QueryLookupStrategy {
 			return createGqlDatastoreQuery(entityType, queryMethod, sql);
 		}
 
-		return new PartTreeDatastoreQuery<>(queryMethod, this.datastoreTemplate,
+		return new PartTreeDatastoreQuery<>(queryMethod, this.datastoreOperations,
 				this.datastoreMappingContext, entityType, projectionFactory);
 	}
 
 	<T> GqlDatastoreQuery<T> createGqlDatastoreQuery(Class<T> entityType,
 			DatastoreQueryMethod queryMethod, String gql) {
-		return new GqlDatastoreQuery<>(entityType, queryMethod, this.datastoreTemplate,
+		return new GqlDatastoreQuery<>(entityType, queryMethod, this.datastoreOperations,
 				gql, this.evaluationContextProvider,
 				this.datastoreMappingContext);
 	}

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/DatastoreQueryLookupStrategy.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/DatastoreQueryLookupStrategy.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.gcp.data.datastore.repository.query;
 import java.lang.reflect.Method;
 
 
-import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
+import org.springframework.cloud.gcp.data.datastore.core.DatastoreOperations;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.NamedQueries;
@@ -39,14 +39,14 @@ import org.springframework.util.Assert;
  */
 public class DatastoreQueryLookupStrategy implements QueryLookupStrategy {
 
-	private final DatastoreTemplate datastoreTemplate;
+	private final DatastoreOperations datastoreTemplate;
 
 	private final DatastoreMappingContext datastoreMappingContext;
 
 	private QueryMethodEvaluationContextProvider evaluationContextProvider;
 
 	public DatastoreQueryLookupStrategy(DatastoreMappingContext datastoreMappingContext,
-			DatastoreTemplate datastoreTemplate,
+										DatastoreOperations datastoreTemplate,
 			QueryMethodEvaluationContextProvider evaluationContextProvider) {
 		Assert.notNull(datastoreMappingContext,
 				"A non-null DatastoreMappingContext is required.");

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQuery.java
@@ -36,8 +36,8 @@ import com.google.cloud.datastore.GqlQuery;
 import com.google.cloud.datastore.GqlQuery.Builder;
 import com.google.cloud.datastore.Key;
 
+import org.springframework.cloud.gcp.data.datastore.core.DatastoreOperations;
 import org.springframework.cloud.gcp.data.datastore.core.DatastoreResultsIterable;
-import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
 import org.springframework.cloud.gcp.data.datastore.core.convert.DatastoreNativeTypes;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreDataException;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
@@ -97,9 +97,9 @@ public class GqlDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 	 * @param datastoreMappingContext used for getting metadata about entities.
 	 */
 	public GqlDatastoreQuery(Class<T> type, DatastoreQueryMethod queryMethod,
-			DatastoreTemplate datastoreTemplate, String gql,
-			QueryMethodEvaluationContextProvider evaluationContextProvider,
-			DatastoreMappingContext datastoreMappingContext) {
+							DatastoreOperations datastoreTemplate, String gql,
+							QueryMethodEvaluationContextProvider evaluationContextProvider,
+							DatastoreMappingContext datastoreMappingContext) {
 		super(queryMethod, datastoreTemplate, datastoreMappingContext, type);
 		this.evaluationContextProvider = evaluationContextProvider;
 		this.originalGql = StringUtils.trimTrailingCharacter(gql.trim(), ';');

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactory.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactory.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.gcp.data.datastore.repository.support;
 import java.util.Optional;
 
 import org.springframework.beans.BeansException;
-import org.springframework.cloud.gcp.data.datastore.core.DatastoreTemplate;
+import org.springframework.cloud.gcp.data.datastore.core.DatastoreOperations;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastoreMappingContext;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastorePersistentEntity;
 import org.springframework.cloud.gcp.data.datastore.core.mapping.DatastorePersistentEntityInformation;
@@ -54,7 +54,7 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 
 	private final DatastoreMappingContext datastoreMappingContext;
 
-	private final DatastoreTemplate datastoreTemplate;
+	private final DatastoreOperations datastoreTemplate;
 
 	private ApplicationContext applicationContext;
 
@@ -66,7 +66,7 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 	 * repositories.
 	 */
 	DatastoreRepositoryFactory(DatastoreMappingContext datastoreMappingContext,
-			DatastoreTemplate datastoreTemplate) {
+							DatastoreOperations datastoreTemplate) {
 		Assert.notNull(datastoreMappingContext,
 				"A non-null Datastore mapping context is required.");
 		Assert.notNull(datastoreTemplate,

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactory.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactory.java
@@ -54,7 +54,7 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 
 	private final DatastoreMappingContext datastoreMappingContext;
 
-	private final DatastoreOperations datastoreTemplate;
+	private final DatastoreOperations datastoreOperations;
 
 	private ApplicationContext applicationContext;
 
@@ -62,17 +62,17 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 	 * Constructor.
 	 * @param datastoreMappingContext the mapping context used to get mapping metadata for
 	 * entity types.
-	 * @param datastoreTemplate the Datastore operations object used by Datastore
+	 * @param datastoreOperations the Datastore operations object used by Datastore
 	 * repositories.
 	 */
 	DatastoreRepositoryFactory(DatastoreMappingContext datastoreMappingContext,
-							DatastoreOperations datastoreTemplate) {
+			DatastoreOperations datastoreOperations) {
 		Assert.notNull(datastoreMappingContext,
 				"A non-null Datastore mapping context is required.");
-		Assert.notNull(datastoreTemplate,
+		Assert.notNull(datastoreOperations,
 				"A non-null Datastore template object is required.");
 		this.datastoreMappingContext = datastoreMappingContext;
-		this.datastoreTemplate = datastoreTemplate;
+		this.datastoreOperations = datastoreOperations;
 	}
 
 	@Override
@@ -92,7 +92,7 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 
 	@Override
 	protected Object getTargetRepository(RepositoryInformation metadata) {
-		return getTargetRepositoryViaReflection(metadata, this.datastoreTemplate,
+		return getTargetRepositoryViaReflection(metadata, this.datastoreOperations,
 				metadata.getDomainType());
 	}
 
@@ -106,7 +106,7 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 			QueryMethodEvaluationContextProvider evaluationContextProvider) {
 
 		return Optional.of(new DatastoreQueryLookupStrategy(this.datastoreMappingContext,
-				this.datastoreTemplate,
+				this.datastoreOperations,
 				delegateContextProvider(evaluationContextProvider)));
 	}
 


### PR DESCRIPTION
Fixes #2436 

Replaced ocurrences of DatastoreTemplate to use interface DatastoreOperations. Had to pull up 3 methods into interface, but all of them are using the same types as any other method in the interface.

Note: Master build is failing, therefore I could not validate all tests, for what I can tell the data-datastore tests passes along with checkstyle and so does the autoconfigure tests and integration with emulator. But master is failing as of now.