### PR TITLE
Install Linkage Checker enforcer rule for the spring-cloud-gcp-dependencies BOM

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx1024m -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx3g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx3g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx4g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx4g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx4g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
       ./mvnw test -B -P codecov ${INTEGRATION_TEST_FLAGS} && bash <(curl -s https://codecov.io/bash) -F integration;
     fi;
 install:
-  - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -P full-checkstyle -B -V
+  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -P full-checkstyle -B -V
 before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -248,7 +248,7 @@
 					<dependency>
 						<groupId>com.google.cloud.tools</groupId>
 						<artifactId>linkage-checker-enforcer-rules</artifactId>
-						<version>1.4.0</version>
+						<version>1.5.0</version>
 					</dependency>
 				</dependencies>
 				<executions>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -263,8 +263,8 @@
 							<rules>
 								<LinkageCheckerRule
 										implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
-									<dependencySection>DEPENDENCY_MANAGEMENT
-									</dependencySection>
+									<dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
+									<reportOnlyReachable>true</reportOnlyReachable>
 								</LinkageCheckerRule>
 							</rules>
 						</configuration>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -236,6 +237,42 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.google.cloud.tools</groupId>
+						<artifactId>linkage-checker-enforcer-rules</artifactId>
+						<version>1.4.0</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>enforce-linkage-checker</id>
+						<!-- Important! Should run after compile -->
+						<phase>verify</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<LinkageCheckerRule
+										implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+									<dependencySection>DEPENDENCY_MANAGEMENT
+									</dependencySection>
+								</LinkageCheckerRule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 	<profiles>
 		<profile>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>


### PR DESCRIPTION
This is a followup of #1658 

- Linkage Checker Enforcer rule 1.5.0
- Increase of JVM to 2GB heap
- Setting `reportOnlyReachable` to only see reachable linkage errors. (Otherwise you'll see 22,000 lines of linkage errors: https://gist.github.com/suztomo/b73c69e5b769108a62657bb84fd0203a)
