### PR TITLE
Install Linkage Checker for spring-cloud-gcp-dependencies BOM

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx1024m -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx3g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx3g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx4g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx4g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx4g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,10 @@ script:
   - if [ "$INTEGRATION_TEST_FLAGS" != "" ]; then
       ./mvnw test -B -P codecov ${INTEGRATION_TEST_FLAGS} && bash <(curl -s https://codecov.io/bash) -F integration;
     fi;
+  # run enforcer rules
+  - ./mvnw -T 1.5C verify -DskipTests=true -Dspring.profiles.active=spring -B -V -P full-checkstyle
 install:
-  - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -P full-checkstyle -B -V
+  - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -Denforcer.skip=true -B -V
 before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ script:
   - if [ "$INTEGRATION_TEST_FLAGS" != "" ]; then
       ./mvnw test -B -P codecov ${INTEGRATION_TEST_FLAGS} && bash <(curl -s https://codecov.io/bash) -F integration;
     fi;
-  # run enforcer rules
-  - ./mvnw -T 1.5C verify -DskipTests=true -Dspring.profiles.active=spring -B -V -P full-checkstyle
 install:
+  # run enforcer rules separate from 'install' as it interferes with Linkage Checker. 
+  - ./mvnw -T 1.5C verify -DskipTests=true -Dspring.profiles.active=spring -B -V -P full-checkstyle
   - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -Denforcer.skip=true -B -V
 before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
       ./mvnw test -B -P codecov ${INTEGRATION_TEST_FLAGS} && bash <(curl -s https://codecov.io/bash) -F integration;
     fi;
 install:
-  # run enforcer rules separate from 'install' as it interferes with Linkage Checker. 
+  # run enforcer rules separate from 'install' as 'install' interferes with Linkage Checker.
   - ./mvnw -T 1.5C verify -DskipTests=true -Dspring.profiles.active=spring -B -V -P full-checkstyle
   - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -Denforcer.skip=true -B -V
 before_install:

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -248,7 +248,7 @@
 					<dependency>
 						<groupId>com.google.cloud.tools</groupId>
 						<artifactId>linkage-checker-enforcer-rules</artifactId>
-						<version>1.4.0</version>
+						<version>1.5.0</version>
 					</dependency>
 				</dependencies>
 				<executions>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -263,8 +263,8 @@
 							<rules>
 								<LinkageCheckerRule
 										implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
-									<dependencySection>DEPENDENCY_MANAGEMENT
-									</dependencySection>
+									<dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
+									<reportOnlyReachable>true</reportOnlyReachable>
 								</LinkageCheckerRule>
 							</rules>
 						</configuration>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -236,6 +237,42 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.google.cloud.tools</groupId>
+						<artifactId>linkage-checker-enforcer-rules</artifactId>
+						<version>1.4.0</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>enforce-linkage-checker</id>
+						<!-- Important! Should run after compile -->
+						<phase>verify</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<LinkageCheckerRule
+										implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+									<dependencySection>DEPENDENCY_MANAGEMENT
+									</dependencySection>
+								</LinkageCheckerRule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 	<profiles>
 		<profile>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -253,7 +253,7 @@
 				<executions>
 					<execution>
 						<id>enforce-linkage-checker</id>
-						<!-- Important! Should run after compile -->
+						<!-- Important! Should run after compile. Cannot run concurrently with 'install' -->
 						<phase>verify</phase>
 						<goals>
 							<goal>enforce</goal>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>


### PR DESCRIPTION
- Install Linkage Checker for spring-cloud-gcp-dependencies BOM
- run `mvn verify` as a separate task in Travis, because Linkage Checker cannot handle multi-thread Maven execution with `install` task.