### PR TITLE
Allow null bindings in Spanner Repository Queries

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/SpannerStatementQueryExecutor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/SpannerStatementQueryExecutor.java
@@ -362,7 +362,7 @@ public final class SpannerStatementQueryExecutor {
 			Function<Object, Struct> paramStructConvertFunc, SpannerCustomConverter spannerCustomConverter,
 			Object originalParam, Parameter paramMetadata) {
 
-	  // Gets the type of the bind parameter; if null then infer the type from the parameter metadata.
+		// Gets the type of the bind parameter; if null then infer the type from the parameter metadata.
 		Class<?> parameterClass = originalParam != null
 				? originalParam.getClass() : paramMetadata.getType();
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/SqlSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/SqlSpannerQuery.java
@@ -199,13 +199,12 @@ public class SqlSpannerQuery<T> extends AbstractSpannerQuery<T> {
 		Sort sort = null;
 
 		for (Object param : parameters) {
-			Class<?> paramClass = param.getClass();
-			if (isPageableOrSort(paramClass)) {
+			if (param != null && isPageableOrSort(param.getClass())) {
 				if (pageable != null || sort != null) {
 					throw new SpannerDataException(
 							"Only a single Pageable or Sort param is allowed.");
 				}
-				else if (Pageable.class.isAssignableFrom(paramClass)) {
+				else if (Pageable.class.isAssignableFrom(param.getClass())) {
 						pageable = (Pageable) param;
 				}
 				else {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -39,6 +39,8 @@ import org.springframework.cloud.gcp.data.spanner.core.SpannerTemplate;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.SpannerMappingContext;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.SpannerPersistentEntity;
 import org.springframework.cloud.gcp.data.spanner.test.AbstractSpannerIntegrationTest;
+import org.springframework.cloud.gcp.data.spanner.test.domain.Singer;
+import org.springframework.cloud.gcp.data.spanner.test.domain.SingerRepository;
 import org.springframework.cloud.gcp.data.spanner.test.domain.SubTrade;
 import org.springframework.cloud.gcp.data.spanner.test.domain.SubTradeComponent;
 import org.springframework.cloud.gcp.data.spanner.test.domain.SubTradeComponentRepository;
@@ -71,6 +73,9 @@ import static org.mockito.ArgumentMatchers.eq;
  */
 @RunWith(SpringRunner.class)
 public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegrationTest {
+
+	@Autowired
+	SingerRepository singerRepository;
 
 	@Autowired
 	TradeRepository tradeRepository;
@@ -400,6 +405,13 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 			// expected exception that causes roll-back;
 		}
 		assertThat(this.tradeRepository.count()).isEqualTo(0L);
+	}
+
+	@Test
+	public void testDmlStatement_nullColumn() {
+		this.singerRepository.insert("123", null);
+		Singer singer = this.singerRepository.findById("123").get();
+		assertThat(singer.getName()).isNull();
 	}
 
 	private void arrayParameterBindTest() {

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/AbstractSpannerIntegrationTest.java
@@ -32,6 +32,7 @@ import org.springframework.cloud.gcp.data.spanner.core.admin.SpannerDatabaseAdmi
 import org.springframework.cloud.gcp.data.spanner.core.admin.SpannerSchemaUtils;
 import org.springframework.cloud.gcp.data.spanner.core.mapping.SpannerMappingContext;
 import org.springframework.cloud.gcp.data.spanner.test.domain.CommitTimestamps;
+import org.springframework.cloud.gcp.data.spanner.test.domain.Singer;
 import org.springframework.cloud.gcp.data.spanner.test.domain.Trade;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -144,6 +145,7 @@ public abstract class AbstractSpannerIntegrationTest {
 	protected List<String> createSchemaStatements() {
 		List<String> list = new ArrayList<>(this.spannerSchemaUtils
 				.getCreateTableDdlStringsForInterleavedHierarchy(Trade.class));
+		list.add(this.spannerSchemaUtils.getCreateTableDdlString(Singer.class));
 		list.add(this.spannerSchemaUtils
 				.getCreateTableDdlString(CommitTimestamps.class)
 				.replaceAll("TIMESTAMP", "TIMESTAMP OPTIONS (allow_commit_timestamp = true)"));
@@ -153,6 +155,7 @@ public abstract class AbstractSpannerIntegrationTest {
 	protected Iterable<String> dropSchemaStatements() {
 		List<String> list = new ArrayList<>(this.spannerSchemaUtils
 				.getDropTableDdlStringsForInterleavedHierarchy(Trade.class));
+		list.add(this.spannerSchemaUtils.getDropTableDdlString(Singer.class));
 		list.add(this.spannerSchemaUtils
 				.getDropTableDdlString(CommitTimestamps.class));
 		return list;

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/Singer.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/Singer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.spanner.test.domain;
+
+import org.springframework.cloud.gcp.data.spanner.core.mapping.PrimaryKey;
+import org.springframework.cloud.gcp.data.spanner.core.mapping.Table;
+
+/**
+ * Simple Entity for Spanner integration testing.
+ *
+ * @author Daniel Zou
+ */
+@Table(name = "#{'singer_'.concat(tableNameSuffix)}")
+public class Singer {
+
+	@PrimaryKey
+	private String id;
+
+	private String name;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/SingerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/org/springframework/cloud/gcp/data/spanner/test/domain/SingerRepository.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gcp.data.spanner.test.domain;
+
+import org.springframework.cloud.gcp.data.spanner.repository.SpannerRepository;
+import org.springframework.cloud.gcp.data.spanner.repository.query.Query;
+
+/**
+ * Spanner Repository for the {@link Singer} object.
+ *
+ * @author Daniel Zou
+ */
+public interface SingerRepository extends SpannerRepository<Singer, String> {
+
+	@Query(
+			dmlStatement = true,
+			value = "INSERT INTO "
+					+ ":org.springframework.cloud.gcp.data.spanner.test.domain.Singer: (id, name)"
+					+ "VALUES (@singerId, @name)")
+	void insert(String singerId, String name);
+}


### PR DESCRIPTION
Allows for the value of `null` to be bound as a variable in a Spanner query.

Fixes #2443.