### PR TITLE
Adjust SecretManagerOperations Parameter Ordering

### DIFF
--- a/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerOperations.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerOperations.java
@@ -97,10 +97,10 @@ public interface SecretManagerOperations {
 	 * Enables the secret version under the specified project.
 	 *
 	 * @param secretId the secret ID of the secret to delete.
-	 * @param projectId unique identifier of your project.
 	 * @param version the version to enable
+	 * @param projectId unique identifier of your project.
 	 */
-	void enableSecretVersion(String secretId, String projectId, String version);
+	void enableSecretVersion(String secretId, String version, String projectId);
 
 	/**
 	 * Disables the specified secret version under the default-configured project.
@@ -114,10 +114,10 @@ public interface SecretManagerOperations {
 	 * Disables the secret version under the specified project.
 	 *
 	 * @param secretId the secret ID of the secret to disable.
-	 * @param projectId unique identifier of your project.
 	 * @param version the version to enable
+	 * @param projectId unique identifier of your project.
 	 */
-	void disableSecretVersion(String secretId, String projectId, String version);
+	void disableSecretVersion(String secretId, String version, String projectId);
 
 	/**
 	 * Deletes the specified secret under the default-configured project.
@@ -138,10 +138,10 @@ public interface SecretManagerOperations {
 	 * Deletes the specified secret.
 	 *
 	 * @param secretId the secret ID of the secret to delete.
-	 * @param projectId the GCP project containing the secret to delete.
 	 * @param version the version to delete
+	 * @param projectId the GCP project containing the secret to delete.
 	 */
-	void deleteSecretVersion(String secretId, String projectId, String version);
+	void deleteSecretVersion(String secretId, String version, String projectId);
 
 	/**
 	 * Gets the secret payload of the specified {@code secretIdentifier} secret.

--- a/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerOperations.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerOperations.java
@@ -88,7 +88,7 @@ public interface SecretManagerOperations {
 	/**
 	 * Enables the specified secret version under the default-configured project.
 	 *
-	 * @param secretId the secret ID of the secret to delete.
+	 * @param secretId the secret ID of the secret to enable.
 	 * @param version the version to enable
 	 */
 	void enableSecretVersion(String secretId, String version);
@@ -96,7 +96,7 @@ public interface SecretManagerOperations {
 	/**
 	 * Enables the secret version under the specified project.
 	 *
-	 * @param secretId the secret ID of the secret to delete.
+	 * @param secretId the secret ID of the secret to enable.
 	 * @param version the version to enable
 	 * @param projectId unique identifier of your project.
 	 */
@@ -106,7 +106,7 @@ public interface SecretManagerOperations {
 	 * Disables the specified secret version under the default-configured project.
 	 *
 	 * @param secretId the secret ID of the secret to disable.
-	 * @param version the version to enable
+	 * @param version the version to disable
 	 */
 	void disableSecretVersion(String secretId, String version);
 
@@ -114,7 +114,7 @@ public interface SecretManagerOperations {
 	 * Disables the secret version under the specified project.
 	 *
 	 * @param secretId the secret ID of the secret to disable.
-	 * @param version the version to enable
+	 * @param version the version to disable
 	 * @param projectId unique identifier of your project.
 	 */
 	void disableSecretVersion(String secretId, String version, String projectId);
@@ -135,7 +135,7 @@ public interface SecretManagerOperations {
 	void deleteSecret(String secretId, String projectId);
 
 	/**
-	 * Deletes the specified secret.
+	 * Deletes the specified secret version.
 	 *
 	 * @param secretId the secret ID of the secret to delete.
 	 * @param version the version to delete

--- a/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplate.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplate.java
@@ -103,11 +103,11 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 
 	@Override
 	public void disableSecretVersion(String secretId, String version) {
-		disableSecretVersion(secretId, this.projectIdProvider.getProjectId(), version);
+		disableSecretVersion(secretId, version, this.projectIdProvider.getProjectId());
 	}
 
 	@Override
-	public void disableSecretVersion(String secretId, String projectId, String version) {
+	public void disableSecretVersion(String secretId, String version, String projectId) {
 		SecretVersionName secretVersionName = SecretVersionName.newBuilder()
 				.setProject(projectId)
 				.setSecret(secretId)
@@ -118,11 +118,11 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 
 	@Override
 	public void enableSecretVersion(String secretId, String version) {
-		enableSecretVersion(secretId, this.projectIdProvider.getProjectId(), version);
+		enableSecretVersion(secretId, version, this.projectIdProvider.getProjectId());
 	}
 
 	@Override
-	public void enableSecretVersion(String secretId, String projectId, String version) {
+	public void enableSecretVersion(String secretId, String version, String projectId) {
 		SecretVersionName secretVersionName = SecretVersionName.newBuilder()
 				.setProject(projectId)
 				.setSecret(secretId)
@@ -146,7 +146,7 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 	}
 
 	@Override
-	public void deleteSecretVersion(String secretId, String projectId, String version) {
+	public void deleteSecretVersion(String secretId, String version, String projectId) {
 		SecretVersionName secretVersionName = SecretVersionName.newBuilder()
 				.setProject(projectId)
 				.setSecret(secretId)

--- a/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplateTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/org/springframework/cloud/gcp/secretmanager/SecretManagerTemplateTests.java
@@ -184,10 +184,10 @@ public class SecretManagerTemplateTests {
 	@Test
 	public void testEnableSecretVersion() {
 		this.secretManagerTemplate.enableSecretVersion("my-secret", "1");
-		verifyEnableSecretVersionRequest("my-secret", "my-project", "1");
+		verifyEnableSecretVersionRequest("my-secret", "1", "my-project");
 
-		this.secretManagerTemplate.enableSecretVersion("my-secret", "custom-project", "1");
-		verifyEnableSecretVersionRequest("my-secret", "custom-project", "1");
+		this.secretManagerTemplate.enableSecretVersion("my-secret", "1", "custom-project");
+		verifyEnableSecretVersionRequest("my-secret", "1", "custom-project");
 	}
 
 	@Test
@@ -201,17 +201,17 @@ public class SecretManagerTemplateTests {
 
 	@Test
 	public void testDeleteSecretVersion() {
-		this.secretManagerTemplate.deleteSecretVersion("my-secret", "custom-project", "10");
-		verifyDeleteSecretVersionRequest("my-secret", "custom-project", "10");
+		this.secretManagerTemplate.deleteSecretVersion("my-secret", "10", "custom-project");
+		verifyDeleteSecretVersionRequest("my-secret", "10", "custom-project");
 	}
 
 	@Test
 	public void testDisableSecretVersion() {
 		this.secretManagerTemplate.disableSecretVersion("my-secret", "1");
-		verifyDisableSecretVersionRequest("my-secret", "my-project", "1");
+		verifyDisableSecretVersionRequest("my-secret", "1", "my-project");
 
-		this.secretManagerTemplate.disableSecretVersion("my-secret", "custom-project", "1");
-		verifyDisableSecretVersionRequest("my-secret", "custom-project", "1");
+		this.secretManagerTemplate.disableSecretVersion("my-secret", "1", "custom-project");
+		verifyDisableSecretVersionRequest("my-secret", "1", "custom-project");
 	}
 
 	private void verifyCreateSecretRequest(String secretId, String projectId) {
@@ -238,7 +238,7 @@ public class SecretManagerTemplateTests {
 		verify(this.client).addSecretVersion(addSecretVersionRequest);
 	}
 
-	private void verifyEnableSecretVersionRequest(String secretId, String projectId, String version) {
+	private void verifyEnableSecretVersionRequest(String secretId, String version, String projectId) {
 		SecretVersionName secretVersionName = SecretVersionName.newBuilder()
 				.setProject(projectId)
 				.setSecret(secretId)
@@ -255,7 +255,7 @@ public class SecretManagerTemplateTests {
 		verify(this.client).deleteSecret(request);
 	}
 
-	private void verifyDeleteSecretVersionRequest(String secretId, String projectId, String version) {
+	private void verifyDeleteSecretVersionRequest(String secretId, String version, String projectId) {
 		SecretVersionName secretVersionName = SecretVersionName.newBuilder()
 				.setProject(projectId)
 				.setSecret(secretId)
@@ -264,7 +264,7 @@ public class SecretManagerTemplateTests {
 		verify(this.client).destroySecretVersion(secretVersionName);
 	}
 
-	private void verifyDisableSecretVersionRequest(String secretId, String projectId, String version) {
+	private void verifyDisableSecretVersionRequest(String secretId, String version, String projectId) {
 		SecretVersionName secretVersionName = SecretVersionName.newBuilder()
 				.setProject(projectId)
 				.setSecret(secretId)


### PR DESCRIPTION
For the new methods introduced `enableSecretVersion`, `disableSecretVersion`, and `deleteSecretVersion` I adjusted the parameter order to move the `projectId` to the end of the parameter list. This makes things consistent with our other methods which introduced `projectId`.

cc/ @kioie 