### PR TITLE
Increase Pub/Sub timeout for PubSubApplicationTests

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubApplicationTests.java
@@ -65,7 +65,7 @@ import static org.junit.Assume.assumeThat;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { PubSubApplication.class })
 public class PubSubApplicationTests {
 
-	private static final int PUBSUB_CLIENT_TIMEOUT_SECONDS = 10;
+	private static final int PUBSUB_CLIENT_TIMEOUT_SECONDS = 60;
 
 	private static final String SAMPLE_TEST_TOPIC = "pubsub-sample-test-exampleTopic";
 


### PR DESCRIPTION
This has already been done in `master`.
Applying the same flakiness fix to `1.1.x`.