### PR TITLE
Workaround to keep exception from disappearing during Pub/Sub processing

### DIFF
--- a/spring-cloud-gcp-pubsub/pom.xml
+++ b/spring-cloud-gcp-pubsub/pom.xml
@@ -45,5 +45,10 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-test-support</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.cloud.gcp.pubsub.support.converter.ConvertedBasicAcknowledgeablePubsubMessage;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
 /**
@@ -165,6 +166,18 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 						+ "] failed; message neither acked nor nacked.", re);
 			}
 		}
+	}
+
+	/**
+	 * Workaround for GH-2615; prevents successful completion when exception received with closed context.
+	 * @return error channel configured in parent class
+	 */
+	@Override
+	public MessageChannel getErrorChannel() {
+		if (!this.isRunning()) {
+			return null;
+		}
+		return super.getErrorChannel();
 	}
 
 }


### PR DESCRIPTION
I've filed spring-projects/spring-integration#3450 in Spring Integration for the root cause, but in the meantime this will keep the problem from affecting Pub/Sub binder. The workaround will force the exception in `MessageProducerSupport` to bubble up without trying to go through message infrastructure, in the scenario where context shutdown is detected.

Fixes #2615.