### PR TITLE
Bound the acknowledging operation methods' type parameter

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/PubSubTemplate.java
@@ -204,19 +204,19 @@ public class PubSubTemplate implements PubSubOperations, InitializingBean {
 
 	@Override
 	public ListenableFuture<Void> ack(
-			Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages) {
+			Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages) {
 		return this.pubSubSubscriberTemplate.ack(acknowledgeablePubsubMessages);
 	}
 
 	@Override
 	public ListenableFuture<Void> nack(
-			Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages) {
+			Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages) {
 		return this.pubSubSubscriberTemplate.nack(acknowledgeablePubsubMessages);
 	}
 
 	@Override
 	public ListenableFuture<Void> modifyAckDeadline(
-			Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages, int ackDeadlineSeconds) {
+			Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages, int ackDeadlineSeconds) {
 		return this.pubSubSubscriberTemplate.modifyAckDeadline(acknowledgeablePubsubMessages, ackDeadlineSeconds);
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -192,14 +192,14 @@ public interface PubSubSubscriberOperations {
 	 * @param acknowledgeablePubsubMessages messages to be acknowledged
 	 * @return {@code ListenableFuture<Void>} the ListenableFuture for the asynchronous execution
 	 */
-	ListenableFuture<Void> ack(Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages);
+	ListenableFuture<Void> ack(Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages);
 
 	/**
 	 * Negatively acknowledge a batch of messages. The messages must have the same project id.
 	 * @param acknowledgeablePubsubMessages messages to be negatively acknowledged
 	 * @return {@code ListenableFuture<Void>} the ListenableFuture for the asynchronous execution
 	 */
-	ListenableFuture<Void> nack(Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages);
+	ListenableFuture<Void> nack(Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages);
 
 	/**
 	 * Modify the ack deadline of a batch of messages. The messages must have the same project id.
@@ -209,7 +209,7 @@ public interface PubSubSubscriberOperations {
 	 * @since 1.1
 	 */
 	ListenableFuture<Void> modifyAckDeadline(
-			Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages,
+			Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages,
 			int ackDeadlineSeconds);
 
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/core/subscriber/PubSubSubscriberTemplate.java
@@ -374,7 +374,7 @@ public class PubSubSubscriberTemplate
 	 */
 	@Override
 	public ListenableFuture<Void> ack(
-			Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages) {
+			Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages) {
 		Assert.notEmpty(acknowledgeablePubsubMessages, "The acknowledgeablePubsubMessages can't be empty.");
 
 		return doBatchedAsyncOperation(acknowledgeablePubsubMessages, this::ack);
@@ -389,7 +389,7 @@ public class PubSubSubscriberTemplate
 	 */
 	@Override
 	public ListenableFuture<Void> nack(
-			Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages) {
+			Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages) {
 		return modifyAckDeadline(acknowledgeablePubsubMessages, 0);
 	}
 
@@ -402,7 +402,7 @@ public class PubSubSubscriberTemplate
 	 */
 	@Override
 	public ListenableFuture<Void> modifyAckDeadline(
-			Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages, int ackDeadlineSeconds) {
+			Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages, int ackDeadlineSeconds) {
 		Assert.notEmpty(acknowledgeablePubsubMessages, "The acknowledgeablePubsubMessages can't be empty.");
 		Assert.isTrue(ackDeadlineSeconds >= 0, "The ackDeadlineSeconds must not be negative.");
 
@@ -453,7 +453,7 @@ public class PubSubSubscriberTemplate
 	 * @return {@link ListenableFuture} indicating overall success or failure.
 	 */
 	private ListenableFuture<Void> doBatchedAsyncOperation(
-			Collection<AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages,
+			Collection<? extends AcknowledgeablePubsubMessage> acknowledgeablePubsubMessages,
 			BiFunction<String, List<String>, ApiFuture<Empty>> asyncOperation) {
 
 		Map<ProjectSubscriptionName, List<String>> groupedMessages


### PR DESCRIPTION
Modify PubSubSubscriberOperations#ack, PubSubSubscriberOperations#nack and PubSubSubscriberOperations#modifyAckDeadline.
This is a breaking change for implementations of PubSubSubscriberOperations, but not for callers.

see https://github.com/spring-cloud/spring-cloud-gcp/issues/2538