### PR TITLE
Clarify Secret Manager Sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+# You can directly load the secret into a variable, as in this example
+# This demonstrates multiple ways of loading the same application secret using template syntax.
+#
+# Please refer to the Spring Cloud GCP Secret Manager reference documentation for the full protocol syntax.
+
+# You load a secret at a specified version; the project is inferred from Application Default Credentials or
+# spring.cloud.gcp.secretmanager.project-id set in bootstrap.properties.
+my-app-secret-1=${sm://application-secret/latest}
+my-app-secret-2=${sm://application-secret/1}
+
+# If you would like to specify a secret from another project,
+# you may specify the project ID in the first token of the URI.
+# example.property=${sm://MY_PROJECT/MY_SECRET_ID/MY_VERSION}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -8,6 +8,8 @@
 my-app-secret-1=${sm://application-secret/latest}
 my-app-secret-2=${sm://application-secret/1}
 
-# If you would like to specify a secret from another project,
-# you may specify the project ID in the first token of the URI.
+# You can also specify a secret from another project.
 # example.property=${sm://MY_PROJECT/MY_SECRET_ID/MY_VERSION}
+
+# Using SpEL, you can reference an environment variable and fallback to a secret if it is missing.
+# example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
@@ -1,15 +1,6 @@
-# You can directly load the secret into a variable like this example
-# This demonstrates multiple ways of loading the same application secret using template syntax.
-#
-# Please refer to the documentation for the protocol syntax.
-#
-# Examples:
-# my-app-secret-3=${sm://projects/<YOUR_PROJECT_ID>/secrets/application-secret}
-# my-app-secret-4=${sm://projects/<YOUR_PROJECT_ID>/secrets/application-secret/version/latest}
-# my-app-secret-5=${sm://<YOUR_PROJECT_ID>/application-secret/latest}
+# Configuration-level settings for Secret Manager must be specified in a bootstrap.properties file because
+# because Secret Manager secrets are resolved before application.properties is resolved by Spring.
 
-# Defaults to latest version if omitted.
-my-app-secret-1=${sm://application-secret}
-
-# Use to specify explicit version (like version 1) under the default project.
-my-app-secret-2=${sm://application-secret/1}
+# spring.cloud.gcp.secretmanager.enabled=<true or false> (this is true by default when the starter is added.)
+# spring.cloud.gcp.secretmanager.project-id=<your-project-id>
+# spring.cloud.gcp.secretmanager.credentials.location=<secretmanager-specific-credentials>


### PR DESCRIPTION
Clarify secret manager sample by splitting the properties into `bootstrap.properties` and `application.properties` to show where settings belong and show the default ENV variable syntax.

This is a cherrypick of: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/229 https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/225