### PR TITLE
Fix auditing when running through DatastoreTemplate.performTransaction

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplate.java
@@ -434,10 +434,14 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		}
 		return ((Datastore) getDatastoreReadWriter())
 				.runInTransaction(
-				(DatastoreReaderWriter readerWriter) -> operations.apply(new DatastoreTemplate(() -> readerWriter,
-						DatastoreTemplate.this.datastoreEntityConverter,
-						DatastoreTemplate.this.datastoreMappingContext,
-						DatastoreTemplate.this.objectToKeyFactory)));
+				(DatastoreReaderWriter readerWriter) -> {
+					DatastoreTemplate template = new DatastoreTemplate(() -> readerWriter,
+							DatastoreTemplate.this.datastoreEntityConverter,
+							DatastoreTemplate.this.datastoreMappingContext,
+							DatastoreTemplate.this.objectToKeyFactory);
+					template.setApplicationEventPublisher(DatastoreTemplate.this.eventPublisher);
+					return operations.apply(template);
+				});
 	}
 
 	@Override

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplateAuditingTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/DatastoreTemplateAuditingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.when;
  * Tests the auditing features of the template.
  *
  * @author Chengyuan Zhao
+ * @author Frank Pavageau
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -62,6 +63,8 @@ public class DatastoreTemplateAuditingTests {
 
 	@Autowired
 	DatastoreTemplate datastoreTemplate;
+	@Autowired
+	Datastore datastore;
 
 	@Test
 	public void testModifiedNullProperties() {
@@ -80,6 +83,20 @@ public class DatastoreTemplateAuditingTests {
 		testEntity.lastUser = "person";
 
 		this.datastoreTemplate.saveAll(Collections.singletonList(testEntity));
+	}
+
+	@Test
+	public void testInTransaction() {
+		when(datastore.runInTransaction(any()))
+				.thenAnswer(invocation -> {
+					Datastore.TransactionCallable<?> callable = invocation.getArgument(0);
+					return callable.run(datastore);
+				});
+
+		TestEntity testEntity = new TestEntity();
+		testEntity.id = "a";
+
+		this.datastoreTemplate.performTransaction(operations -> operations.save(testEntity));
 	}
 
 	/**


### PR DESCRIPTION
The new `DatastoreTemplate` instance should have the same
`ApplicationEventPublisher` as the original one, so that `AuditingHandler`
can be called.

Fixes #2603 