### PR TITLE
Fix logging filter syntax from `and` to `AND`

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
@@ -59,7 +59,7 @@ import static org.junit.Assume.assumeThat;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { Application.class })
 public class LoggingSampleApplicationTests {
 
-	private static final String LOG_FILTER_FORMAT = "trace:%s and logName=projects/%s/logs/spring.log and timestamp>=\"%s\"";
+	private static final String LOG_FILTER_FORMAT = "trace:%s AND logName=projects/%s/logs/spring.log AND timestamp>=\"%s\"";
 
 	@Autowired
 	private GcpProjectIdProvider projectIdProvider;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationTests.java
@@ -132,7 +132,7 @@ public class TraceSampleApplicationTests {
 				.build();
 
 		String logFilter = String.format(
-				"trace=projects/%s/traces/%s and logName=projects/%s/logs/spring.log and timestamp>=\"%s\"",
+				"trace=projects/%s/traces/%s AND logName=projects/%s/logs/spring.log AND timestamp>=\"%s\"",
 				this.projectIdProvider.getProjectId(), uuidString,
 				this.projectIdProvider.getProjectId(), startDateTime.toStringRfc3339());
 


### PR DESCRIPTION
So far I only see this affecting `spring-cloud-gcp-ci` project, but not my own.
I'm not sure why it's case-sensitive for some projects but not others.