### PR TITLE
Control sync/async publish in Spring Cloud Stream binder

### DIFF
--- a/docs/src/main/asciidoc/spring-stream.adoc
+++ b/docs/src/main/asciidoc/spring-stream.adoc
@@ -40,6 +40,10 @@ If you are using Pub/Sub auto-configuration from the Spring Cloud GCP Pub/Sub St
 
 NOTE: To use this binder with a https://cloud.google.com/pubsub/docs/emulator[running emulator], configure its host and port via `spring.cloud.gcp.pubsub.emulator-host`.
 
+==== Producer Synchronous Sending Configuration
+By default, this binder will send messages to Cloud Pub/Sub asynchronously.
+If synchronous sending is preferred (for example, to allow propagating errors back to the sender), set `spring.cloud.stream.gcp.pubsub.default.producer.sync` property to `true`.
+
 ==== Producer Destination Configuration
 
 If automatic resource creation is turned ON and the topic corresponding to the destination name does not exist, it will be created.

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -73,6 +73,7 @@ public class PubSubMessageChannelBinder
 
 		PubSubMessageHandler messageHandler = new PubSubMessageHandler(this.pubSubTemplate, destination.getName());
 		messageHandler.setBeanFactory(getBeanFactory());
+		messageHandler.setSync(producerProperties.getExtension().isSync());
 		return messageHandler;
 	}
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
@@ -24,4 +24,13 @@ package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
  * @author Chengyuan Zhao
  */
 public class PubSubProducerProperties extends PubSubCommonProperties {
+	private boolean sync;
+
+	public boolean isSync() {
+		return sync;
+	}
+
+	public void setSync(boolean sync) {
+		this.sync = sync;
+	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/properties/PubSubProducerProperties.java
@@ -22,9 +22,10 @@ package org.springframework.cloud.gcp.stream.binder.pubsub.properties;
  * @author João André Martins
  * @author Daniel Zou
  * @author Chengyuan Zhao
+ * @author Elena Felder
  */
 public class PubSubProducerProperties extends PubSubCommonProperties {
-	private boolean sync;
+	private boolean sync = false;
 
 	public boolean isSync() {
 		return sync;


### PR DESCRIPTION
Expose the Spring Integration `PubSubMessageHandler`'s `sync` property via extended binder properties. Turning async mode off is useful when errors must be exposed to sender.

There is currently no way to force synchronous sending through Cloud Pub/Sub Spring Cloud Stream binder.