### PR TITLE
Upgrade GCP Library Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<spring-cloud-bus.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-bus.version>
 		<spring-cloud-sleuth.version>2.2.4.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
 		<spring-cloud-stream.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream.version>
-		<zipkin-gcp.version>0.17.0</zipkin-gcp.version>
+		<zipkin-gcp.version>1.0.2</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>2.3.0</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
 		<errorprone.version>2.4.0</errorprone.version>

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTemplate.java
@@ -45,7 +45,6 @@ import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -503,7 +502,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 
 		final ResultSet resultSet = options != null && options.getIndex() != null
 				? readContext.readUsingIndex(tableName, options.getIndex(), keys, columns, options.getOptions())
-				: readContext.read(tableName, keys, columns, options == null ? ArrayUtils.toArray() : options.getOptions());
+				: readContext.read(tableName, keys, columns, options == null ? new ReadOption[0] : options.getOptions());
 
 		if (LOGGER.isDebugEnabled()) {
 			StringBuilder logs = logColumns(tableName, keys, columns);

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManager.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManager.java
@@ -30,7 +30,6 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.Options.ReadOption;
-import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
@@ -107,26 +106,25 @@ public class SpannerTransactionManager extends AbstractPlatformTransactionManage
 				}
 
 				@Override
-				public long executeUpdate(Statement statement, UpdateOption... var2) {
+				public long executeUpdate(Statement statement) {
 					throw new IllegalStateException("Spanner transaction cannot execute DML " +
 							"because it is in readonly mode");
 				}
 
 				@Override
-				public ApiFuture<Long> executeUpdateAsync(Statement statement, UpdateOption... var2) {
+				public ApiFuture<Long> executeUpdateAsync(Statement statement) {
 					throw new IllegalStateException("Spanner transaction cannot execute DML " +
 							"because it is in readonly mode");
 				}
 
 				@Override
-				public long[] batchUpdate(Iterable<Statement> iterable, UpdateOption... var2) {
+				public long[] batchUpdate(Iterable<Statement> iterable) {
 					throw new IllegalStateException("Spanner transaction cannot execute DML " +
 							"because it is in readonly mode");
 				}
 
 				@Override
-				public ApiFuture<long[]> batchUpdateAsync(
-						Iterable<Statement> iterable, UpdateOption... var2) {
+				public ApiFuture<long[]> batchUpdateAsync(Iterable<Statement> iterable) {
 					throw new IllegalStateException("Spanner transaction cannot execute DML " +
 							"because it is in readonly mode");
 				}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManager.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerTransactionManager.java
@@ -30,6 +30,7 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.Options.ReadOption;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SpannerException;
@@ -106,25 +107,26 @@ public class SpannerTransactionManager extends AbstractPlatformTransactionManage
 				}
 
 				@Override
-				public long executeUpdate(Statement statement) {
+				public long executeUpdate(Statement statement, UpdateOption... var2) {
 					throw new IllegalStateException("Spanner transaction cannot execute DML " +
 							"because it is in readonly mode");
 				}
 
 				@Override
-				public ApiFuture<Long> executeUpdateAsync(Statement statement) {
+				public ApiFuture<Long> executeUpdateAsync(Statement statement, UpdateOption... var2) {
 					throw new IllegalStateException("Spanner transaction cannot execute DML " +
 							"because it is in readonly mode");
 				}
 
 				@Override
-				public long[] batchUpdate(Iterable<Statement> iterable) {
+				public long[] batchUpdate(Iterable<Statement> iterable, UpdateOption... var2) {
 					throw new IllegalStateException("Spanner transaction cannot execute DML " +
 							"because it is in readonly mode");
 				}
 
 				@Override
-				public ApiFuture<long[]> batchUpdateAsync(Iterable<Statement> iterable) {
+				public ApiFuture<long[]> batchUpdateAsync(
+						Iterable<Statement> iterable, UpdateOption... var2) {
 					throw new IllegalStateException("Spanner transaction cannot execute DML " +
 							"because it is in readonly mode");
 				}

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/SpannerStatementQueryExecutor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/query/SpannerStatementQueryExecutor.java
@@ -34,7 +34,6 @@ import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.ValueBinder;
-import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.cloud.gcp.data.spanner.core.SpannerPageableQueryOptions;
 import org.springframework.cloud.gcp.data.spanner.core.SpannerTemplate;
@@ -51,6 +50,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.parser.Part.IgnoreCaseType;
 import org.springframework.data.repository.query.parser.PartTree;
+import org.springframework.util.StringUtils;
 
 /**
  * Executes Cloud Spanner query statements using
@@ -315,10 +315,10 @@ public final class SpannerStatementQueryExecutor {
 	 */
 	private static String combineWithAnd(String cond1, String cond2) {
 		if (StringUtils.isEmpty(cond1)) {
-			return StringUtils.defaultIfEmpty(cond2, StringUtils.EMPTY);
+			return !StringUtils.isEmpty(cond2) ? cond2 : "";
 		}
 		if (StringUtils.isEmpty(cond2)) {
-			return StringUtils.defaultIfEmpty(cond1, StringUtils.EMPTY);
+			return !StringUtils.isEmpty(cond1) ? cond1 : "";
 		}
 		return "(" + cond1 + ") AND (" + cond2 + ")";
 	}

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,11 +16,9 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<gcp-libraries-bom.version>16.4.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>16.2.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.2.1</cloud-sql-socket-factory.version>
-		<guava.version>30.1-jre</guava.version>
-    <!-- The spanner version should not be managed manually; remove when libraries-bom manages spanner > 4.0.0. -->
-		<cloud-spanner-version>4.0.0</cloud-spanner-version>
+		<guava.version>30.0-jre</guava.version>
 	</properties>
 
 	<dependencyManagement>
@@ -228,12 +226,6 @@
 				<version>${gcp-libraries-bom.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>com.google.cloud</groupId>
-				<artifactId>google-cloud-spanner</artifactId>
-				<version>${cloud-spanner-version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -16,10 +16,11 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<gcp-libraries-bom.version>13.4.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>16.4.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.0.16</cloud-sql-socket-factory.version>
-		<guava.version>29.0-jre</guava.version>
-		<google-api-client.version>1.30.7</google-api-client.version>
+		<guava.version>30.1-jre</guava.version>
+    <!-- The spanner version should not be managed manually; remove after libraries-bom is upgraded to included 4.0.0. -->
+		<cloud-spanner-version>4.0.0</cloud-spanner-version>
 	</properties>
 
 	<dependencyManagement>
@@ -221,19 +222,18 @@
 			</dependency>
 
 			<!--Google Cloud Platform Libraries BOM -->
-
-			<dependency>
-				<groupId>com.google.api-client</groupId>
-				<artifactId>google-api-client</artifactId>
-				<version>${google-api-client.version}</version>
-			</dependency>
-
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>libraries-bom</artifactId>
 				<version>${gcp-libraries-bom.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>google-cloud-spanner</artifactId>
+				<version>${cloud-spanner-version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<gcp-libraries-bom.version>16.4.0</gcp-libraries-bom.version>
-		<cloud-sql-socket-factory.version>1.0.16</cloud-sql-socket-factory.version>
+		<cloud-sql-socket-factory.version>1.2.1</cloud-sql-socket-factory.version>
 		<guava.version>30.1-jre</guava.version>
     <!-- The spanner version should not be managed manually; remove when libraries-bom manages spanner > 4.0.0. -->
 		<cloud-spanner-version>4.0.0</cloud-spanner-version>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -19,7 +19,7 @@
 		<gcp-libraries-bom.version>16.4.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.0.16</cloud-sql-socket-factory.version>
 		<guava.version>30.1-jre</guava.version>
-    <!-- The spanner version should not be managed manually; remove after libraries-bom is upgraded to included 4.0.0. -->
+    <!-- The spanner version should not be managed manually; remove when libraries-bom manages spanner > 4.0.0. -->
 		<cloud-spanner-version>4.0.0</cloud-spanner-version>
 	</properties>
 


### PR DESCRIPTION
Upgrades the GCP Library versions.

Had to manually override the version of spanner to `4.0.0` because it includes a bug fix for user-agent headers. Once the `libraries-bom` catches up to the latest spanner version we can remove the override.

Will cherrypick to new repo and create an issue to track the dep override if satisfactory.

Also `com.google.api-client` no longer needs to be managed manually, so removed.

```
<dependency>	
	<groupId>com.google.api-client</groupId>	
	<artifactId>google-api-client</artifactId>	
	<version>${google-api-client.version}</version>	
</dependency>
```