### PR TITLE
Re-enable checkstyle on samples by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
       ./mvnw test -B -P codecov ${INTEGRATION_TEST_FLAGS} && bash <(curl -s https://codecov.io/bash) -F integration;
     fi;
 install:
-  - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -P full-checkstyle -B -V
+  - ./mvnw -T 1.5C install -DskipTests=true -Dmaven.javadoc.skip=true -Dspring.profiles.active=spring -B -V
 before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       openssl aes-256-cbc -K $encrypted_1ef8dfbdb114_key -iv $encrypted_1ef8dfbdb114_iv -in travis.tar.gz.enc -out travis.tar.gz -d;

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,8 +14,6 @@ Run `./mvnw clean test` in the root directory of the project to run the tests.
 The `./mvnw` is a self-contained https://maven.apache.org/[Maven] wrapper that allows you to build the project without having Maven installed on your local machine.
 +
 You can run the tests of a specific module by using the `-f` flag like this: `./mvnw clean test -f spring-cloud-gcp-pubsub`
-+
-If you are contributing to a sample application, please use `full-checkstyle` maven profile to validate code style locally: `./mvnw clean test -P full-checkstyle`.
 
 3. (Optional) Install the https://cloud.google.com/sdk/docs/[Google Cloud SDK].
 The Google Cloud SDK a set of tools that you can use to manage resources and applications hosted on Google Cloud Platform.

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -23,7 +23,6 @@
 
 		<!-- Checkstyle version settings. Keep in sync with ../pom.xml -->
 		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
-		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
 		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
 		<app-engine-maven-plugin.version>2.2.0</app-engine-maven-plugin.version>
 	</properties>
@@ -60,64 +59,6 @@
 		<module>spring-cloud-gcp-metrics-sample</module>
 	</modules>
 
-	<!-- Checkstyle on samples invoked during CI or manually when running locally. -->
-	<profiles>
-		<profile>
-			<id>full-checkstyle</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-checkstyle-plugin</artifactId>
-						<version>${maven-checkstyle-plugin.version}</version>
-						<dependencies>
-							<dependency>
-								<groupId>com.puppycrawl.tools</groupId>
-								<artifactId>checkstyle</artifactId>
-								<version>${puppycrawl-tools-checkstyle.version}</version>
-							</dependency>
-							<dependency>
-								<groupId>io.spring.javaformat</groupId>
-								<artifactId>spring-javaformat-checkstyle</artifactId>
-								<!-- Keep in sync with spring-javaformat-checkstyle.version in pom.xml -->
-								<version>0.0.25</version>
-							</dependency>
-							<dependency>
-								<groupId>org.springframework.cloud</groupId>
-								<artifactId>spring-cloud-build-tools</artifactId>
-								<version>${spring-cloud-build-tools.version}</version>
-							</dependency>
-						</dependencies>
-						<executions>
-							<execution>
-								<id>checkstyle-validation</id>
-								<phase>validate</phase>
-								<configuration>
-									<propertyExpansion>
-										checkstyle.build.directory=${project.build.directory}
-										checkstyle.suppressions.file=${checkstyle.suppressions.file}
-										checkstyle.additional.suppressions.file=${checkstyle.additional.suppressions.file}
-									</propertyExpansion>
-									<configLocation>checkstyle.xml</configLocation>
-									<headerLocation>checkstyle-header.txt</headerLocation>
-									<consoleOutput>true</consoleOutput>
-									<includeTestSourceDirectory>true</includeTestSourceDirectory>
-									<failsOnError>true</failsOnError>
-									<failOnViolation>true</failOnViolation>
-									<suppressionsLocation>../src/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
-									<violationSeverity>warning</violationSeverity>
-								</configuration>
-								<goals>
-									<goal>check</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -139,6 +80,43 @@
 				<!-- Enables repackaging the JAR into an executable. -->
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${maven-checkstyle-plugin.version}</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.springframework.cloud</groupId>
+						<artifactId>spring-cloud-build-tools</artifactId>
+						<version>${spring-cloud-build-tools.version}</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>checkstyle-validation</id>
+						<phase>validate</phase>
+						<configuration>
+							<propertyExpansion>
+								checkstyle.build.directory=${project.build.directory}
+								checkstyle.suppressions.file=${checkstyle.suppressions.file}
+								checkstyle.additional.suppressions.file=${checkstyle.additional.suppressions.file}
+							</propertyExpansion>
+							<configLocation>checkstyle.xml</configLocation>
+							<headerLocation>checkstyle-header.txt</headerLocation>
+							<consoleOutput>true</consoleOutput>
+							<includeTestSourceDirectory>true</includeTestSourceDirectory>
+							<failsOnError>true</failsOnError>
+							<failOnViolation>true</failOnViolation>
+							<suppressionsLocation>../src/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
+							<violationSeverity>warning</violationSeverity>
+						</configuration>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
I created the full-checkstyle profile because `-Dcheckstyle.skip` did not work for a while. It works fine now! Also, the special checkstyle profile for samples proved to have been a bad decision -- we regularly forget it's there and assume the sample code passes locally, only to be surprised when creating a pull request.

This PR:
* Removes the full-checkstyle profile from samples parent, instead running checkstyle by default.
* Removes redundant dependencies from the plugin -- `spring-cloud-build-tools` brings them in transitively.