### PR TITLE
Gate emulator datastore test with a property

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
@@ -26,6 +26,7 @@ import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.StructuredQuery;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
@@ -44,6 +45,8 @@ import org.springframework.data.annotation.Id;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -56,6 +59,14 @@ import static org.mockito.Mockito.mock;
  * @since 1.2
  */
 public class GcpDatastoreEmulatorIntegrationTests {
+
+	@BeforeClass
+	public static void checkToRun() {
+		assumeThat(
+				"Datastore integration tests are disabled. Please use '-Dit.datastore=true' "
+						+ "to enable them. ",
+				System.getProperty("it.datastore"), is("true"));
+	}
 
 	@Test
 	public void testDatastoreEmulatorConfiguration() {


### PR DESCRIPTION
This test is not a unit test -- it requires a datastore emulator -- so it should be gated with a property.