### PR TITLE
Make Secret Manager Configuration conditional on Secret Manager Library

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -49,7 +49,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
  */
 @Configuration
 @EnableConfigurationProperties(GcpSecretManagerProperties.class)
-@ConditionalOnClass(SecretManagerServiceClient.class)
+@ConditionalOnClass({SecretManagerServiceClient.class, SecretManagerTemplate.class})
 @ConditionalOnProperty(value = "spring.cloud.gcp.secretmanager.enabled", matchIfMissing = true)
 public class GcpSecretManagerBootstrapConfiguration {
 


### PR DESCRIPTION
The Secret Manager autoconfiguration should only be activated if the Spring Cloud GCP Secret Manager library is added on the classpath. This makes the change.

Fixes #2506.