### PR TITLE
fixes #2404 by upgrading error prone to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<zipkin-gcp.version>0.17.0</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>2.3.0</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
-		<errorprone.version>2.3.4</errorprone.version>
+		<errorprone.version>2.4.0</errorprone.version>
 		<java-cfenv.version>2.1.2.RELEASE</java-cfenv.version>
 
 		<!-- Checkstyle version settings. Keep in sync with spring-cloud-gcp-samples/pom.xml -->
@@ -395,12 +395,12 @@
 				</plugins>
 			</build>
 		</profile>
-		<!-- Error prone; plugin is recommended but only works with Java 9 - 13.
-		Update activation jdk when this issue is fixed: https://github.com/google/error-prone/issues/1106 -->
+		<!-- Error prone; plugin is recommended but only works with Java 9 and newer.
+		Remove the two profiles and pull the pluginManagement contents up into the main config when the project moves off Java 8. -->
 		<profile>
 			<id>errorprone_java_9_and_up</id>
 			<activation>
-				<jdk>[9,13]</jdk>
+				<jdk>[9,)</jdk>
 			</activation>
 			<build>
 				<pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
 								<dependency>
 									<groupId>com.google.errorprone</groupId>
 									<artifactId>error_prone_core</artifactId>
-									<version>${errorprone.version}</version>
+									<version>2.3.4</version>
 								</dependency>
 							</dependencies>
 						</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,7 @@
 								<dependency>
 									<groupId>com.google.errorprone</groupId>
 									<artifactId>error_prone_core</artifactId>
+									<!-- Overriding version for Java 8 compatibility. See gh/2624 -->
 									<version>2.3.4</version>
 								</dependency>
 							</dependencies>


### PR DESCRIPTION
hopefully will fix the issue with error-prone, got the same issue but with a different class, did try to switch between 8, 11, 15 but the error still persists, after upgrading error-prone at least got further