### PR TITLE
Upgrade version numbers to 1.2.6

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ This will allow you to not specify versions for any of the Maven dependencies an
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-dependencies</artifactId>
-            <version>1.2.4.RELEASE</version>
+            <version>1.2.5.RELEASE</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -112,7 +112,7 @@ We offer `BUILD-SNAPSHOT` versions that always reflect the latest code changes t
 </repositories>
 ----
 
-For example, the `1.2.5.BUILD-SNAPSHOT` is available from this repository.
+For example, the `1.2.6.BUILD-SNAPSHOT` is available from this repository.
 
 == Spring Boot Starters
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -63,7 +63,7 @@ This will allow you to not specify versions for any of the Maven dependencies an
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-dependencies</artifactId>
-            <version>1.2.4.RELEASE</version>
+            <version>1.2.5.RELEASE</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -105,7 +105,7 @@ We offer `BUILD-SNAPSHOT` versions that always reflect the latest code changes t
 </repositories>
 ----
 
-For example, the `1.2.5.BUILD-SNAPSHOT` is available from this repository.
+For example, the `1.2.6.BUILD-SNAPSHOT` is available from this repository.
 
 == Spring Boot Starters
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<artifactId>spring-cloud-gcp</artifactId>
-	<version>1.2.5.BUILD-SNAPSHOT</version>
+	<version>1.2.6.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud GCP</name>
 	<description>Spring Cloud GCP</description>

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-gcp</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-bigquery/pom.xml
+++ b/spring-cloud-gcp-bigquery/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>spring-cloud-gcp</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
 
   <artifactId>spring-cloud-gcp-bigquery</artifactId>

--- a/spring-cloud-gcp-cloudfoundry/pom.xml
+++ b/spring-cloud-gcp-cloudfoundry/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>spring-cloud-gcp</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-cloud-gcp-cloudfoundry</artifactId>

--- a/spring-cloud-gcp-core/pom.xml
+++ b/spring-cloud-gcp-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-cloud-gcp-core</artifactId>

--- a/spring-cloud-gcp-data-datastore/pom.xml
+++ b/spring-cloud-gcp-data-datastore/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>spring-cloud-gcp</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <groupId>org.springframework.cloud</groupId>
   <artifactId>spring-cloud-gcp-data-datastore</artifactId>

--- a/spring-cloud-gcp-data-firestore/pom.xml
+++ b/spring-cloud-gcp-data-firestore/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>spring-cloud-gcp</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-cloud-gcp-data-firestore</artifactId>

--- a/spring-cloud-gcp-data-spanner/pom.xml
+++ b/spring-cloud-gcp-data-spanner/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-gcp-data-spanner</artifactId>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>spring-cloud-gcp-dependencies</artifactId>
 	<name>Spring Cloud GCP Dependencies</name>
 	<description>Spring Cloud GCP Dependencies</description>
-	<version>1.2.5.BUILD-SNAPSHOT</version>
+	<version>1.2.6.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/spring-cloud-gcp-kotlin-samples/pom.xml
+++ b/spring-cloud-gcp-kotlin-samples/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-gcp-kotlin-samples</artifactId>
-	<version>1.2.5.BUILD-SNAPSHOT</version>
+	<version>1.2.6.BUILD-SNAPSHOT</version>
 
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>pom</packaging>

--- a/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/pom.xml
+++ b/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-kotlin-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-logging/pom.xml
+++ b/spring-cloud-gcp-logging/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-cloud-gcp-logging</artifactId>

--- a/spring-cloud-gcp-pubsub-stream-binder/pom.xml
+++ b/spring-cloud-gcp-pubsub-stream-binder/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-pubsub/pom.xml
+++ b/spring-cloud-gcp-pubsub/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-cloud-gcp-pubsub</artifactId>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -13,7 +13,7 @@
 	<name>Spring Cloud GCP Code Samples</name>
 	<artifactId>spring-cloud-gcp-samples</artifactId>
 	<groupId>org.springframework.cloud</groupId>
-	<version>1.2.5.BUILD-SNAPSHOT</version>
+	<version>1.2.6.BUILD-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-bigquery-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-bigquery-sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/pom.xml
@@ -7,7 +7,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/pom.xml
@@ -6,7 +6,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/pom.xml
@@ -6,7 +6,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
@@ -6,7 +6,7 @@
     <!-- Your own application should inherit from spring-boot-starter-parent -->
     <artifactId>spring-cloud-gcp-samples</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/pom.xml
@@ -6,7 +6,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-firestore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-firestore-sample/pom.xml
@@ -7,7 +7,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/pom.xml
@@ -7,7 +7,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-cloud-gcp-integration-pubsub-sample</artifactId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-polling-receiver/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-polling-receiver/pom.xml
@@ -7,7 +7,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-integration-pubsub-sample</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-integration-pubsub-sample</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-integration-pubsub-sample</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-test/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-test/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-integration-pubsub-sample</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/pom.xml
@@ -6,7 +6,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/pom.xml
@@ -11,7 +11,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-metrics-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-metrics-sample/pom.xml
@@ -11,7 +11,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/pom.xml
@@ -6,7 +6,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/pom.xml
@@ -6,7 +6,7 @@
     <!-- Your own application should inherit from spring-boot-starter-parent -->
     <artifactId>spring-cloud-gcp-pubsub-bus-config-sample</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-github/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-github/pom.xml
