### PR TITLE
Differentiate between Publisher and Subscriber TransportChannelProvider

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,13 @@ https://spring.io/projects/spring-cloud-gcp[Spring Cloud GCP] is a set of integr
 This document provides a high-level overview of the changes introduced in Spring Cloud GCP by release.
 For a detailed view of what has changed, refer to the https://github.com/spring-cloud/spring-cloud-gcp/commits/master[commit history] on GitHub.
 
+== 1.2.6.BUILD-SNAPSHOT
+
+=== Pub/Sub
+
+* Differentiate between Publisher and Subscriber `TransportChannelProvider` (https://github.com/spring-cloud/spring-cloud-gcp/issues/2520[#2520])
+ ** If you've been overwriting the auto-configured `transportChannelProvider` bean for Pub/Sub, you will need to rename it to `{"subscriberTransportChannelProvider", "publisherTransportChannelProvider"}`.
+
 == 1.2.5.RELEASE (2020-08-28)
 
 === Secret Manager

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,11 @@ package org.springframework.cloud.gcp.autoconfigure.pubsub;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.pubsub.v1.stub.PublisherStubSettings;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import org.threeten.bp.Duration;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -34,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
  * to a running pub/sub emulator.
  *
  * @author Andreas Berger
+ * @author Mike Eltsufin
  */
 @Configuration
 @ConditionalOnProperty(prefix = "spring.cloud.gcp.pubsub", name = "emulator-host")
@@ -41,7 +45,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(GcpPubSubProperties.class)
 public class GcpPubSubEmulatorAutoConfiguration {
 
-	@Bean
+	@Bean(name = {"subscriberTransportChannelProvider", "publisherTransportChannelProvider"})
 	@ConditionalOnMissingBean
 	public TransportChannelProvider transportChannelProvider(GcpPubSubProperties gcpPubSubProperties) {
 		ManagedChannel channel = ManagedChannelBuilder

--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
@@ -19,11 +19,8 @@ package org.springframework.cloud.gcp.autoconfigure.pubsub;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
-import com.google.cloud.pubsub.v1.stub.PublisherStubSettings;
-import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import org.threeten.bp.Duration;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -46,7 +43,7 @@ import org.springframework.context.annotation.Configuration;
 public class GcpPubSubEmulatorAutoConfiguration {
 
 	@Bean(name = {"subscriberTransportChannelProvider", "publisherTransportChannelProvider"})
-	@ConditionalOnMissingBean
+	@ConditionalOnMissingBean(name = {"subscriberTransportChannelProvider", "publisherTransportChannelProvider"})
 	public TransportChannelProvider transportChannelProvider(GcpPubSubProperties gcpPubSubProperties) {
 		ManagedChannel channel = ManagedChannelBuilder
 				.forTarget("dns:///" + gcpPubSubProperties.getEmulatorHost())


### PR DESCRIPTION
Ensures that the correct client library defaults are applied for `maxInboundMessageSize`.

Fixes: #2511.