### PR TITLE
dependency: bump spring-javaformat-checkstyle.version to 0.0.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<java-cfenv.version>2.1.2.RELEASE</java-cfenv.version>
 
 		<!-- Checkstyle version settings. Keep in sync with spring-cloud-gcp-samples/pom.xml -->
-		<spring-javaformat-checkstyle.version>0.0.23</spring-javaformat-checkstyle.version>
+		<spring-javaformat-checkstyle.version>0.0.25</spring-javaformat-checkstyle.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
this version bump will allow checkstyle team to reuse this project in regression testing on each commit.
it will make sure there is no false positives be introduced in new version of checkstyle to this project.