### PR TITLE
(backport): Fix javadoc on SpannerOperations.executeDmlStatement

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerOperations.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/core/SpannerOperations.java
@@ -37,8 +37,9 @@ import com.google.cloud.spanner.Struct;
 public interface SpannerOperations {
 
 	/**
-	 * Execute a DML statement on Cloud Spanner. If this is not performed in a transaction
-	 * then it is done in partitioned-mode.
+	 * Execute a DML statement on Cloud Spanner. This must always be done in a transaction
+	 * and one will be started if needed. See {@link #executePartitionedDmlStatement(Statement)}
+	 * for executing partitioned DML without a transaction.
 	 * @param statement the DML statement to execute.
 	 * @return the number of rows affected.
 	 */


### PR DESCRIPTION
Clarify that executeDmlStatement may start a transaction.

Fixes: #2650.

Backport of: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/347