### PR TITLE
(backport): Fixes build by improving performance of LogEntry reads

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
@@ -59,7 +59,7 @@ import static org.junit.Assume.assumeThat;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { Application.class })
 public class LoggingSampleApplicationTests {
 
-	private static final String LOG_FILTER_FORMAT = "trace:%s and logName=projects/%s/logs/spring.log and timestamp>=\"%s\"";
+	private static final String LOG_FILTER_FORMAT = "trace:%s AND logName=projects/%s/logs/spring.log AND timestamp>=\"%s\"";
 
 	@Autowired
 	private GcpProjectIdProvider projectIdProvider;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationTests.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import com.google.api.client.util.DateTime;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
@@ -58,7 +59,7 @@ import static org.junit.Assume.assumeThat;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { Application.class })
 public class LoggingSampleApplicationTests {
 
-	private static final String LOG_FILTER_FORMAT = "trace:%s";
+	private static final String LOG_FILTER_FORMAT = "trace:%s and logName=projects/%s/logs/spring.log and timestamp>=\"%s\"";
 
 	@Autowired
 	private GcpProjectIdProvider projectIdProvider;
@@ -86,6 +87,7 @@ public class LoggingSampleApplicationTests {
 
 	@Test
 	public void testLogRecordedInStackDriver() {
+		DateTime startDateTime = new DateTime(System.currentTimeMillis());
 		String url = String.format("http://localhost:%s/log", this.port);
 		String traceHeader = "gcp-logging-test-" + Instant.now().toEpochMilli();
 
@@ -95,7 +97,8 @@ public class LoggingSampleApplicationTests {
 				url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
 		assertThat(responseEntity.getStatusCode().is2xxSuccessful()).isTrue();
 
-		String logFilter = String.format(LOG_FILTER_FORMAT, traceHeader);
+		String logFilter = String.format(LOG_FILTER_FORMAT, traceHeader,
+				this.projectIdProvider.getProjectId(), startDateTime.toStringRfc3339());
 
 		await().atMost(60, TimeUnit.SECONDS)
 				.pollInterval(2, TimeUnit.SECONDS)

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/ApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/ApplicationTests.java
@@ -131,7 +131,7 @@ public class ApplicationTests {
 				.build();
 
 		String logFilter = String.format(
-				"trace=projects/%s/traces/%s and logName=projects/%s/logs/spring.log and timestamp>=\"%s\"",
+				"trace=projects/%s/traces/%s AND logName=projects/%s/logs/spring.log AND timestamp>=\"%s\"",
 				this.projectIdProvider.getProjectId(), uuidString,
 				this.projectIdProvider.getProjectId(), startDateTime.toStringRfc3339());
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/ApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/ApplicationTests.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import com.google.api.client.util.DateTime;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
@@ -115,6 +116,8 @@ public class ApplicationTests {
 
 	@Test
 	public void testTracesAreLoggedCorrectly() {
+		DateTime startDateTime = new DateTime(System.currentTimeMillis());
+
 		HttpHeaders headers = new HttpHeaders();
 
 		String uuidString = UUID.randomUUID().toString().replaceAll("-", "");
@@ -128,7 +131,9 @@ public class ApplicationTests {
 				.build();
 
 		String logFilter = String.format(
-				"trace=projects/%s/traces/%s", this.projectIdProvider.getProjectId(), uuidString);
+				"trace=projects/%s/traces/%s and logName=projects/%s/logs/spring.log and timestamp>=\"%s\"",
+				this.projectIdProvider.getProjectId(), uuidString,
+				this.projectIdProvider.getProjectId(), startDateTime.toStringRfc3339());
 
 		await().atMost(120, TimeUnit.SECONDS)
 				.pollInterval(Duration.TWO_SECONDS)


### PR DESCRIPTION
Cherry-picked:
- Fixes build by improving performance of LogEntry reads (#2526)
- Fix logging filter syntax from `and` to `AND` (#2527)