### PR TITLE
fixes #2514 will use given project id if any and fallback to unused

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfiguration.java
@@ -30,6 +30,7 @@ import com.google.firestore.v1.FirestoreGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.auth.MoreCallCredentials;
+import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Flux;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -55,15 +56,14 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureBefore(GcpFirestoreAutoConfiguration.class)
 @EnableConfigurationProperties(GcpFirestoreProperties.class)
 public class GcpFirestoreEmulatorAutoConfiguration {
-
-	private static final String EMULATOR_PROJECT_ID = "unused";
-
-	private static final String ROOT_PATH = "projects/unused/databases/(default)";
-
 	private final String hostPort;
+	private final String projectId;
+	private final String rootPath;
 
 	GcpFirestoreEmulatorAutoConfiguration(GcpFirestoreProperties properties) {
 		this.hostPort = properties.getHostPort();
+		this.projectId = StringUtils.defaultIfEmpty(properties.getProjectId(), "unused");
+		this.rootPath = String.format("projects/%s/databases/(default)", this.projectId);
 	}
 
 	@Bean
@@ -71,7 +71,7 @@ public class GcpFirestoreEmulatorAutoConfiguration {
 	public FirestoreOptions firestoreOptions() {
 		return FirestoreOptions.newBuilder()
 				.setCredentials(emulatorCredentials())
-				.setProjectId(EMULATOR_PROJECT_ID)
+				.setProjectId(projectId)
 				.setChannelProvider(
 						InstantiatingGrpcChannelProvider.newBuilder()
 								.setEndpoint(this.hostPort)
@@ -84,7 +84,7 @@ public class GcpFirestoreEmulatorAutoConfiguration {
 		final Map<String, List<String>> headerMap = new HashMap<>();
 		headerMap.put("Authorization", Collections.singletonList("Bearer owner"));
 		headerMap.put(
-				"google-cloud-resource-prefix", Collections.singletonList(ROOT_PATH));
+				"google-cloud-resource-prefix", Collections.singletonList(rootPath));
 
 		return new Credentials() {
 			@Override
@@ -126,7 +126,7 @@ public class GcpFirestoreEmulatorAutoConfiguration {
 				FirestoreClassMapper classMapper, FirestoreMappingContext firestoreMappingContext) {
 			FirestoreTemplate template = new FirestoreTemplate(
 					firestoreStub,
-					ROOT_PATH + "/documents",
+					rootPath + "/documents",
 					classMapper,
 					firestoreMappingContext);
 			template.setUsingStreamTokens(false);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationTests.java
@@ -66,6 +66,7 @@ public class GcpFirestoreEmulatorAutoConfigurationTests {
 
 					FirestoreTemplate firestoreTemplate = context.getBean(FirestoreTemplate.class);
 					assertThat(firestoreTemplate.isUsingStreamTokens()).isFalse();
+					assertThat(firestoreOptions.getProjectId()).isEqualTo("unused");
 				});
 	}
 
@@ -81,6 +82,19 @@ public class GcpFirestoreEmulatorAutoConfigurationTests {
 
 					FirestoreTemplate firestoreTemplate = context.getBean(FirestoreTemplate.class);
 					assertThat(firestoreTemplate.isUsingStreamTokens()).isTrue();
+				});
+	}
+
+	@Test
+	public void testThatIfProjectIdIsGivenItWillBeUsed() {
+		contextRunner
+				.withPropertyValues(
+						"spring.cloud.gcp.firestore.project-id=demo",
+						"spring.cloud.gcp.firestore.emulator.enabled=true",
+						"spring.cloud.gcp.firestore.host-port=localhost:9000")
+				.run(context -> {
+					FirestoreOptions firestoreOptions = context.getBean(FirestoreOptions.class);
+					assertThat(firestoreOptions.getProjectId()).isEqualTo("demo");
 				});
 	}
 }


### PR DESCRIPTION
fixes #2514 by using given project id, indeed it might be used in many other places, e.g. to reset database we can `curl -x delete /project/{projectId}` so instead of trying to figure out what default are we can use given option and fallback to `unused`