### PR TITLE
Correcting small typo on Google Cloud Storage documentation (#2597)

### DIFF
--- a/docs/src/main/asciidoc/storage.adoc
+++ b/docs/src/main/asciidoc/storage.adoc
@@ -67,7 +67,7 @@ SpringApplication.run(...).getResource("gs://[YOUR_GCS_BUCKET]/[GCS_FILE_NAME]")
 
 This creates a `Resource` object that can be used to read the object, among https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html#resources-resource[other possible operations].
 
-It is also possible to write to a `Resource`, although a `WriteableResource` is required.
+It is also possible to write to a `Resource`, although a `WritableResource` is required.
 
 [source,java]
 ----


### PR DESCRIPTION
Correcting the name of the class from `WriteableResource` to `WritableResource`

I know that the issue was still not approved, but given the microscopic size of the change, I figured that I could start and submit right away. If I am wrong, sorry about this. 