### PR TITLE
(Cherrypick) Allow for manually specifying BigQuery table schema

### DIFF
--- a/spring-cloud-gcp-bigquery/src/main/java/org/springframework/cloud/gcp/bigquery/core/BigQueryOperations.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/org/springframework/cloud/gcp/bigquery/core/BigQueryOperations.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.Schema;
 
 import org.springframework.util.concurrent.ListenableFuture;
 
@@ -44,4 +45,34 @@ public interface BigQueryOperations {
 	 */
 	ListenableFuture<Job> writeDataToTable(
 			String tableName, InputStream inputStream, FormatOptions dataFormatOptions);
+
+	/**
+	 * Writes data to a specified BigQuery table with a manually-specified table Schema.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>{@code
+	 *
+	 * Schema schema = Schema.of(
+	 *    Field.of("CountyId", StandardSQLTypeName.INT64),
+	 *    Field.of("State", StandardSQLTypeName.STRING),
+	 *    Field.of("County", StandardSQLTypeName.STRING)
+	 * );
+	 *
+	 * ListenableFuture<Job> bigQueryJobFuture =
+	 *     bigQueryTemplate.writeDataToTable(
+	 * 	       TABLE_NAME, dataFile.getInputStream(), FormatOptions.csv(), schema);
+	 * }</pre>
+	 *
+	 * @param tableName name of the table to write to
+	 * @param inputStream input stream of the table data to write
+	 * @param dataFormatOptions the format of the data to write
+	 * @param schema the schema of the table being loaded
+	 * @return {@link ListenableFuture} containing the BigQuery Job indicating completion of
+	 * operation
+	 *
+	 * @throws BigQueryException if errors occur when loading data to the BigQuery table
+	 */
+	ListenableFuture<Job> writeDataToTable(
+			String tableName, InputStream inputStream, FormatOptions dataFormatOptions, Schema schema);
 }

--- a/spring-cloud-gcp-bigquery/src/main/java/org/springframework/cloud/gcp/bigquery/integration/BigQuerySpringMessageHeaders.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/org/springframework/cloud/gcp/bigquery/integration/BigQuerySpringMessageHeaders.java
@@ -40,6 +40,11 @@ public final class BigQuerySpringMessageHeaders {
 	 */
 	public static final String FORMAT_OPTIONS = PREFIX + "format_options";
 
+	/**
+	 * The schema of the table to load. Not needed if relying on auto-detecting the schema.
+	 */
+	public static final String TABLE_SCHEMA = PREFIX + "table_schema";
+
 	private BigQuerySpringMessageHeaders() {
 	}
 }


### PR DESCRIPTION
This adds an interface method to the BigQueryTemplate which allows you to specify an explicit schema if you don't want to rely on schema autodetection on your dataset.

Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/2576

(cherry picked from commit 283cd16effa144262c57846e55c6a6169ba0dbc1)
Source: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/108