### PR TITLE
Bring samples checkstyle in sync with root checkstyle version

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -79,7 +79,8 @@
 							<dependency>
 								<groupId>io.spring.javaformat</groupId>
 								<artifactId>spring-javaformat-checkstyle</artifactId>
-								<version>0.0.9</version>
+                                <!-- Keep in sync with spring-javaformat-checkstyle.version in pom.xml -->
+                                <version>0.0.25</version>
 							</dependency>
 							<dependency>
 								<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
#2529 updated the main spring checkstyle rules version. This PR brings samples version in line with it.

I've filed GoogleCloudPlatform/spring-cloud-gcp#57 to remove the exclusion in the new repo that's on Illford, since Illford checkstyle rules are kept up to date in Spring Cloud Build.