### PR TITLE
Double the wait for log retrieval

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
@@ -131,7 +131,7 @@ public class TraceSampleApplicationTests {
 		String logFilter = String.format(
 				"trace=projects/%s/traces/%s", this.projectIdProvider.getProjectId(), uuidString);
 
-		await().atMost(120, TimeUnit.SECONDS)
+		await().atMost(240, TimeUnit.SECONDS)
 				.pollInterval(Duration.TWO_SECONDS)
 				.ignoreExceptions()
 				.untilAsserted(() -> {


### PR DESCRIPTION
Logging retrieval seems to take longer than 2 minutes now. The odd thing is that I can query for the same filter string in the UI, and it shows up almost instantly.

Let's see if this deflakes the test (I was able to reproduce the issue some of the time but not 100% of the time on my machine with the 2 minute timeout).