### PR TITLE
Backport - Allow pubsub binder to use fully qualified topic name when creating subscription (consumer destination)

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -17,12 +17,14 @@
 package org.springframework.cloud.gcp.stream.binder.pubsub.provisioning;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
 import com.google.api.gax.rpc.AlreadyExistsException;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -61,7 +63,7 @@ public class PubSubChannelProvisioner
 	public ProducerDestination provisionProducerDestination(String topic,
 			ExtendedProducerProperties<PubSubProducerProperties> properties)
 			throws ProvisioningException {
-		makeSureTopicExists(topic, properties.getExtension().isAutoCreateResources());
+		ensureTopicExists(topic, properties.getExtension().isAutoCreateResources());
 
 		return new PubSubProducerDestination(topic);
 	}
@@ -71,23 +73,23 @@ public class PubSubChannelProvisioner
 			ExtendedConsumerProperties<PubSubConsumerProperties> properties)
 			throws ProvisioningException {
 
-		Topic topic = makeSureTopicExists(topicName, properties.getExtension().isAutoCreateResources());
+		// topicName may be either the short or fully-qualified version.
+		String topicShortName = TopicName.isParsableFrom(topicName) ? TopicName.parse(topicName).getTopic() : topicName;
+		Optional<Topic> topic = ensureTopicExists(topicName, properties.getExtension().isAutoCreateResources());
 
 		String subscriptionName;
 		Subscription subscription;
 		if (StringUtils.hasText(group)) {
-			// Use <topicName>.<group> as subscription name
-			subscriptionName = topicName + "." + group;
+			subscriptionName = topicShortName + "." + group;
 			subscription = this.pubSubAdmin.getSubscription(subscriptionName);
 		}
 		else {
 			// Generate anonymous random group since one wasn't provided
-			subscriptionName = "anonymous." + topicName + "." + UUID.randomUUID().toString();
+			subscriptionName = "anonymous." + topicShortName + "." + UUID.randomUUID().toString();
 			subscription = this.pubSubAdmin.createSubscription(subscriptionName, topicName);
 			this.anonymousGroupSubscriptionNames.add(subscriptionName);
 		}
 
-		// make sure subscription exists
 		if (subscription == null) {
 			if (properties.getExtension().isAutoCreateResources()) {
 				this.pubSubAdmin.createSubscription(subscriptionName, topicName);
@@ -96,7 +98,7 @@ public class PubSubChannelProvisioner
 				throw new ProvisioningException("Non-existing '" + subscriptionName + "' subscription.");
 			}
 		}
-		else if (!subscription.getTopic().equals(topic.getName())) {
+		else if (topic.isPresent() && !subscription.getTopic().equals(topic.get().getName())) {
 			throw new ProvisioningException(
 					"Existing '" + subscriptionName + "' subscription is for a different topic '"
 							+ subscription.getTopic() + "'.");
@@ -115,7 +117,7 @@ public class PubSubChannelProvisioner
 		}
 	}
 
-	private Topic makeSureTopicExists(String topicName, boolean autoCreate) {
+	private Optional<Topic> ensureTopicExists(String topicName, boolean autoCreate) {
 		Topic topic = this.pubSubAdmin.getTopic(topicName);
 		if (topic == null) {
 			if (autoCreate) {
@@ -132,6 +134,6 @@ public class PubSubChannelProvisioner
 			}
 		}
 
-		return topic;
+		return Optional.ofNullable(topic);
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -61,8 +61,7 @@ public class PubSubChannelProvisioner
 
 	@Override
 	public ProducerDestination provisionProducerDestination(String topic,
-			ExtendedProducerProperties<PubSubProducerProperties> properties)
-			throws ProvisioningException {
+			ExtendedProducerProperties<PubSubProducerProperties> properties) {
 		ensureTopicExists(topic, properties.getExtension().isAutoCreateResources());
 
 		return new PubSubProducerDestination(topic);
@@ -70,8 +69,7 @@ public class PubSubChannelProvisioner
 
 	@Override
 	public ConsumerDestination provisionConsumerDestination(String topicName, String group,
-			ExtendedConsumerProperties<PubSubConsumerProperties> properties)
-			throws ProvisioningException {
+			ExtendedConsumerProperties<PubSubConsumerProperties> properties) {
 
 		// topicName may be either the short or fully-qualified version.
 		String topicShortName = TopicName.isParsableFrom(topicName) ? TopicName.parse(topicName).getTopic() : topicName;

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -201,7 +201,7 @@ public class PubSubChannelProvisionerTests {
 		when(this.pubSubAdminMock.getTopic(eq("already_existing_topic"))).thenReturn(null);
 
 		// Ensure no exceptions occur if topic already exists on create call
-		this.pubSubChannelProvisioner
-				.provisionConsumerDestination("already_existing_topic", "group1", this.properties);
+		assertThat(this.pubSubChannelProvisioner
+				.provisionConsumerDestination("already_existing_topic", "group1", this.properties)).isNotNull();
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -76,7 +76,10 @@ public class PubSubChannelProvisionerTests {
 		doAnswer((invocation) ->
 			Subscription.newBuilder()
 					.setName("projects/test-project/subscriptions/" + invocation.getArgument(0))
-					.setTopic("projects/test-project/topics/" + invocation.getArgument(1)).build()
+					.setTopic(invocation.getArgument(1, String.class).startsWith("projects/") ?
+							invocation.getArgument(1) :
+							"projects/test-project/topics/" + invocation.getArgument(1))
+					.build()
 		).when(this.pubSubAdminMock).createSubscription(any(), any());
 		doAnswer((invocation) ->
 				Topic.newBuilder().setName("projects/test-project/topics/" + invocation.getArgument(0)).build()
@@ -95,6 +98,20 @@ public class PubSubChannelProvisionerTests {
 		assertThat(result.getName()).isEqualTo("topic_A.group_A");
 
 		verify(this.pubSubAdminMock).createSubscription("topic_A.group_A", "topic_A");
+	}
+
+	@Test
+	public void testProvisionConsumerDestination_specifiedGroupTopicInDifferentProject() {
+		String fullTopicName = "projects/differentProject/topics/topic_A";
+		when(this.pubSubAdminMock.getTopic(fullTopicName)).thenReturn(
+				Topic.newBuilder().setName(fullTopicName).build());
+
+		PubSubConsumerDestination result = (PubSubConsumerDestination) this.pubSubChannelProvisioner
+				.provisionConsumerDestination(fullTopicName, "group_A", this.properties);
+
+		assertThat(result.getName()).isEqualTo("topic_A.group_A");
+
+		verify(this.pubSubAdminMock).createSubscription("topic_A.group_A", "projects/differentProject/topics/topic_A");
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
@@ -48,9 +48,9 @@ import org.springframework.util.Assert;
  */
 public class PubSubAdmin implements AutoCloseable {
 
-	private static final int MIN_ACK_DEADLINE_SECONDS = 10;
+	protected static final int MIN_ACK_DEADLINE_SECONDS = 10;
 
-	private static final int MAX_ACK_DEADLINE_SECONDS = 600;
+	protected static final int MAX_ACK_DEADLINE_SECONDS = 600;
 
 	private final String projectId;
 
@@ -104,7 +104,7 @@ public class PubSubAdmin implements AutoCloseable {
 	public Topic createTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		return this.topicAdminClient.createTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
+		return this.topicAdminClient.createTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
 	}
 
 	/**
@@ -118,7 +118,7 @@ public class PubSubAdmin implements AutoCloseable {
 		Assert.hasText(topicName, "No topic name was specified.");
 
 		try {
-			return this.topicAdminClient.getTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
+			return this.topicAdminClient.getTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
 		}
 		catch (ApiException aex) {
 			if (aex.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
@@ -138,7 +138,7 @@ public class PubSubAdmin implements AutoCloseable {
 	public void deleteTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		this.topicAdminClient.deleteTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
+		this.topicAdminClient.deleteTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
 	}
 
 	/**
@@ -231,7 +231,7 @@ public class PubSubAdmin implements AutoCloseable {
 
 		return this.subscriptionAdminClient.createSubscription(
 				PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, this.projectId),
-				PubSubTopicUtils.toProjectTopicName(topicName, this.projectId),
+				PubSubTopicUtils.toTopicName(topicName, this.projectId),
 				pushConfigBuilder.build(),
 				finalAckDeadline);
 	}
@@ -324,5 +324,4 @@ public class PubSubAdmin implements AutoCloseable {
 			this.subscriptionAdminClient.close();
 		}
 	}
-
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/PubSubAdmin.java
@@ -52,6 +52,8 @@ public class PubSubAdmin implements AutoCloseable {
 
 	protected static final int MAX_ACK_DEADLINE_SECONDS = 600;
 
+	private static final String NO_TOPIC_SPECIFIED_ERROR_MSG = "No topic name was specified.";
+
 	private final String projectId;
 
 	private final TopicAdminClient topicAdminClient;
@@ -102,7 +104,7 @@ public class PubSubAdmin implements AutoCloseable {
 	 * @return the created topic
 	 */
 	public Topic createTopic(String topicName) {
-		Assert.hasText(topicName, "No topic name was specified.");
+		Assert.hasText(topicName, NO_TOPIC_SPECIFIED_ERROR_MSG);
 
 		return this.topicAdminClient.createTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
 	}
@@ -115,7 +117,7 @@ public class PubSubAdmin implements AutoCloseable {
 	 * @return topic configuration or {@code null} if topic doesn't exist
 	 */
 	public Topic getTopic(String topicName) {
-		Assert.hasText(topicName, "No topic name was specified.");
+		Assert.hasText(topicName, NO_TOPIC_SPECIFIED_ERROR_MSG);
 
 		try {
 			return this.topicAdminClient.getTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
@@ -136,7 +138,7 @@ public class PubSubAdmin implements AutoCloseable {
 	 * name in the {@code projects/<project_name>/topics/<topic_name>} format
 	 */
 	public void deleteTopic(String topicName) {
-		Assert.hasText(topicName, "No topic name was specified.");
+		Assert.hasText(topicName, NO_TOPIC_SPECIFIED_ERROR_MSG);
 
 		this.topicAdminClient.deleteTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
 	}
@@ -216,7 +218,7 @@ public class PubSubAdmin implements AutoCloseable {
 	public Subscription createSubscription(String subscriptionName, String topicName,
 			Integer ackDeadline, String pushEndpoint) {
 		Assert.hasText(subscriptionName, "No subscription name was specified.");
-		Assert.hasText(topicName, "No topic name was specified.");
+		Assert.hasText(topicName, NO_TOPIC_SPECIFIED_ERROR_MSG);
 
 		int finalAckDeadline = this.defaultAckDeadline;
 		if (ackDeadline != null) {

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -128,7 +128,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 		return this.publishers.computeIfAbsent(topic, (key) -> {
 			try {
 				Publisher.Builder publisherBuilder =
-						Publisher.newBuilder(PubSubTopicUtils.toProjectTopicName(topic, this.projectId));
+						Publisher.newBuilder(PubSubTopicUtils.toTopicName(topic, this.projectId));
 
 				if (this.executorProvider != null) {
 					publisherBuilder.setExecutorProvider(this.executorProvider);

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -125,7 +125,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 
 	@Override
 	public Publisher createPublisher(String topic) {
-		return this.publishers.computeIfAbsent(topic, (key) -> {
+		return this.publishers.computeIfAbsent(topic, key -> {
 			try {
 				Publisher.Builder publisherBuilder =
 						Publisher.newBuilder(PubSubTopicUtils.toTopicName(topic, this.projectId));

--- a/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtils.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gcp.pubsub.support;
 
 import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.TopicName;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -56,5 +57,19 @@ public final class PubSubTopicUtils {
 		}
 
 		return projectTopicName;
+	}
+
+	/**
+	 * Create a {@link TopicName} based on a topic name within a project or the
+	 * fully-qualified topic name. If the specified topic is in the
+	 * {@code projects/<project_name>/topics/<topic_name>} format, then the {@code projectId} is
+	 * ignored}
+	 * @param topic the topic name in the project or the fully-qualified project name
+	 * @param projectId the project ID to use if the topic is not a fully-qualified name
+	 * @return the Pub/Sub object representing the topic name
+	 */
+	public static TopicName toTopicName(String topic, @Nullable String projectId) {
+		ProjectTopicName ptn = toProjectTopicName(topic, projectId);
+		return TopicName.ofProjectTopicName(ptn.getProject(), ptn.getTopic());
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/PubSubAdminTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/PubSubAdminTests.java
@@ -16,14 +16,31 @@
 
 package org.springframework.cloud.gcp.pubsub;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
-import org.junit.Rule;
+import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.TopicName;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the Pub/Sub admin operations.
@@ -34,12 +51,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PubSubAdminTests {
 
-	/**
-	 * used to check exception messages and types.
-	 */
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-
 	@Mock
 	private TopicAdminClient mockTopicAdminClient;
 
@@ -48,22 +59,239 @@ public class PubSubAdminTests {
 
 	@Test
 	public void testNewPubSubAdmin_nullProjectProvider() {
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("The project ID provider can't be null.");
-		new PubSubAdmin(null, this.mockTopicAdminClient, this.mockSubscriptionAdminClient);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new PubSubAdmin(null, this.mockTopicAdminClient, this.mockSubscriptionAdminClient))
+				.withMessage("The project ID provider can't be null.");
 	}
 
 	@Test
 	public void testNewPubSubAdmin_nullTopicAdminClient() {
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("The topic administration client can't be null");
-		new PubSubAdmin(() -> "test-project", null, this.mockSubscriptionAdminClient);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new PubSubAdmin(() -> "test-project", null, this.mockSubscriptionAdminClient))
+				.withMessage("The topic administration client can't be null");
 	}
 
 	@Test
 	public void testNewPubSubAdmin_nullSubscriptionAdminClient() {
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("The subscription administration client can't be null");
-		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, null);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, null))
+				.withMessage("The subscription administration client can't be null");
+	}
+
+	@Test
+	public void testNewPubSubAdmin() throws IOException {
+		assertThat(new PubSubAdmin(() -> "test-project", NoCredentials::getInstance)).isNotNull();
+	}
+
+	@Test
+	public void testCreateTopic() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.createTopic("fooTopic");
+		verify(this.mockTopicAdminClient).createTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testCreateTopic_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.createTopic("projects/differentProject/topics/fooTopic");
+		verify(this.mockTopicAdminClient).createTopic(TopicName.of("differentProject", "fooTopic"));
+	}
+
+	@Test
+	public void testGetTopic() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getTopic("fooTopic");
+		verify(this.mockTopicAdminClient).getTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testGetTopic_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getTopic("projects/differentProject/topics/fooTopic");
+		verify(this.mockTopicAdminClient).getTopic(TopicName.of("differentProject", "fooTopic"));
+	}
+
+	@Test
+	public void testGetTopic_notFound() {
+		when(this.mockTopicAdminClient.getTopic(any(TopicName.class)))
+				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.NOT_FOUND), false));
+		assertThat(new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getTopic("fooTopic")).isNull();
+		verify(this.mockTopicAdminClient).getTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testGetTopic_serviceDown() {
+		when(this.mockTopicAdminClient.getTopic(any(TopicName.class)))
+				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.UNAVAILABLE), false));
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project",
+				this.mockTopicAdminClient, this.mockSubscriptionAdminClient);
+
+		assertThatExceptionOfType(ApiException.class).isThrownBy(() -> psa.getTopic("fooTopic"));
+		verify(this.mockTopicAdminClient).getTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testDeleteTopic() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.deleteTopic("fooTopic");
+		verify(this.mockTopicAdminClient).deleteTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testDeleteTopic_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.deleteTopic("projects/differentProject/topics/fooTopic");
+		verify(this.mockTopicAdminClient).deleteTopic(TopicName.of("differentProject", "fooTopic"));
+	}
+
+	@Test
+	public void testListTopic() throws ExecutionException, InterruptedException {
+		when(this.mockTopicAdminClient.listTopics(any(ProjectName.class))).thenReturn(
+				mock(TopicAdminClient.ListTopicsPagedResponse.class)
+		);
+
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.listTopics();
+		verify(this.mockTopicAdminClient).listTopics(ProjectName.of("test-project"));
+	}
+
+	@Test
+	public void testCreateSubscription_nullArgs() {
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient,
+				this.mockSubscriptionAdminClient);
+
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.createSubscription(null, "testTopic"));
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.createSubscription("testSubscription", null));
+	}
+
+	@Test
+	public void testCreateSubscription() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.createSubscription("testSubscription", "testTopic");
+		verify(this.mockSubscriptionAdminClient).createSubscription(
+				eq(ProjectSubscriptionName.of("test-project", "testSubscription")),
+				eq(TopicName.of("test-project", "testTopic")),
+				any(),
+				anyInt()
+		);
+	}
+
+	@Test
+	public void testCreateSubscription_ackDeadline() {
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient,
+				this.mockSubscriptionAdminClient);
+
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.createSubscription("a", "b", PubSubAdmin.MIN_ACK_DEADLINE_SECONDS - 1));
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.createSubscription("a", "b", PubSubAdmin.MAX_ACK_DEADLINE_SECONDS + 1));
+
+		psa.createSubscription("testSubscription", "testTopic", 100);
+		verify(this.mockSubscriptionAdminClient).createSubscription(
+				eq(ProjectSubscriptionName.of("test-project", "testSubscription")),
+				eq(TopicName.of("test-project", "testTopic")),
+				any(),
+				eq(100)
+		);
+	}
+
+	@Test
+	public void testCreateSubscription_pushEndpoint() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.createSubscription("testSubscription", "testTopic", "endpoint");
+		verify(this.mockSubscriptionAdminClient).createSubscription(
+				eq(ProjectSubscriptionName.of("test-project", "testSubscription")),
+				eq(TopicName.of("test-project", "testTopic")),
+				argThat(arg -> "endpoint".equals(arg.getPushEndpoint())),
+				anyInt()
+		);
+	}
+
+	@Test
+	public void testGetSubscription() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getSubscription("fooSubscription");
+		verify(this.mockSubscriptionAdminClient).getSubscription(
+				ProjectSubscriptionName.of("test-project", "fooSubscription"));
+	}
+
+	@Test
+	public void testGetSubscription_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getSubscription("projects/differentProject/subscriptions/fooSubscription");
+		verify(this.mockSubscriptionAdminClient).getSubscription(
+				ProjectSubscriptionName.of("differentProject", "fooSubscription"));
+	}
+
+	@Test
+	public void testGetSubscription_notFound() {
+		when(this.mockSubscriptionAdminClient.getSubscription(any(ProjectSubscriptionName.class)))
+				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.NOT_FOUND), false));
+		assertThat(new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getSubscription("fooSubscription"))
+				.isNull();
+		verify(this.mockSubscriptionAdminClient).getSubscription(
+				ProjectSubscriptionName.of("test-project", "fooSubscription"));
+	}
+
+	@Test
+	public void testGetSubscription_serviceDown() {
+		when(this.mockSubscriptionAdminClient.getSubscription(any(ProjectSubscriptionName.class)))
+				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.UNAVAILABLE), false));
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project",
+				this.mockTopicAdminClient, this.mockSubscriptionAdminClient);
+
+		assertThatExceptionOfType(ApiException.class).isThrownBy(() -> psa.getSubscription("fooSubscription"));
+		verify(this.mockSubscriptionAdminClient).getSubscription(
+				ProjectSubscriptionName.of("test-project", "fooSubscription"));
+	}
+
+	@Test
+	public void testDeleteSubscription() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.deleteSubscription("fooSubscription");
+		verify(this.mockSubscriptionAdminClient).deleteSubscription(
+				ProjectSubscriptionName.of("test-project", "fooSubscription"));
+	}
+
+	@Test
+	public void testDeleteSubscription_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.deleteSubscription("projects/differentProject/subscriptions/fooSubscription");
+		verify(this.mockSubscriptionAdminClient).deleteSubscription(
+				ProjectSubscriptionName.of("differentProject", "fooSubscription"));
+	}
+
+	@Test
+	public void testListSubscription() {
+		when(this.mockSubscriptionAdminClient.listSubscriptions(any(ProjectName.class))).thenReturn(
+				mock(SubscriptionAdminClient.ListSubscriptionsPagedResponse.class)
+		);
+
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.listSubscriptions();
+		verify(this.mockSubscriptionAdminClient).listSubscriptions(ProjectName.of("test-project"));
+	}
+
+	@Test
+	public void testDefaultAckDeadline() throws IOException {
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project", NoCredentials::getInstance);
+		int defaultAckDeadline = psa.getDefaultAckDeadline();
+		psa.setDefaultAckDeadline(defaultAckDeadline + 1);
+		assertThat(psa.getDefaultAckDeadline()).isEqualTo(defaultAckDeadline + 1);
+
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.setDefaultAckDeadline(PubSubAdmin.MIN_ACK_DEADLINE_SECONDS - 1));
+	}
+
+	@Test
+	public void testClose() throws Exception {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.close();
+		verify(this.mockTopicAdminClient).close();
+		verify(this.mockSubscriptionAdminClient).close();
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/PubSubSubscriptionUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/PubSubSubscriptionUtilsTests.java
@@ -38,8 +38,9 @@ public class PubSubSubscriptionUtilsTests {
 		ProjectSubscriptionName parsedProjectSubscriptionName = PubSubSubscriptionUtils
 				.toProjectSubscriptionName(subscription, project);
 
-		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectSubscriptionName)
+				.isEqualTo(ProjectSubscriptionName.of(project, subscription))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -65,8 +66,9 @@ public class PubSubSubscriptionUtilsTests {
 		ProjectSubscriptionName parsedProjectSubscriptionName = PubSubSubscriptionUtils.toProjectSubscriptionName(fqn,
 				project);
 
-		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectSubscriptionName)
+				.isEqualTo(ProjectSubscriptionName.of(project, subscription))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -78,7 +80,8 @@ public class PubSubSubscriptionUtilsTests {
 		ProjectSubscriptionName parsedProjectSubscriptionName = PubSubSubscriptionUtils.toProjectSubscriptionName(fqn,
 				null);
 
-		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectSubscriptionName)
+				.isEqualTo(ProjectSubscriptionName.of(project, subscription))
+				.hasToString(fqn);
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/org/springframework/cloud/gcp/pubsub/support/PubSubTopicUtilsTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gcp.pubsub.support;
 
 import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.TopicName;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,8 +38,9 @@ public class PubSubTopicUtilsTests {
 
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(topic, project);
 
-		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectTopicName)
+				.isEqualTo(ProjectTopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -63,8 +65,9 @@ public class PubSubTopicUtilsTests {
 
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(fqn, project);
 
-		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectTopicName)
+				.isEqualTo(ProjectTopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -75,7 +78,61 @@ public class PubSubTopicUtilsTests {
 
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(fqn, null);
 
-		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectTopicName)
+				.isEqualTo(ProjectTopicName.of(project, topic))
+				.hasToString(fqn);
+	}
+
+	@Test
+	public void testToTopicName_canonical() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(topic, project);
+
+		assertThat(parsedTopicName)
+				.isEqualTo(TopicName.of(project, topic))
+				.hasToString(fqn);
+	}
+
+	@Test
+	public void testToTopicName_no_topic() {
+		assertThatThrownBy(() -> PubSubTopicUtils.toTopicName(null, "topicA"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("The topic can't be null.");
+	}
+
+	@Test
+	public void testToTopicName_canonical_no_project() {
+		assertThatThrownBy(() -> PubSubTopicUtils.toTopicName("topicA", null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("The project ID can't be null when using canonical topic name.");
+	}
+
+	@Test
+	public void testToTopicName_fqn() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(fqn, project);
+
+		assertThat(parsedTopicName)
+				.isEqualTo(TopicName.of(project, topic))
+				.hasToString(fqn);
+	}
+
+	@Test
+	public void testToTopicName_fqn_no_project() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(fqn, null);
+
+		assertThat(parsedTopicName)
+				.isEqualTo(TopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/spring-cloud-gcp-pubsub/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/SampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/SampleAppIntegrationTest.java
@@ -81,7 +81,7 @@ public class SampleAppIntegrationTest {
 		RestTemplate restTemplate = new RestTemplate();
 
 		URI redirect = restTemplate.postForLocation("http://localhost:8080/postMessage", map);
-		assertThat(redirect.toString()).isEqualTo("http://localhost:8080/index.html");
+		assertThat(redirect).hasToString("http://localhost:8080/index.html");
 
 		Awaitility.await().atMost(10, TimeUnit.SECONDS)
 				.until(() -> this.output.getOut()


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/2642

Original PR: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/234