@@ -6,7 +6,7 @@
     <!-- Your own application should inherit from spring-boot-starter-parent -->
     <artifactId>spring-cloud-gcp-pubsub-bus-config-sample</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-local/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-local/pom.xml
@@ -6,7 +6,7 @@
     <!-- Your own application should inherit from spring-boot-starter-parent -->
     <artifactId>spring-cloud-gcp-pubsub-bus-config-sample</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/pom.xml
@@ -6,7 +6,7 @@
     <!-- Your own application should inherit from spring-boot-starter-parent -->
     <artifactId>spring-cloud-gcp-pubsub-bus-config-sample</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-polling-binder-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-polling-binder-sample/pom.xml
@@ -6,7 +6,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/pom.xml
@@ -7,7 +7,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-cloud-gcp-samples</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-sink/pom.xml
@@ -6,7 +6,7 @@
     <!-- Your own application should inherit from spring-boot-starter-parent -->
     <artifactId>spring-cloud-gcp-pubsub-stream-binder-functional-sample</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-cloud-gcp-pubsub-stream-binder-functional-sample</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-cloud-gcp-pubsub-stream-binder-functional-sample</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/pom.xml
@@ -7,7 +7,7 @@
     <!-- Your own application should inherit from spring-boot-starter-parent -->
     <artifactId>spring-cloud-gcp-samples</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-firebase-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-firebase-sample/pom.xml
@@ -7,7 +7,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
@@ -12,7 +12,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -11,7 +11,7 @@
         <!-- Your own application should inherit from spring-boot-starter-parent -->
         <artifactId>spring-cloud-gcp-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo/pom.xml
@@ -6,7 +6,7 @@
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<artifactId>spring-cloud-gcp-samples</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-secretmanager/pom.xml
+++ b/spring-cloud-gcp-secretmanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-cloud-gcp</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-security-firebase/pom.xml
+++ b/spring-cloud-gcp-security-firebase/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-gcp</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
 
 

--- a/spring-cloud-gcp-security-iap/pom.xml
+++ b/spring-cloud-gcp-security-iap/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-cloud-gcp-security-iap</artifactId>

--- a/spring-cloud-gcp-starters/pom.xml
+++ b/spring-cloud-gcp-starters/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<name>Spring Cloud GCP Starters</name>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-bigquery/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-bigquery/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-cloud-gcp-starters</artifactId>
     <groupId>org.springframework.cloud</groupId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-bus-pubsub/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-bus-pubsub/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-gcp-starters</artifactId>
-    <version>1.2.5.BUILD-SNAPSHOT</version>
+    <version>1.2.6.BUILD-SNAPSHOT</version>
   </parent>
 
   <artifactId>spring-cloud-gcp-starter-bus-pubsub</artifactId>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-cloudfoundry/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-cloudfoundry/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-gcp-starter-config</artifactId>
 	<name>Spring Cloud GCP Config Starter</name>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-datastore/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-datastore/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-gcp-starter-data-datastore</artifactId>
 	<name>Spring Cloud GCP Datastore Starter</name>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-firestore/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-firestore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-gcp-starters</artifactId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <artifactId>spring-cloud-gcp-starter-data-firestore</artifactId>
     <name>Spring Cloud GCP Data Firestore Starter</name>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-spanner/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-spanner/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-gcp-starter-data-spanner</artifactId>
 	<name>Spring Cloud GCP Spanner Starter</name>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-firestore/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-firestore/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-gcp-starter-firestore</artifactId>
 	<name>Spring Cloud GCP Cloud Firestore Starter</name>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-logging/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-logging/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-metrics/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-metrics/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-pubsub/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
 	<name>Spring Cloud GCP Pub/Sub Starter</name>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-firebase/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-firebase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-gcp-starters</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-security-iap/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-gcp-starters</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-mysql/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-mysql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-postgresql/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-postgresql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-gcp-starters</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.5.BUILD-SNAPSHOT</version>
+        <version>1.2.6.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-storage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-gcp-starter-storage</artifactId>
 	<name>Spring Cloud GCP Storage Starter</name>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-vision/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-vision/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-gcp-starters</artifactId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-gcp-starter</artifactId>
 	<name>Spring Cloud GCP Support Starter</name>

--- a/spring-cloud-gcp-storage/pom.xml
+++ b/spring-cloud-gcp-storage/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-gcp-storage</artifactId>
 	<name>Spring Cloud GCP Storage Module</name>

--- a/spring-cloud-gcp-vision/pom.xml
+++ b/spring-cloud-gcp-vision/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>spring-cloud-gcp</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.5.BUILD-SNAPSHOT</version>
+		<version>1.2.6.BUILD-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
I discovered that `1.2.5.RELEASE` was released? Surprised that it happened without us hearing about it: https://search.maven.org/search?q=spring-cloud-gcp

Upgrading version numbers to `1.2.6.BUILD-SNAPSHOT`.